### PR TITLE
chore: Move spec files for test-util package

### DIFF
--- a/packages/test-util/src/test-destination-mocker.spec.ts
+++ b/packages/test-util/src/test-destination-mocker.spec.ts
@@ -1,13 +1,13 @@
 import { unlinkSync, writeFileSync } from 'fs';
 import { Destination } from '@sap-cloud-sdk/core';
+import { credentials, systems } from '../test/test-util/test-destinations';
 import {
   mockAllTestDestinations,
   mockTestDestination,
   setTestDestination,
   unmockAllTestDestinations,
   unmockTestDestination
-} from '../src/test-destination-mocker';
-import { credentials, systems } from './test-util/test-destinations';
+} from './test-destination-mocker';
 
 describe('setTestDestinationInEnv', () => {
   let envDestination: Destination = {

--- a/packages/test-util/src/test-destination-provider.spec.ts
+++ b/packages/test-util/src/test-destination-provider.spec.ts
@@ -1,10 +1,10 @@
 import { fail } from 'assert';
 import { unlinkSync, writeFileSync } from 'fs';
+import { credentials, systems } from '../test/test-util/test-destinations';
 import {
   getTestDestinationByAlias,
   getTestDestinations
-} from '../src/test-destination-provider';
-import { credentials, systems } from './test-util/test-destinations';
+} from './test-destination-provider';
 // This replaces the fs module with the mocked one defined in __mock__/fs.js
 jest.mock('fs');
 // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
Just two files. However, I could move all the test-util files from the other packages in this one. I do not know if this makes sense. It would add some sort of coupling one would perhaps like to avoid.
On the other had it could make reuse easier.