### PR TITLE
chore: Unwrap axios response

### DIFF
--- a/packages/core/src/openapi/openapi-request-builder.spec.ts
+++ b/packages/core/src/openapi/openapi-request-builder.spec.ts
@@ -1,0 +1,52 @@
+import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { OpenApiRequestBuilder } from './openapi-request-builder';
+
+class TestApi {
+  constructor(public axiosConfig: AxiosRequestConfig) {}
+  fn: () => Promise<AxiosResponse<number>> = async () =>
+    ({
+      data: 1
+    } as AxiosResponse<number>);
+  nonAxiosResponse = async () => 1;
+}
+
+const destination = {
+  url: 'http://example.com'
+};
+
+describe('openapi-request-builder', () => {
+  it('executes request', async () => {
+    const requestBuilder = new OpenApiRequestBuilder(TestApi, 'fn');
+    const response = await requestBuilder.execute(destination);
+
+    expect(response).toEqual(1);
+  });
+
+  it('throws an error if the given function does not exist', async () => {
+    // This cannot happen in TS
+    const requestBuilder = new OpenApiRequestBuilder(
+      TestApi,
+      'notAFunction' as any
+    );
+
+    await expect(() =>
+      requestBuilder.execute(destination)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"Could not execute request. \'notAFunction\' is not a function of TestApi."'
+    );
+  });
+
+  it('throws an error if the response is not an axios response', async () => {
+    // This should never happen
+    const requestBuilder = new OpenApiRequestBuilder(
+      TestApi,
+      'nonAxiosResponse'
+    );
+
+    await expect(() =>
+      requestBuilder.execute(destination)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      "\"Cannot use 'in' operator to search for 'data' in 1\""
+    );
+  });
+});

--- a/packages/core/src/openapi/openapi-request-builder.spec.ts
+++ b/packages/core/src/openapi/openapi-request-builder.spec.ts
@@ -1,12 +1,12 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { OpenApiRequestBuilder } from './openapi-request-builder';
 
+const rawResponse = {
+  data: 1
+} as AxiosResponse<number>;
 class TestApi {
   constructor(public axiosConfig: AxiosRequestConfig) {}
-  fn: () => Promise<AxiosResponse<number>> = async () =>
-    ({
-      data: 1
-    } as AxiosResponse<number>);
+  fn: () => Promise<AxiosResponse<number>> = async () => rawResponse;
   nonAxiosResponse = async () => 1;
 }
 
@@ -19,7 +19,14 @@ describe('openapi-request-builder', () => {
     const requestBuilder = new OpenApiRequestBuilder(TestApi, 'fn');
     const response = await requestBuilder.execute(destination);
 
-    expect(response).toEqual(1);
+    expect(response).toEqual(rawResponse.data);
+  });
+
+  it('executes a raw request', async () => {
+    const requestBuilder = new OpenApiRequestBuilder(TestApi, 'fn');
+    const response = await requestBuilder.executeRaw(destination);
+
+    expect(response).toEqual(rawResponse);
   });
 
   it('throws an error if the given function does not exist', async () => {

--- a/packages/core/src/openapi/openapi-request-builder.ts
+++ b/packages/core/src/openapi/openapi-request-builder.ts
@@ -46,7 +46,8 @@ export class OpenApiRequestBuilder<ApiT, FnT extends keyof ApiT> {
   }
 
   /**
-   * Execute request.
+   * Execute request and get a raw AxiosResponse, including all information about the HTTP response.
+   * This especially comes in handy, when you need to access the headers or status code of the response.
    * @param destination Destination to execute the request against.
    * @param options Options to employ when fetching destinations.
    * @returns A promise resolving to an AxiosResponse.
@@ -71,7 +72,7 @@ export class OpenApiRequestBuilder<ApiT, FnT extends keyof ApiT> {
   }
 
   /**
-   * Execute request.
+   * Execute request and get the response data. Use this to conveniently access the data of a service without technical information about the response.
    * @param destination Destination to execute the request against.
    * @param options Options to employ when fetching destinations.
    * @returns A promise resolving to the requested return type.
@@ -84,7 +85,7 @@ export class OpenApiRequestBuilder<ApiT, FnT extends keyof ApiT> {
       return response.data;
     }
     throw new Error(
-      'Could not execute request. Response was not an axios response.'
+      'Could not access response data. Response was not an axios response.'
     );
   }
 }

--- a/packages/core/src/openapi/types.ts
+++ b/packages/core/src/openapi/types.ts
@@ -1,3 +1,5 @@
+import { AxiosResponse } from 'axios';
+
 /**
  * Type of the parameters of a given function
  *
@@ -24,6 +26,11 @@ export type FunctionReturnType<
 > = ApiT[FnT] extends (...args: any) => any
   ? UnPromisify<ReturnType<ApiT[FnT]>>
   : never;
+
+/**
+ * Unwrap the Axios response type.
+ */
+export type UnwrapAxiosResponse<T> = T extends AxiosResponse<infer U> ? U : T;
 
 /**
  * Get the type of the promised response, e. g. for `Promise<SomeType>` this gives you `SomeType`.

--- a/test-packages/e2e-tests/test/openapi.spec.ts
+++ b/test-packages/e2e-tests/test/openapi.spec.ts
@@ -6,13 +6,12 @@ import { destination } from './test-util';
 
 // TODO: How do I handle paths in rest requests?
 // TODO: Transpilation needed + tsconfig needs dom typings
-// TODO: Response is never "parsed"
 const restDestination = { ...destination, url: destination.url + 'openapi' };
 describe('openapi request builder', () => {
   it('executes getAll request', async () => {
     const request = TestServiceApi.getAllEntities();
     expect(
-      (await request.execute(restDestination)).data.length
+      (await request.execute(restDestination)).length
     ).toBeGreaterThanOrEqual(4);
   });
 
@@ -28,6 +27,6 @@ describe('openapi request builder', () => {
   });
 });
 
-async function countEntities(): Promise<number> {
-  return (await TestServiceApi.countEntities().execute(restDestination)).data;
+function countEntities(): Promise<number> {
+  return TestServiceApi.countEntities().execute(restDestination);
 }


### PR DESCRIPTION
Introduce `executeRaw` that returns an AxiosResponse and return the plain response value in `execute`. Also adds tests.