### PR TITLE
fix: Fix batch read response type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 ## Compatibility Notes
 
-- Renaming of deprecated ODataRequestConfigs e.g. `ODataCreateRequestConfig` -> `ODataCreateRequestConfigLegacy` due to naming conflicts. 
+- Batch `ReadResponse.as` does not parse errors anymore, but throws an error if the response in fact was an `ErrorResponse`. To avoid this check `response.isSuccess()` before casting.
+- Rename deprecated ODataRequestConfigs e.g. `ODataCreateRequestConfig` -> `ODataCreateRequestConfigLegacy` due to naming conflicts.
 
 ## New Functionality
 
@@ -23,6 +24,7 @@
 ## Improvements
 
 - Export the `tenant` interface from the scp-cf module.
+- Throw an error when attempting to parse a batch `ReadResponse` that in fact is an `ErrorResponse`.
 
 ## Fixed Issues
 

--- a/packages/core/src/odata-common/batch-response.ts
+++ b/packages/core/src/odata-common/batch-response.ts
@@ -17,7 +17,7 @@ export interface ReadResponse {
   httpCode: number;
   body: Record<string, any>;
   type: Constructable<EntityBase>;
-  as: <T extends EntityBase>(constructor: Constructable<T>) => Error | T[];
+  as: <T extends EntityBase>(constructor: Constructable<T>) => T[];
   isSuccess: () => boolean;
 }
 

--- a/packages/core/src/odata-common/request-builder/batch/batch-response-deserializer.ts
+++ b/packages/core/src/odata-common/request-builder/batch/batch-response-deserializer.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@sap-cloud-sdk/util';
+import { createLogger, errorWithCause } from '@sap-cloud-sdk/util';
 import {
   ErrorResponse,
   ReadResponse,
@@ -154,9 +154,9 @@ function asReadResponse(
 ) {
   return <EntityT extends EntityBase>(
     constructor: Constructable<EntityT>
-  ): Error | EntityT[] => {
+  ): EntityT[] => {
     if (body.error) {
-      return new Error(body.error);
+      throw errorWithCause('Could not parse read response.', body.error);
     }
     if (responseDataAccessor.isCollectionResult(body)) {
       return responseDataAccessor


### PR DESCRIPTION
In my batch v4 refactoring a while back, I think I made a wrong assumption on a type. If the type remains as is, users would have to always cast the result from `.as(BusinessPartner) as BusinessPartner` otherwise it can be either an error or a business partner. Instead as should only be called, when we know it is not an error. I described this behavior in https://github.com/SAP/cloud-sdk/pull/11.