### PR TITLE
fix: Fix order of parameters

### DIFF
--- a/packages/openapi-generator/src/parser/document.ts
+++ b/packages/openapi-generator/src/parser/document.ts
@@ -34,9 +34,7 @@ export function parseAllOperations(
       ...allOperations,
       ...methods()
         .filter(method => method in pathDefinition)
-        .map(method =>
-          parseOperation(pattern, pathDefinition, method, refs)
-        )
+        .map(method => parseOperation(pattern, pathDefinition, method, refs))
     ],
     []
   );

--- a/packages/openapi-generator/src/parser/document.ts
+++ b/packages/openapi-generator/src/parser/document.ts
@@ -35,7 +35,6 @@ export function parseAllOperations(
       ...methods()
         .filter(method => method in pathDefinition)
         .map(method =>
-          // The line above makes sure that the pathDefinition[method] is not undefined
           parseOperation(pattern, pathDefinition, method, refs)
         )
     ],

--- a/packages/openapi-generator/src/parser/document.ts
+++ b/packages/openapi-generator/src/parser/document.ts
@@ -36,7 +36,7 @@ export function parseAllOperations(
         .filter(method => method in pathDefinition)
         .map(method =>
           // The line above makes sure that the pathDefinition[method] is not undefined
-          parseOperation(pattern, method, pathDefinition[method]!, refs)
+          parseOperation(pattern, pathDefinition, method, refs)
         )
     ],
     []

--- a/packages/openapi-generator/src/parser/operation.spec.ts
+++ b/packages/openapi-generator/src/parser/operation.spec.ts
@@ -1,11 +1,6 @@
 import { OpenAPIV3 } from 'openapi-types';
 import { createRefs } from '../../test/test-util';
-import {
-  parseOperationName,
-  parseParameters,
-  getOperation,
-  filterDuplicates
-} from './operation';
+import { parseOperationName, parseParameters, getOperation } from './operation';
 
 describe('parseOperationName', () => {
   it('parses the operation name from the operationId', () => {
@@ -147,36 +142,5 @@ describe('getOperation', () => {
     ).toThrowErrorMatchingInlineSnapshot(
       '"Could not parse operation. Operation for method \'post\' does not exist."'
     );
-  });
-});
-
-describe('filterDuplicates', () => {
-  it('removes duplicates from parameters, keeping the last elements only', () => {
-    const queryParam1 = {
-      name: 'param1',
-      in: 'query'
-    };
-    const queryParam2 = {
-      name: 'param2',
-      in: 'query'
-    };
-    const pathParam1 = {
-      name: 'param1',
-      in: 'path'
-    };
-    const queryParam1Replacement = {
-      name: 'param1',
-      in: 'query',
-      format: 'uuid'
-    };
-
-    expect(
-      filterDuplicates([
-        queryParam1,
-        queryParam2,
-        queryParam1Replacement,
-        pathParam1
-      ])
-    ).toStrictEqual([queryParam2, queryParam1Replacement, pathParam1]);
   });
 });

--- a/packages/openapi-generator/src/parser/operation.spec.ts
+++ b/packages/openapi-generator/src/parser/operation.spec.ts
@@ -1,6 +1,5 @@
 import { OpenAPIV3 } from 'openapi-types';
-import { createRefs } from '../../test/test-util';
-import { parseOperationName, parseParameters, getOperation } from './operation';
+import { parseOperationName, getOperation } from './operation';
 
 describe('parseOperationName', () => {
   it('parses the operation name from the operationId', () => {
@@ -41,83 +40,6 @@ describe('parseOperationName', () => {
     expect(parseOperationName({}, '/{placeholder}', 'get')).toEqual(
       'getByPlaceholder'
     );
-  });
-});
-
-describe('parseParameters', () => {
-  it('returns empty array if there are no parameters', async () => {
-    expect(parseParameters({}, await createRefs())).toEqual([]);
-  });
-
-  it('parses inline parameters', async () => {
-    const anyParamNoSchema = { in: 'query', name: 'anyParamNoSchema' };
-    const anyParamWithSchema = {
-      in: 'query',
-      name: 'anyParamWithSchema',
-      schema: {}
-    };
-    const stringParam = {
-      in: 'query',
-      name: 'stringParam',
-      schema: { type: 'string' }
-    };
-    const numberParam = {
-      in: 'query',
-      name: 'numberParam',
-      schema: { type: 'integer' }
-    };
-
-    expect(
-      parseParameters(
-        {
-          parameters: [
-            anyParamNoSchema,
-            anyParamWithSchema,
-            stringParam,
-            numberParam
-          ]
-        },
-        await createRefs()
-      )
-    ).toStrictEqual([
-      { ...anyParamNoSchema, type: 'any' },
-      { ...anyParamWithSchema, type: 'any' },
-      { ...stringParam, type: 'string' },
-      { ...numberParam, type: 'number' }
-    ]);
-  });
-
-  it('parses referenced parameters', async () => {
-    const referencedParam = { in: 'query', name: 'referencedParam' };
-    const parameterSchema = { $ref: '#/components/schemas/parameterSchema' };
-    const referencedParamWithReferencedSchema = {
-      in: 'query',
-      name: 'referencedParamWithReferencedSchema',
-      schema: parameterSchema
-    };
-
-    expect(
-      parseParameters(
-        {
-          parameters: [
-            {
-              $ref: '#/components/parameters/referencedParam'
-            },
-            {
-              $ref:
-                '#/components/parameters/referencedParamWithReferencedSchema'
-            }
-          ]
-        },
-        await createRefs({
-          parameters: { referencedParam, referencedParamWithReferencedSchema },
-          schemas: { parameterSchema }
-        })
-      )
-    ).toStrictEqual([
-      { ...referencedParam, type: 'any' },
-      { ...referencedParamWithReferencedSchema, type: 'any' }
-    ]);
   });
 });
 

--- a/packages/openapi-generator/src/parser/operation.ts
+++ b/packages/openapi-generator/src/parser/operation.ts
@@ -4,7 +4,7 @@ import {
   camelCase,
   partition,
   pascalCase,
-  removeDuplicatesLeft
+  filterDuplicatesRight
 } from '@sap-cloud-sdk/util';
 import { Method, OpenApiOperation, OpenApiParameter } from '../openapi-types';
 import { getType } from './type-mapping';
@@ -76,11 +76,12 @@ export function parseParameters(
 ): OpenApiParameter[] {
   // TODO: What if this is a reference? What does OpenApi do?
   // TODO: What about oneof and other operations?
-  return removeDuplicatesLeft(
+  return filterDuplicatesRight(
     operation.parameters?.map(param => resolveObject(param, refs)) || [],
     (left, right) => left.name === right.name && left.in === right.in
   ).map(param => ({
     ...param,
+    // TODO: Check whether types are correct here and whether we can use union types here.
     type: getType(resolveObject(param.schema, refs)?.type?.toString())
   }));
 }

--- a/packages/openapi-generator/src/parser/operation.ts
+++ b/packages/openapi-generator/src/parser/operation.ts
@@ -1,24 +1,10 @@
 import { $Refs } from '@apidevtools/swagger-parser';
 import { OpenAPIV3 } from 'openapi-types';
-import {
-  camelCase,
-  partition,
-  pascalCase,
-  filterDuplicatesRight
-} from '@sap-cloud-sdk/util';
-import { Method, OpenApiOperation, OpenApiParameter } from '../openapi-types';
-import { getType } from './type-mapping';
+import { camelCase, partition, pascalCase } from '@sap-cloud-sdk/util';
+import { Method, OpenApiOperation } from '../openapi-types';
 import { parseRequestBody } from './request-body';
-import { resolveObject } from './refs';
+import { parseParameters } from './parameters';
 
-/**
- * Parse one operation for a path item and method.
- * @param pattern The url pattern, i. e. the key in the original operation definition object.
- * @param pathItem The original path item definition.
- * @param method HTTP method for this operation.
- * @param refs List of crossreferences that can occur in the document.
- * @returns The parsed operation.
- */
 export function parseOperation(
   pattern: string,
   pathItem: OpenAPIV3.PathItemObject,
@@ -62,28 +48,6 @@ export function getOperation(
     ...(operation.parameters || [])
   ];
   return operation;
-}
-
-/**
- * Parse parameters of an operation.
- * @param operation The original operation definition.
- * @param refs List of crossreferences that can occur in the document.
- * @returns A list of parsed parameters.
- */
-export function parseParameters(
-  operation: OpenAPIV3.OperationObject,
-  refs: $Refs
-): OpenApiParameter[] {
-  // TODO: What if this is a reference? What does OpenApi do?
-  // TODO: What about oneof and other operations?
-  return filterDuplicatesRight(
-    operation.parameters?.map(param => resolveObject(param, refs)) || [],
-    (left, right) => left.name === right.name && left.in === right.in
-  ).map(param => ({
-    ...param,
-    // TODO: Check whether types are correct here and whether we can use union types here.
-    type: getType(resolveObject(param.schema, refs)?.type?.toString())
-  }));
 }
 
 export function parseOperationName(

--- a/packages/openapi-generator/src/parser/parameters.spec.ts
+++ b/packages/openapi-generator/src/parser/parameters.spec.ts
@@ -1,0 +1,140 @@
+import { createRefs } from '../../test/test-util';
+import {
+  filterDuplicateParams,
+  parseParameters,
+  renameEquallyNamedParams
+} from './parameters';
+
+describe('parseParameters', () => {
+  it('returns empty array if there are no parameters', async () => {
+    expect(parseParameters({}, await createRefs())).toEqual([]);
+  });
+
+  it('parses inline parameters', async () => {
+    const anyParamNoSchema = { in: 'query', name: 'anyParamNoSchema' };
+    const anyParamWithSchema = {
+      in: 'query',
+      name: 'anyParamWithSchema',
+      schema: {}
+    };
+    const stringParam = {
+      in: 'query',
+      name: 'stringParam',
+      schema: { type: 'string' }
+    };
+    const numberParam = {
+      in: 'query',
+      name: 'numberParam',
+      schema: { type: 'integer' }
+    };
+
+    expect(
+      parseParameters(
+        {
+          parameters: [
+            anyParamNoSchema,
+            anyParamWithSchema,
+            stringParam,
+            numberParam
+          ]
+        },
+        await createRefs()
+      )
+    ).toStrictEqual([
+      { ...anyParamNoSchema, type: 'any' },
+      { ...anyParamWithSchema, type: 'any' },
+      { ...stringParam, type: 'string' },
+      { ...numberParam, type: 'number' }
+    ]);
+  });
+
+  it('parses referenced parameters', async () => {
+    const referencedParam = { in: 'query', name: 'referencedParam' };
+    const parameterSchema = { $ref: '#/components/schemas/parameterSchema' };
+    const referencedParamWithReferencedSchema = {
+      in: 'query',
+      name: 'referencedParamWithReferencedSchema',
+      schema: parameterSchema
+    };
+
+    expect(
+      parseParameters(
+        {
+          parameters: [
+            {
+              $ref: '#/components/parameters/referencedParam'
+            },
+            {
+              $ref:
+                '#/components/parameters/referencedParamWithReferencedSchema'
+            }
+          ]
+        },
+        await createRefs({
+          parameters: { referencedParam, referencedParamWithReferencedSchema },
+          schemas: { parameterSchema }
+        })
+      )
+    ).toStrictEqual([
+      { ...referencedParam, type: 'any' },
+      { ...referencedParamWithReferencedSchema, type: 'any' }
+    ]);
+  });
+});
+
+describe('filterDuplicateParams', () => {
+  it('removes duplicates from parameters, keeping the last elements only', () => {
+    const queryParam1 = {
+      name: 'param1',
+      in: 'query'
+    };
+    const queryParam2 = {
+      name: 'param2',
+      in: 'query'
+    };
+    const pathParam1 = {
+      name: 'param1',
+      in: 'path'
+    };
+    const queryParam1Replacement = {
+      name: 'param1',
+      in: 'query',
+      format: 'uuid'
+    };
+
+    expect(
+      filterDuplicateParams([
+        queryParam1,
+        queryParam2,
+        queryParam1Replacement,
+        pathParam1
+      ])
+    ).toStrictEqual([queryParam2, queryParam1Replacement, pathParam1]);
+  });
+});
+
+describe('renameEquallyNamedParams', () => {
+  it('renames parameters', () => {
+    expect(
+      renameEquallyNamedParams([
+        {
+          name: 'name',
+          in: 'query'
+        },
+        {
+          name: 'name',
+          in: 'path'
+        }
+      ])
+    ).toStrictEqual([
+      {
+        name: 'name',
+        in: 'query'
+      },
+      {
+        name: 'name2',
+        in: 'path'
+      }
+    ]);
+  });
+});

--- a/packages/openapi-generator/src/parser/parameters.ts
+++ b/packages/openapi-generator/src/parser/parameters.ts
@@ -1,0 +1,60 @@
+import { $Refs } from '@apidevtools/swagger-parser';
+import { filterDuplicatesRight, partition } from '@sap-cloud-sdk/util';
+import { OpenAPIV3 } from 'openapi-types';
+import { OpenApiParameter } from '../openapi-types';
+import { resolveObject } from './refs';
+import { getType } from './type-mapping';
+
+/**
+ * Parse parameters of an operation.
+ * @param operation The original operation definition.
+ * @param refs List of crossreferences that can occur in the document.
+ * @returns A list of parsed parameters.
+ */
+export function parseParameters(
+  operation: OpenAPIV3.OperationObject,
+  refs: $Refs
+): OpenApiParameter[] {
+  // TODO: What if this is a reference? What does OpenApi do?
+  // TODO: What about oneof and other operations?
+  let parameters =
+    operation.parameters?.map(param => resolveObject(param, refs)) || [];
+  parameters = filterDuplicateParams(parameters);
+  parameters = reorderParameters(parameters);
+  parameters = renameEquallyNamedParams(parameters);
+  return parameters.map(param => ({
+    ...param,
+    // TODO: Check whether types are correct here and whether we can use union types here.
+    type: getType(resolveObject(param.schema, refs)?.type?.toString())
+  }));
+}
+
+export function filterDuplicateParams(
+  parameters: OpenAPIV3.ParameterObject[]
+): OpenAPIV3.ParameterObject[] {
+  return filterDuplicatesRight(
+    parameters,
+    (left, right) => left.name === right.name && left.in === right.in
+  );
+}
+
+function reorderParameters(
+  parameters: OpenAPIV3.ParameterObject[]
+): OpenAPIV3.ParameterObject[] {
+  const [required, optional] = partition(parameters, param => !!param.required);
+  return [...required, ...optional];
+}
+
+export function renameEquallyNamedParams(
+  parameters: OpenAPIV3.ParameterObject[]
+): OpenAPIV3.ParameterObject[] {
+  return parameters.map((param, i) => {
+    const duplicate = parameters
+      .slice(0, i)
+      .find(previousParam => previousParam.name === param.name);
+    if (duplicate) {
+      param.name = `${param.name}2`;
+    }
+    return param;
+  });
+}

--- a/packages/openapi-generator/src/wrapper-files/__snapshots__/api-file.spec.ts.snap
+++ b/packages/openapi-generator/src/wrapper-files/__snapshots__/api-file.spec.ts.snap
@@ -6,7 +6,12 @@ import { DefaultApi } from './openapi/api';
 import { Body } from './openapi/model';
 
 export const TestServiceApi = {
-  getEntity: (requiredPathParam: number, body: Body, requiredQueryParam: number, optionalQueryParam?: number) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
+  getEntity: (args: {
+      requiredQueryParam: number,
+      requiredPathParam: number,
+      body: Body,
+      optionalQueryParam?: number
+    }) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
     DefaultApi,
     'getEntity',
     requiredQueryParam,
@@ -36,12 +41,17 @@ import { DefaultApi } from './openapi/api';
 import { Body } from './openapi/model';
 
 export const TestServiceApi = {
-  createEntity: (body: Body) => new OpenApiRequestBuilder<DefaultApi, 'createEntity'>(
+  createEntity: (args: {
+      body: Body
+    }) => new OpenApiRequestBuilder<DefaultApi, 'createEntity'>(
     DefaultApi,
     'createEntity',
     body
   ),
-  updateEntity: (id: string, body: Body) => new OpenApiRequestBuilder<DefaultApi, 'updateEntity'>(
+  updateEntity: (args: {
+      id: string,
+      body: Body
+    }) => new OpenApiRequestBuilder<DefaultApi, 'updateEntity'>(
     DefaultApi,
     'updateEntity',
     id,
@@ -56,13 +66,18 @@ import { DefaultApi } from './openapi/api';
 
 
 export const TestServiceApi = {
-  getEntity: (id: string, limit?: number) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
+  getEntity: (args: {
+      id: string,
+      limit?: number
+    }) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
     DefaultApi,
     'getEntity',
     id,
     limit
   ),
-  deleteEntity: (id: string) => new OpenApiRequestBuilder<DefaultApi, 'deleteEntity'>(
+  deleteEntity: (args: {
+      id: string
+    }) => new OpenApiRequestBuilder<DefaultApi, 'deleteEntity'>(
     DefaultApi,
     'deleteEntity',
     id

--- a/packages/openapi-generator/src/wrapper-files/__snapshots__/api-file.spec.ts.snap
+++ b/packages/openapi-generator/src/wrapper-files/__snapshots__/api-file.spec.ts.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`api-file creates api file content for operation with differently ordered parameters 1`] = `
+"import { OpenApiRequestBuilder } from '@sap-cloud-sdk/core';
+import { DefaultApi } from './openapi/api';
+import { Body } from './openapi/model';
+
+export const TestServiceApi = {
+  getEntity: (requiredPathParam: number, body: Body, requiredQueryParam: number, optionalQueryParam?: number) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
+    DefaultApi,
+    'getEntity',
+    requiredQueryParam,
+    requiredPathParam,
+    body,
+    optionalQueryParam
+  )
+};"
+`;
+
 exports[`api-file creates api file content for operation with no parameters or request body 1`] = `
 "import { OpenApiRequestBuilder } from '@sap-cloud-sdk/core';
 import { DefaultApi } from './openapi/api';

--- a/packages/openapi-generator/src/wrapper-files/__snapshots__/api-file.spec.ts.snap
+++ b/packages/openapi-generator/src/wrapper-files/__snapshots__/api-file.spec.ts.snap
@@ -7,17 +7,17 @@ import { Body } from './openapi/model';
 
 export const TestServiceApi = {
   getEntity: (args: {
-      requiredQueryParam: number,
-      requiredPathParam: number,
-      body: Body,
-      optionalQueryParam?: number
-    }) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
+    requiredQueryParam: number,
+    requiredPathParam: number,
+    body: Body,
+    optionalQueryParam?: number
+  }) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
     DefaultApi,
     'getEntity',
-    requiredQueryParam,
-    requiredPathParam,
-    body,
-    optionalQueryParam
+    args.requiredQueryParam,
+    args.requiredPathParam,
+    args.body,
+    args.optionalQueryParam
   )
 };"
 `;
@@ -35,6 +35,22 @@ export const TestServiceApi = {
 };"
 `;
 
+exports[`api-file creates api file content for operation with only  optional parameters 1`] = `
+"import { OpenApiRequestBuilder } from '@sap-cloud-sdk/core';
+import { DefaultApi } from './openapi/api';
+
+
+export const TestServiceApi = {
+  getEntity: (args?: {
+    optionalQueryParam?: number
+  }) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
+    DefaultApi,
+    'getEntity',
+    args?.optionalQueryParam
+  )
+};"
+`;
+
 exports[`api-file creates api file content for operation with request body 1`] = `
 "import { OpenApiRequestBuilder } from '@sap-cloud-sdk/core';
 import { DefaultApi } from './openapi/api';
@@ -42,20 +58,20 @@ import { Body } from './openapi/model';
 
 export const TestServiceApi = {
   createEntity: (args: {
-      body: Body
-    }) => new OpenApiRequestBuilder<DefaultApi, 'createEntity'>(
+    body: Body
+  }) => new OpenApiRequestBuilder<DefaultApi, 'createEntity'>(
     DefaultApi,
     'createEntity',
-    body
+    args.body
   ),
   updateEntity: (args: {
-      id: string,
-      body: Body
-    }) => new OpenApiRequestBuilder<DefaultApi, 'updateEntity'>(
+    id: string,
+    body: Body
+  }) => new OpenApiRequestBuilder<DefaultApi, 'updateEntity'>(
     DefaultApi,
     'updateEntity',
-    id,
-    body
+    args.id,
+    args.body
   )
 };"
 `;
@@ -67,20 +83,20 @@ import { DefaultApi } from './openapi/api';
 
 export const TestServiceApi = {
   getEntity: (args: {
-      id: string,
-      limit?: number
-    }) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
+    id: string,
+    limit?: number
+  }) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
     DefaultApi,
     'getEntity',
-    id,
-    limit
+    args.id,
+    args.limit
   ),
   deleteEntity: (args: {
-      id: string
-    }) => new OpenApiRequestBuilder<DefaultApi, 'deleteEntity'>(
+    id: string
+  }) => new OpenApiRequestBuilder<DefaultApi, 'deleteEntity'>(
     DefaultApi,
     'deleteEntity',
-    id
+    args.id
   )
 };"
 `;

--- a/packages/openapi-generator/src/wrapper-files/__snapshots__/api-file.spec.ts.snap
+++ b/packages/openapi-generator/src/wrapper-files/__snapshots__/api-file.spec.ts.snap
@@ -1,51 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`api-file creates api file content for operation with differently ordered parameters 1`] = `
-"import { OpenApiRequestBuilder } from '@sap-cloud-sdk/core';
-import { DefaultApi } from './openapi/api';
-import { Body } from './openapi/model';
-
-export const TestServiceApi = {
-  getEntity: (args: {
-    requiredQueryParam: number,
-    requiredPathParam: number,
-    body: Body,
-    optionalQueryParam?: number
-  }) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
-    DefaultApi,
-    'getEntity',
-    args.requiredQueryParam,
-    args.requiredPathParam,
-    args.body,
-    args.optionalQueryParam
-  )
-};"
-`;
-
 exports[`api-file creates api file content for operation with no parameters or request body 1`] = `
 "import { OpenApiRequestBuilder } from '@sap-cloud-sdk/core';
 import { DefaultApi } from './openapi/api';
 
 
-export const TestServiceApi = {
-  getEntity: () => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
+export const TestApi = {
+  getFn: () => new OpenApiRequestBuilder<DefaultApi, 'getFn'>(
     DefaultApi,
-    'getEntity'
+    'getFn'
   )
 };"
 `;
 
-exports[`api-file creates api file content for operation with only  optional parameters 1`] = `
+exports[`api-file creates api file content for operation with only optional parameters 1`] = `
 "import { OpenApiRequestBuilder } from '@sap-cloud-sdk/core';
 import { DefaultApi } from './openapi/api';
 
 
-export const TestServiceApi = {
-  getEntity: (args?: {
+export const TestApi = {
+  getFn: (args?: {
     optionalQueryParam?: number
-  }) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
+  }) => new OpenApiRequestBuilder<DefaultApi, 'getFn'>(
     DefaultApi,
-    'getEntity',
+    'getFn',
     args?.optionalQueryParam
   )
 };"
@@ -56,22 +34,44 @@ exports[`api-file creates api file content for operation with request body 1`] =
 import { DefaultApi } from './openapi/api';
 import { Body } from './openapi/model';
 
-export const TestServiceApi = {
-  createEntity: (args: {
+export const TestApi = {
+  createFn: (args: {
     body: Body
-  }) => new OpenApiRequestBuilder<DefaultApi, 'createEntity'>(
+  }) => new OpenApiRequestBuilder<DefaultApi, 'createFn'>(
     DefaultApi,
-    'createEntity',
+    'createFn',
     args.body
   ),
-  updateEntity: (args: {
+  updateFn: (args: {
     id: string,
     body: Body
-  }) => new OpenApiRequestBuilder<DefaultApi, 'updateEntity'>(
+  }) => new OpenApiRequestBuilder<DefaultApi, 'updateFn'>(
     DefaultApi,
-    'updateEntity',
+    'updateFn',
     args.id,
     args.body
+  )
+};"
+`;
+
+exports[`api-file creates api file content for operation with required parameters defined after optional parameters 1`] = `
+"import { OpenApiRequestBuilder } from '@sap-cloud-sdk/core';
+import { DefaultApi } from './openapi/api';
+import { Body } from './openapi/model';
+
+export const TestApi = {
+  createFn: (args: {
+    requiredQueryParam: number,
+    requiredPathParam: number,
+    body: Body,
+    optionalQueryParam?: number
+  }) => new OpenApiRequestBuilder<DefaultApi, 'createFn'>(
+    DefaultApi,
+    'createFn',
+    args.requiredQueryParam,
+    args.requiredPathParam,
+    args.body,
+    args.optionalQueryParam
   )
 };"
 `;
@@ -81,21 +81,21 @@ exports[`api-file creates api file content for operations with parameters and no
 import { DefaultApi } from './openapi/api';
 
 
-export const TestServiceApi = {
-  getEntity: (args: {
+export const TestApi = {
+  getFn: (args: {
     id: string,
     limit?: number
-  }) => new OpenApiRequestBuilder<DefaultApi, 'getEntity'>(
+  }) => new OpenApiRequestBuilder<DefaultApi, 'getFn'>(
     DefaultApi,
-    'getEntity',
+    'getFn',
     args.id,
     args.limit
   ),
-  deleteEntity: (args: {
+  deleteFn: (args: {
     id: string
-  }) => new OpenApiRequestBuilder<DefaultApi, 'deleteEntity'>(
+  }) => new OpenApiRequestBuilder<DefaultApi, 'deleteFn'>(
     DefaultApi,
-    'deleteEntity',
+    'deleteFn',
     args.id
   )
 };"

--- a/packages/openapi-generator/src/wrapper-files/api-file.spec.ts
+++ b/packages/openapi-generator/src/wrapper-files/api-file.spec.ts
@@ -4,10 +4,10 @@ import { apiFile } from './api-file';
 describe('api-file', () => {
   it('creates api file content for operations with parameters and no request bodies', () => {
     const openApiDocument: OpenApiDocument = {
-      apiName: 'TestServiceApi',
+      apiName: 'TestApi',
       operations: [
         {
-          operationName: 'getEntity',
+          operationName: 'getFn',
           method: 'get',
           parameters: [
             {
@@ -25,7 +25,7 @@ describe('api-file', () => {
           pattern: 'test/{id}'
         },
         {
-          operationName: 'deleteEntity',
+          operationName: 'deleteFn',
           method: 'delete',
           parameters: [
             {
@@ -45,10 +45,10 @@ describe('api-file', () => {
 
   it('creates api file content for operation with request body', () => {
     const openApiDocument: OpenApiDocument = {
-      apiName: 'TestServiceApi',
+      apiName: 'TestApi',
       operations: [
         {
-          operationName: 'createEntity',
+          operationName: 'createFn',
           method: 'post',
           parameters: [],
           requestBody: {
@@ -59,7 +59,7 @@ describe('api-file', () => {
           pattern: 'test'
         },
         {
-          operationName: 'updateEntity',
+          operationName: 'updateFn',
           method: 'patch',
           parameters: [
             {
@@ -84,10 +84,10 @@ describe('api-file', () => {
 
   it('creates api file content for operation with no parameters or request body', () => {
     const openApiDocument: OpenApiDocument = {
-      apiName: 'TestServiceApi',
+      apiName: 'TestApi',
       operations: [
         {
-          operationName: 'getEntity',
+          operationName: 'getFn',
           method: 'get',
           parameters: [],
           pattern: 'test'
@@ -98,12 +98,12 @@ describe('api-file', () => {
     expect(apiFile(openApiDocument)).toMatchSnapshot();
   });
 
-  it('creates api file content for operation with differently ordered parameters', () => {
+  it('creates api file content for operation with required parameters defined after optional parameters', () => {
     const openApiDocument: OpenApiDocument = {
-      apiName: 'TestServiceApi',
+      apiName: 'TestApi',
       operations: [
         {
-          operationName: 'getEntity',
+          operationName: 'createFn',
           method: 'post',
           parameters: [
             {
@@ -137,12 +137,12 @@ describe('api-file', () => {
     expect(apiFile(openApiDocument)).toMatchSnapshot();
   });
 
-  it('creates api file content for operation with only  optional parameters', () => {
+  it('creates api file content for operation with only optional parameters', () => {
     const openApiDocument: OpenApiDocument = {
-      apiName: 'TestServiceApi',
+      apiName: 'TestApi',
       operations: [
         {
-          operationName: 'getEntity',
+          operationName: 'getFn',
           method: 'get',
           parameters: [
             {

--- a/packages/openapi-generator/src/wrapper-files/api-file.spec.ts
+++ b/packages/openapi-generator/src/wrapper-files/api-file.spec.ts
@@ -11,15 +11,15 @@ describe('api-file', () => {
           method: 'get',
           parameters: [
             {
+              in: 'query',
+              name: 'limit',
+              type: 'number'
+            },
+            {
               in: 'path',
               name: 'id',
               type: 'string',
               required: true
-            },
-            {
-              in: 'query',
-              name: 'limit',
-              type: 'number'
             }
           ],
           pattern: 'test/{id}'
@@ -90,6 +90,45 @@ describe('api-file', () => {
           operationName: 'getEntity',
           method: 'get',
           parameters: [],
+          pattern: 'test'
+        }
+      ],
+      serviceDirName: 'test-service'
+    };
+    expect(apiFile(openApiDocument)).toMatchSnapshot();
+  });
+
+  it('creates api file content for operation with differently ordered parameters', () => {
+    const openApiDocument: OpenApiDocument = {
+      apiName: 'TestServiceApi',
+      operations: [
+        {
+          operationName: 'getEntity',
+          method: 'post',
+          parameters: [
+            {
+              in: 'query',
+              name: 'optionalQueryParam',
+              type: 'number'
+            },
+            {
+              in: 'query',
+              name: 'requiredQueryParam',
+              type: 'number',
+              required: true
+            },
+            {
+              in: 'path',
+              name: 'requiredPathParam',
+              type: 'number',
+              required: true
+            }
+          ],
+          requestBody: {
+            parameterName: 'body',
+            parameterType: 'Body',
+            required: true
+          } as OpenApiRequestBody,
           pattern: 'test'
         }
       ],

--- a/packages/openapi-generator/src/wrapper-files/api-file.spec.ts
+++ b/packages/openapi-generator/src/wrapper-files/api-file.spec.ts
@@ -136,4 +136,26 @@ describe('api-file', () => {
     };
     expect(apiFile(openApiDocument)).toMatchSnapshot();
   });
+
+  it('creates api file content for operation with only  optional parameters', () => {
+    const openApiDocument: OpenApiDocument = {
+      apiName: 'TestServiceApi',
+      operations: [
+        {
+          operationName: 'getEntity',
+          method: 'get',
+          parameters: [
+            {
+              in: 'query',
+              name: 'optionalQueryParam',
+              type: 'number'
+            }
+          ],
+          pattern: 'test'
+        }
+      ],
+      serviceDirName: 'test-service'
+    };
+    expect(apiFile(openApiDocument)).toMatchSnapshot();
+  });
 });

--- a/packages/openapi-generator/src/wrapper-files/api-file.ts
+++ b/packages/openapi-generator/src/wrapper-files/api-file.ts
@@ -55,17 +55,18 @@ function getOperations(openApiDocument: OpenApiDocument): string {
  */
 function getOperation(operation: OpenApiOperation): string {
   const params = getParams(operation);
+  const argsQuestionMark = params.every(param => !param.required) ? '?' : '';
   const paramsArg = params.length
-    ? codeBlock`args: {
-    ${params
-      .map(param => `${param.name}${param.required ? '' : '?'}: ${param.type}`)
-      .join(',\n')}
-  }`
+    ? codeBlock`args${argsQuestionMark}: {
+  ${params
+    .map(param => `${param.name}${param.required ? '' : '?'}: ${param.type}`)
+    .join(',\n')}
+}`
     : '';
   const requestBuilderParams = [
     'DefaultApi',
     `'${operation.operationName}'`,
-    ...params.map(param => param.name)
+    ...params.map(param => `args${argsQuestionMark}.${param.name}`)
   ];
 
   return codeBlock`

--- a/packages/openapi-generator/src/wrapper-files/api-file.ts
+++ b/packages/openapi-generator/src/wrapper-files/api-file.ts
@@ -80,7 +80,6 @@ interface Parameter {
 function getApiFunctionSignatureParams(
   operation: OpenApiOperation
 ): Parameter[] {
-  // const parameters = operation.operationName //getAllParameters(operation);
   const [required, optional] = partition(
     operation.parameters,
     param => !!param.required

--- a/packages/util/src/array.spec.ts
+++ b/packages/util/src/array.spec.ts
@@ -8,7 +8,8 @@ import {
   variadicArgumentToArray,
   zip,
   partition,
-  removeDuplicatesLeft
+  filterDuplicates,
+  filterDuplicatesRight
 } from './array';
 
 describe('array', () => {
@@ -164,18 +165,37 @@ describe('partition', () => {
   });
 });
 
-describe('removeDuplicatesLeft', () => {
+describe('filterDuplicates', () => {
   it('can handle empty array', () => {
-    expect(removeDuplicatesLeft([])).toEqual([]);
+    expect(filterDuplicates([])).toEqual([]);
   });
 
   it('removes duplicates using the default comparator', () => {
-    expect(removeDuplicatesLeft([1, 2, 1, 4])).toEqual([2, 1, 4]);
+    expect(filterDuplicates([1, 2, 1, 4])).toEqual([1, 2, 4]);
   });
 
   it('removes duplicates using a custom comparator', () => {
     expect(
-      removeDuplicatesLeft(
+      filterDuplicates(
+        [{ a: 1, b: 1 }, { a: 2 }, { a: 1, b: 2 }, { a: 4 }],
+        (left, right) => left.a === right.a
+      )
+    ).toEqual([{ a: 1, b: 1 }, { a: 2 }, { a: 4 }]);
+  });
+});
+
+describe('filterDuplicatesRight', () => {
+  it('can handle empty array', () => {
+    expect(filterDuplicatesRight([])).toEqual([]);
+  });
+
+  it('removes duplicates using the default comparator', () => {
+    expect(filterDuplicatesRight([1, 2, 1, 4])).toEqual([2, 1, 4]);
+  });
+
+  it('removes duplicates using a custom comparator', () => {
+    expect(
+      filterDuplicatesRight(
         [{ a: 1, b: 1 }, { a: 2 }, { a: 1, b: 2 }, { a: 4 }],
         (left, right) => left.a === right.a
       )

--- a/packages/util/src/array.spec.ts
+++ b/packages/util/src/array.spec.ts
@@ -7,7 +7,8 @@ import {
   splitInChunks,
   variadicArgumentToArray,
   zip,
-  partition
+  partition,
+  removeDuplicatesLeft
 } from './array';
 
 describe('array', () => {
@@ -160,5 +161,24 @@ describe('partition', () => {
       [true, true],
       [false, false]
     ]);
+  });
+});
+
+describe('removeDuplicatesLeft', () => {
+  it('can handle empty array', () => {
+    expect(removeDuplicatesLeft([])).toEqual([]);
+  });
+
+  it('removes duplicates using the default comparator', () => {
+    expect(removeDuplicatesLeft([1, 2, 1, 4])).toEqual([2, 1, 4]);
+  });
+
+  it('removes duplicates using a custom comparator', () => {
+    expect(
+      removeDuplicatesLeft(
+        [{ a: 1, b: 1 }, { a: 2 }, { a: 1, b: 2 }, { a: 4 }],
+        (left, right) => left.a === right.a
+      )
+    ).toEqual([{ a: 2 }, { a: 1, b: 2 }, { a: 4 }]);
   });
 });

--- a/packages/util/src/array.ts
+++ b/packages/util/src/array.ts
@@ -135,3 +135,24 @@ export function partition<T>(
     [[], []]
   );
 }
+
+/**
+ * Remove duplicates from an array, keeping the right most occurence.
+ * @param arr Array to remove duplicates from.
+ * @param comparator Optional comparator function, indicating whether two items are equal and therefore handled as duplicates. Defaults to identity.
+ * @returns A filtered array containing no duplicates.
+ */
+export function removeDuplicatesLeft<T>(
+  arr: T[],
+  comparator: (left: T, right: T) => boolean = (left, right) => left === right
+): T[] {
+  return arr.reduce((reducedArr: T[], currentItem: T) => {
+    const duplicateIndex = reducedArr.findIndex(item =>
+      comparator(item, currentItem)
+    );
+    if (duplicateIndex >= 0) {
+      reducedArr.splice(duplicateIndex, 1);
+    }
+    return [...reducedArr, currentItem];
+  }, []);
+}

--- a/packages/util/src/array.ts
+++ b/packages/util/src/array.ts
@@ -137,22 +137,30 @@ export function partition<T>(
 }
 
 /**
- * Remove duplicates from an array, keeping the right most occurence.
+ * Filter an array by removing duplicates and keeping the left most occurence. By default this compares by identity.
  * @param arr Array to remove duplicates from.
  * @param comparator Optional comparator function, indicating whether two items are equal and therefore handled as duplicates. Defaults to identity.
  * @returns A filtered array containing no duplicates.
  */
-export function removeDuplicatesLeft<T>(
+export function filterDuplicates<T>(
   arr: T[],
   comparator: (left: T, right: T) => boolean = (left, right) => left === right
 ): T[] {
-  return arr.reduce((reducedArr: T[], currentItem: T) => {
-    const duplicateIndex = reducedArr.findIndex(item =>
-      comparator(item, currentItem)
-    );
-    if (duplicateIndex >= 0) {
-      reducedArr.splice(duplicateIndex, 1);
-    }
-    return [...reducedArr, currentItem];
-  }, []);
+  return arr.filter(
+    (item, index) =>
+      !arr.slice(0, index).find(filteredItem => comparator(item, filteredItem))
+  );
+}
+
+/**
+ * Filter an array by removing duplicates and keeping the right most occurence. By default this compares by identity.
+ * @param arr Array to remove duplicates from.
+ * @param comparator Optional comparator function, indicating whether two items are equal and therefore handled as duplicates. Defaults to identity.
+ * @returns A filtered array containing no duplicates.
+ */
+export function filterDuplicatesRight<T>(
+  arr: T[],
+  comparator: (left: T, right: T) => boolean = (left, right) => left === right
+): T[] {
+  return filterDuplicates(arr.reverse(), comparator).reverse();
 }

--- a/test-packages/e2e-tests/test/openapi.spec.ts
+++ b/test-packages/e2e-tests/test/openapi.spec.ts
@@ -22,7 +22,7 @@ describe('openapi request builder', () => {
       keyProperty: 'a13e7a92-cb9c-8f4a-b1e1-6b5c8458a9fb',
       stringProperty: 'string'
     };
-    await TestServiceApi.createEntity(testEntity).execute(restDestination);
+    await TestServiceApi.createEntity({ testEntity }).execute(restDestination);
     const postCreateCount = await countEntities();
     expect(postCreateCount).toEqual(preCreateCount + 1);
   });

--- a/test-packages/test-services/openapi/test-service/api.ts
+++ b/test-packages/test-services/openapi/test-service/api.ts
@@ -8,65 +8,65 @@ import { DefaultApi } from './openapi/api';
 import { TestEntity, SimpleTestEntity } from './openapi/model';
 
 export const TestServiceApi = {
-  getAllEntities: (args: {
-      stringParameter?: string,
-      integerParameter?: number
-    }) => new OpenApiRequestBuilder<DefaultApi, 'getAllEntities'>(
+  getAllEntities: (args?: {
+    stringParameter?: string,
+    integerParameter?: number
+  }) => new OpenApiRequestBuilder<DefaultApi, 'getAllEntities'>(
     DefaultApi,
     'getAllEntities',
-    stringParameter,
-    integerParameter
+    args?.stringParameter,
+    args?.integerParameter
   ),
-  createEntity: (args: {
-      testEntity?: TestEntity
-    }) => new OpenApiRequestBuilder<DefaultApi, 'createEntity'>(
+  createEntity: (args?: {
+    testEntity?: TestEntity
+  }) => new OpenApiRequestBuilder<DefaultApi, 'createEntity'>(
     DefaultApi,
     'createEntity',
-    testEntity
+    args?.testEntity
   ),
   getEntityByKey: (args: {
-      entityId: string
-    }) => new OpenApiRequestBuilder<DefaultApi, 'getEntityByKey'>(
+    entityId: string
+  }) => new OpenApiRequestBuilder<DefaultApi, 'getEntityByKey'>(
     DefaultApi,
     'getEntityByKey',
-    entityId
+    args.entityId
   ),
   countEntities: () => new OpenApiRequestBuilder<DefaultApi, 'countEntities'>(
     DefaultApi,
     'countEntities'
   ),
   testCaseGetRequiredParameters: (args: {
-      requiredPathItemQueryParam: string,
-      requiredPathItemPathParam: string,
-      requiredQueryParam: string,
-      optionalQueryParam?: string,
-      optionalPathItemQueryParam?: string,
-      simpleTestEntity?: SimpleTestEntity
-    }) => new OpenApiRequestBuilder<DefaultApi, 'testCaseGetRequiredParameters'>(
+    requiredPathItemQueryParam: string,
+    requiredPathItemPathParam: string,
+    requiredQueryParam: string,
+    optionalQueryParam?: string,
+    optionalPathItemQueryParam?: string,
+    simpleTestEntity?: SimpleTestEntity
+  }) => new OpenApiRequestBuilder<DefaultApi, 'testCaseGetRequiredParameters'>(
     DefaultApi,
     'testCaseGetRequiredParameters',
-    requiredPathItemQueryParam,
-    requiredPathItemPathParam,
-    requiredQueryParam,
-    optionalQueryParam,
-    optionalPathItemQueryParam,
-    simpleTestEntity
+    args.requiredPathItemQueryParam,
+    args.requiredPathItemPathParam,
+    args.requiredQueryParam,
+    args.optionalQueryParam,
+    args.optionalPathItemQueryParam,
+    args.simpleTestEntity
   ),
   testCasePostRequiredParameters: (args: {
-      requiredPathItemQueryParam: string,
-      requiredPathItemPathParam: string,
-      requiredQueryParam: string,
-      simpleTestEntity: SimpleTestEntity,
-      optionalPathItemQueryParam?: string,
-      optionalQueryParam?: string
-    }) => new OpenApiRequestBuilder<DefaultApi, 'testCasePostRequiredParameters'>(
+    requiredPathItemQueryParam: string,
+    requiredPathItemPathParam: string,
+    requiredQueryParam: string,
+    simpleTestEntity: SimpleTestEntity,
+    optionalPathItemQueryParam?: string,
+    optionalQueryParam?: string
+  }) => new OpenApiRequestBuilder<DefaultApi, 'testCasePostRequiredParameters'>(
     DefaultApi,
     'testCasePostRequiredParameters',
-    requiredPathItemQueryParam,
-    requiredPathItemPathParam,
-    requiredQueryParam,
-    simpleTestEntity,
-    optionalPathItemQueryParam,
-    optionalQueryParam
+    args.requiredPathItemQueryParam,
+    args.requiredPathItemPathParam,
+    args.requiredQueryParam,
+    args.simpleTestEntity,
+    args.optionalPathItemQueryParam,
+    args.optionalQueryParam
   )
 };

--- a/test-packages/test-services/openapi/test-service/api.ts
+++ b/test-packages/test-services/openapi/test-service/api.ts
@@ -68,5 +68,14 @@ export const TestServiceApi = {
     args.simpleTestEntity,
     args.optionalPathItemQueryParam,
     args.optionalQueryParam
+  ),
+  testCaseGetDuplicateParameters: (args: {
+    duplicateParam: string,
+    duplicateParam2: string
+  }) => new OpenApiRequestBuilder<DefaultApi, 'testCaseGetDuplicateParameters'>(
+    DefaultApi,
+    'testCaseGetDuplicateParameters',
+    args.duplicateParam,
+    args.duplicateParam2
   )
 };

--- a/test-packages/test-services/openapi/test-service/api.ts
+++ b/test-packages/test-services/openapi/test-service/api.ts
@@ -8,18 +8,25 @@ import { DefaultApi } from './openapi/api';
 import { TestEntity, SimpleTestEntity } from './openapi/model';
 
 export const TestServiceApi = {
-  getAllEntities: (stringParameter?: string, integerParameter?: number) => new OpenApiRequestBuilder<DefaultApi, 'getAllEntities'>(
+  getAllEntities: (args: {
+      stringParameter?: string,
+      integerParameter?: number
+    }) => new OpenApiRequestBuilder<DefaultApi, 'getAllEntities'>(
     DefaultApi,
     'getAllEntities',
     stringParameter,
     integerParameter
   ),
-  createEntity: (testEntity?: TestEntity) => new OpenApiRequestBuilder<DefaultApi, 'createEntity'>(
+  createEntity: (args: {
+      testEntity?: TestEntity
+    }) => new OpenApiRequestBuilder<DefaultApi, 'createEntity'>(
     DefaultApi,
     'createEntity',
     testEntity
   ),
-  getEntityByKey: (entityId: string) => new OpenApiRequestBuilder<DefaultApi, 'getEntityByKey'>(
+  getEntityByKey: (args: {
+      entityId: string
+    }) => new OpenApiRequestBuilder<DefaultApi, 'getEntityByKey'>(
     DefaultApi,
     'getEntityByKey',
     entityId
@@ -28,7 +35,14 @@ export const TestServiceApi = {
     DefaultApi,
     'countEntities'
   ),
-  testCaseGetRequiredParameters: (requiredPathItemPathParam: string, simpleTestEntity?: SimpleTestEntity, requiredPathItemQueryParam: string, requiredQueryParam: string, optionalQueryParam?: string, optionalPathItemQueryParam?: string) => new OpenApiRequestBuilder<DefaultApi, 'testCaseGetRequiredParameters'>(
+  testCaseGetRequiredParameters: (args: {
+      requiredPathItemQueryParam: string,
+      requiredPathItemPathParam: string,
+      requiredQueryParam: string,
+      optionalQueryParam?: string,
+      optionalPathItemQueryParam?: string,
+      simpleTestEntity?: SimpleTestEntity
+    }) => new OpenApiRequestBuilder<DefaultApi, 'testCaseGetRequiredParameters'>(
     DefaultApi,
     'testCaseGetRequiredParameters',
     requiredPathItemQueryParam,
@@ -38,7 +52,14 @@ export const TestServiceApi = {
     optionalPathItemQueryParam,
     simpleTestEntity
   ),
-  testCasePostRequiredParameters: (requiredPathItemPathParam: string, simpleTestEntity: SimpleTestEntity, requiredPathItemQueryParam: string, requiredQueryParam: string, optionalPathItemQueryParam?: string, optionalQueryParam?: string) => new OpenApiRequestBuilder<DefaultApi, 'testCasePostRequiredParameters'>(
+  testCasePostRequiredParameters: (args: {
+      requiredPathItemQueryParam: string,
+      requiredPathItemPathParam: string,
+      requiredQueryParam: string,
+      simpleTestEntity: SimpleTestEntity,
+      optionalPathItemQueryParam?: string,
+      optionalQueryParam?: string
+    }) => new OpenApiRequestBuilder<DefaultApi, 'testCasePostRequiredParameters'>(
     DefaultApi,
     'testCasePostRequiredParameters',
     requiredPathItemQueryParam,

--- a/test-packages/test-services/openapi/test-service/api.ts
+++ b/test-packages/test-services/openapi/test-service/api.ts
@@ -28,7 +28,7 @@ export const TestServiceApi = {
     DefaultApi,
     'countEntities'
   ),
-  testCaseGetRequiredParameters: (requiredPathItemQueryParam: string, requiredPathItemPathParam: string, requiredQueryParam: string, optionalQueryParam?: string, optionalPathItemQueryParam?: string, simpleTestEntity?: SimpleTestEntity) => new OpenApiRequestBuilder<DefaultApi, 'testCaseGetRequiredParameters'>(
+  testCaseGetRequiredParameters: (requiredPathItemPathParam: string, simpleTestEntity?: SimpleTestEntity, requiredPathItemQueryParam: string, requiredQueryParam: string, optionalQueryParam?: string, optionalPathItemQueryParam?: string) => new OpenApiRequestBuilder<DefaultApi, 'testCaseGetRequiredParameters'>(
     DefaultApi,
     'testCaseGetRequiredParameters',
     requiredPathItemQueryParam,
@@ -38,7 +38,7 @@ export const TestServiceApi = {
     optionalPathItemQueryParam,
     simpleTestEntity
   ),
-  testCasePostRequiredParameters: (requiredPathItemQueryParam: string, requiredPathItemPathParam: string, requiredQueryParam: string, simpleTestEntity: SimpleTestEntity, optionalPathItemQueryParam?: string, optionalQueryParam?: string) => new OpenApiRequestBuilder<DefaultApi, 'testCasePostRequiredParameters'>(
+  testCasePostRequiredParameters: (requiredPathItemPathParam: string, simpleTestEntity: SimpleTestEntity, requiredPathItemQueryParam: string, requiredQueryParam: string, optionalPathItemQueryParam?: string, optionalQueryParam?: string) => new OpenApiRequestBuilder<DefaultApi, 'testCasePostRequiredParameters'>(
     DefaultApi,
     'testCasePostRequiredParameters',
     requiredPathItemQueryParam,

--- a/test-packages/test-services/openapi/test-service/api.ts
+++ b/test-packages/test-services/openapi/test-service/api.ts
@@ -5,7 +5,7 @@
  */
 import { OpenApiRequestBuilder } from '@sap-cloud-sdk/core';
 import { DefaultApi } from './openapi/api';
-import { TestEntity } from './openapi/model';
+import { TestEntity, SimpleTestEntity } from './openapi/model';
 
 export const TestServiceApi = {
   getAllEntities: (stringParameter?: string, integerParameter?: number) => new OpenApiRequestBuilder<DefaultApi, 'getAllEntities'>(
@@ -27,5 +27,25 @@ export const TestServiceApi = {
   countEntities: () => new OpenApiRequestBuilder<DefaultApi, 'countEntities'>(
     DefaultApi,
     'countEntities'
+  ),
+  testCaseGetRequiredParameters: (requiredPathItemQueryParam: string, requiredPathItemPathParam: string, requiredQueryParam: string, optionalQueryParam?: string, optionalPathItemQueryParam?: string, simpleTestEntity?: SimpleTestEntity) => new OpenApiRequestBuilder<DefaultApi, 'testCaseGetRequiredParameters'>(
+    DefaultApi,
+    'testCaseGetRequiredParameters',
+    requiredPathItemQueryParam,
+    requiredPathItemPathParam,
+    requiredQueryParam,
+    optionalQueryParam,
+    optionalPathItemQueryParam,
+    simpleTestEntity
+  ),
+  testCasePostRequiredParameters: (requiredPathItemQueryParam: string, requiredPathItemPathParam: string, requiredQueryParam: string, simpleTestEntity: SimpleTestEntity, optionalPathItemQueryParam?: string, optionalQueryParam?: string) => new OpenApiRequestBuilder<DefaultApi, 'testCasePostRequiredParameters'>(
+    DefaultApi,
+    'testCasePostRequiredParameters',
+    requiredPathItemQueryParam,
+    requiredPathItemPathParam,
+    requiredQueryParam,
+    simpleTestEntity,
+    optionalPathItemQueryParam,
+    optionalQueryParam
   )
 };

--- a/test-packages/test-services/openapi/test-service/open-api.json
+++ b/test-packages/test-services/openapi/test-service/open-api.json
@@ -129,7 +129,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/TestEntity"
                   }
@@ -162,6 +161,120 @@
           },
           "400": {
             "description": "bad input parameter"
+          }
+        },
+        "tags": [
+          "default"
+        ]
+      }
+    },
+    "/test-cases/parameters/required-parameters/{requiredPathItemPathParam}": {
+      "parameters": [
+        {
+          "name": "optionalPathItemQueryParam",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "requiredPathItemQueryParam",
+          "in": "query",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "requiredPathItemPathParam",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "testCaseGetRequiredParameters",
+        "parameters": [
+          {
+            "name": "optionalQueryParam",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requiredQueryParam",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "optionalPathItemQueryParam",
+            "description": "Overrides original path item query parameter.",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SimpleTestEntity"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        },
+        "tags": [
+          "default"
+        ]
+      },
+      "post": {
+        "operationId": "testCasePostRequiredParameters",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SimpleTestEntity"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "optionalQueryParam",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requiredQueryParam",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "no content"
           }
         },
         "tags": [

--- a/test-packages/test-services/openapi/test-service/open-api.json
+++ b/test-packages/test-services/openapi/test-service/open-api.json
@@ -281,6 +281,37 @@
           "default"
         ]
       }
+    },
+    "/test-cases/parameters/{duplicateParam}": {
+      "get": {
+        "operationId": "testCaseGetDuplicateParameters",
+        "parameters": [
+          {
+            "name": "duplicateParam",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "duplicateParam",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        },
+        "tags": [
+          "default"
+        ]
+      }
     }
   },
   "components": {

--- a/test-packages/test-services/openapi/test-service/openapi/api/default-api.ts
+++ b/test-packages/test-services/openapi/test-service/openapi/api/default-api.ts
@@ -19,6 +19,8 @@ import { Configuration } from '../configuration';
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from '../base';
 // @ts-ignore
+import { SimpleTestEntity } from '../model';
+// @ts-ignore
 import { TestEntity } from '../model';
 /**
  * DefaultApi - axios parameter creator
@@ -191,6 +193,158 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * 
+         * @param {string} requiredPathItemQueryParam 
+         * @param {string} requiredPathItemPathParam 
+         * @param {string} requiredQueryParam 
+         * @param {string} [optionalQueryParam] 
+         * @param {string} [optionalPathItemQueryParam] Overrides original path item query parameter.
+         * @param {SimpleTestEntity} [simpleTestEntity] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        testCaseGetRequiredParameters: async (requiredPathItemQueryParam: string, requiredPathItemPathParam: string, requiredQueryParam: string, optionalQueryParam?: string, optionalPathItemQueryParam?: string, simpleTestEntity?: SimpleTestEntity, options: any = {}): Promise<RequestArgs> => {
+            // verify required parameter 'requiredPathItemQueryParam' is not null or undefined
+            if (requiredPathItemQueryParam === null || requiredPathItemQueryParam === undefined) {
+                throw new RequiredError('requiredPathItemQueryParam','Required parameter requiredPathItemQueryParam was null or undefined when calling testCaseGetRequiredParameters.');
+            }
+            // verify required parameter 'requiredPathItemPathParam' is not null or undefined
+            if (requiredPathItemPathParam === null || requiredPathItemPathParam === undefined) {
+                throw new RequiredError('requiredPathItemPathParam','Required parameter requiredPathItemPathParam was null or undefined when calling testCaseGetRequiredParameters.');
+            }
+            // verify required parameter 'requiredQueryParam' is not null or undefined
+            if (requiredQueryParam === null || requiredQueryParam === undefined) {
+                throw new RequiredError('requiredQueryParam','Required parameter requiredQueryParam was null or undefined when calling testCaseGetRequiredParameters.');
+            }
+            const localVarPath = `/test-cases/parameters/required-parameters/{requiredPathItemPathParam}`
+                .replace(`{${"requiredPathItemPathParam"}}`, encodeURIComponent(String(requiredPathItemPathParam)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (requiredPathItemQueryParam !== undefined) {
+                localVarQueryParameter['requiredPathItemQueryParam'] = requiredPathItemQueryParam;
+            }
+
+            if (optionalQueryParam !== undefined) {
+                localVarQueryParameter['optionalQueryParam'] = optionalQueryParam;
+            }
+
+            if (requiredQueryParam !== undefined) {
+                localVarQueryParameter['requiredQueryParam'] = requiredQueryParam;
+            }
+
+            if (optionalPathItemQueryParam !== undefined) {
+                localVarQueryParameter['optionalPathItemQueryParam'] = optionalPathItemQueryParam;
+            }
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            const needsSerialization = (typeof simpleTestEntity !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.data =  needsSerialization ? JSON.stringify(simpleTestEntity !== undefined ? simpleTestEntity : {}) : (simpleTestEntity || "");
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {string} requiredPathItemQueryParam 
+         * @param {string} requiredPathItemPathParam 
+         * @param {string} requiredQueryParam 
+         * @param {SimpleTestEntity} simpleTestEntity 
+         * @param {string} [optionalPathItemQueryParam] 
+         * @param {string} [optionalQueryParam] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        testCasePostRequiredParameters: async (requiredPathItemQueryParam: string, requiredPathItemPathParam: string, requiredQueryParam: string, simpleTestEntity: SimpleTestEntity, optionalPathItemQueryParam?: string, optionalQueryParam?: string, options: any = {}): Promise<RequestArgs> => {
+            // verify required parameter 'requiredPathItemQueryParam' is not null or undefined
+            if (requiredPathItemQueryParam === null || requiredPathItemQueryParam === undefined) {
+                throw new RequiredError('requiredPathItemQueryParam','Required parameter requiredPathItemQueryParam was null or undefined when calling testCasePostRequiredParameters.');
+            }
+            // verify required parameter 'requiredPathItemPathParam' is not null or undefined
+            if (requiredPathItemPathParam === null || requiredPathItemPathParam === undefined) {
+                throw new RequiredError('requiredPathItemPathParam','Required parameter requiredPathItemPathParam was null or undefined when calling testCasePostRequiredParameters.');
+            }
+            // verify required parameter 'requiredQueryParam' is not null or undefined
+            if (requiredQueryParam === null || requiredQueryParam === undefined) {
+                throw new RequiredError('requiredQueryParam','Required parameter requiredQueryParam was null or undefined when calling testCasePostRequiredParameters.');
+            }
+            // verify required parameter 'simpleTestEntity' is not null or undefined
+            if (simpleTestEntity === null || simpleTestEntity === undefined) {
+                throw new RequiredError('simpleTestEntity','Required parameter simpleTestEntity was null or undefined when calling testCasePostRequiredParameters.');
+            }
+            const localVarPath = `/test-cases/parameters/required-parameters/{requiredPathItemPathParam}`
+                .replace(`{${"requiredPathItemPathParam"}}`, encodeURIComponent(String(requiredPathItemPathParam)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (optionalPathItemQueryParam !== undefined) {
+                localVarQueryParameter['optionalPathItemQueryParam'] = optionalPathItemQueryParam;
+            }
+
+            if (requiredPathItemQueryParam !== undefined) {
+                localVarQueryParameter['requiredPathItemQueryParam'] = requiredPathItemQueryParam;
+            }
+
+            if (optionalQueryParam !== undefined) {
+                localVarQueryParameter['optionalQueryParam'] = optionalQueryParam;
+            }
+
+            if (requiredQueryParam !== undefined) {
+                localVarQueryParameter['requiredQueryParam'] = requiredQueryParam;
+            }
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            const needsSerialization = (typeof simpleTestEntity !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.data =  needsSerialization ? JSON.stringify(simpleTestEntity !== undefined ? simpleTestEntity : {}) : (simpleTestEntity || "");
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -256,6 +410,42 @@ export const DefaultApiFp = function(configuration?: Configuration) {
                 return axios.request(axiosRequestArgs);
             };
         },
+        /**
+         * 
+         * @param {string} requiredPathItemQueryParam 
+         * @param {string} requiredPathItemPathParam 
+         * @param {string} requiredQueryParam 
+         * @param {string} [optionalQueryParam] 
+         * @param {string} [optionalPathItemQueryParam] Overrides original path item query parameter.
+         * @param {SimpleTestEntity} [simpleTestEntity] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async testCaseGetRequiredParameters(requiredPathItemQueryParam: string, requiredPathItemPathParam: string, requiredQueryParam: string, optionalQueryParam?: string, optionalPathItemQueryParam?: string, simpleTestEntity?: SimpleTestEntity, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).testCaseGetRequiredParameters(requiredPathItemQueryParam, requiredPathItemPathParam, requiredQueryParam, optionalQueryParam, optionalPathItemQueryParam, simpleTestEntity, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * 
+         * @param {string} requiredPathItemQueryParam 
+         * @param {string} requiredPathItemPathParam 
+         * @param {string} requiredQueryParam 
+         * @param {SimpleTestEntity} simpleTestEntity 
+         * @param {string} [optionalPathItemQueryParam] 
+         * @param {string} [optionalQueryParam] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async testCasePostRequiredParameters(requiredPathItemQueryParam: string, requiredPathItemPathParam: string, requiredQueryParam: string, simpleTestEntity: SimpleTestEntity, optionalPathItemQueryParam?: string, optionalQueryParam?: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).testCasePostRequiredParameters(requiredPathItemQueryParam, requiredPathItemPathParam, requiredQueryParam, simpleTestEntity, optionalPathItemQueryParam, optionalQueryParam, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
+                return axios.request(axiosRequestArgs);
+            };
+        },
     }
 };
 
@@ -304,6 +494,34 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         getEntityByKey(entityId: string, options?: any): AxiosPromise<Array<TestEntity>> {
             return DefaultApiFp(configuration).getEntityByKey(entityId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {string} requiredPathItemQueryParam 
+         * @param {string} requiredPathItemPathParam 
+         * @param {string} requiredQueryParam 
+         * @param {string} [optionalQueryParam] 
+         * @param {string} [optionalPathItemQueryParam] Overrides original path item query parameter.
+         * @param {SimpleTestEntity} [simpleTestEntity] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        testCaseGetRequiredParameters(requiredPathItemQueryParam: string, requiredPathItemPathParam: string, requiredQueryParam: string, optionalQueryParam?: string, optionalPathItemQueryParam?: string, simpleTestEntity?: SimpleTestEntity, options?: any): AxiosPromise<void> {
+            return DefaultApiFp(configuration).testCaseGetRequiredParameters(requiredPathItemQueryParam, requiredPathItemPathParam, requiredQueryParam, optionalQueryParam, optionalPathItemQueryParam, simpleTestEntity, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {string} requiredPathItemQueryParam 
+         * @param {string} requiredPathItemPathParam 
+         * @param {string} requiredQueryParam 
+         * @param {SimpleTestEntity} simpleTestEntity 
+         * @param {string} [optionalPathItemQueryParam] 
+         * @param {string} [optionalQueryParam] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        testCasePostRequiredParameters(requiredPathItemQueryParam: string, requiredPathItemPathParam: string, requiredQueryParam: string, simpleTestEntity: SimpleTestEntity, optionalPathItemQueryParam?: string, optionalQueryParam?: string, options?: any): AxiosPromise<void> {
+            return DefaultApiFp(configuration).testCasePostRequiredParameters(requiredPathItemQueryParam, requiredPathItemPathParam, requiredQueryParam, simpleTestEntity, optionalPathItemQueryParam, optionalQueryParam, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -361,5 +579,37 @@ export class DefaultApi extends BaseAPI {
      */
     public getEntityByKey(entityId: string, options?: any) {
         return DefaultApiFp(this.configuration).getEntityByKey(entityId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {string} requiredPathItemQueryParam 
+     * @param {string} requiredPathItemPathParam 
+     * @param {string} requiredQueryParam 
+     * @param {string} [optionalQueryParam] 
+     * @param {string} [optionalPathItemQueryParam] Overrides original path item query parameter.
+     * @param {SimpleTestEntity} [simpleTestEntity] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public testCaseGetRequiredParameters(requiredPathItemQueryParam: string, requiredPathItemPathParam: string, requiredQueryParam: string, optionalQueryParam?: string, optionalPathItemQueryParam?: string, simpleTestEntity?: SimpleTestEntity, options?: any) {
+        return DefaultApiFp(this.configuration).testCaseGetRequiredParameters(requiredPathItemQueryParam, requiredPathItemPathParam, requiredQueryParam, optionalQueryParam, optionalPathItemQueryParam, simpleTestEntity, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {string} requiredPathItemQueryParam 
+     * @param {string} requiredPathItemPathParam 
+     * @param {string} requiredQueryParam 
+     * @param {SimpleTestEntity} simpleTestEntity 
+     * @param {string} [optionalPathItemQueryParam] 
+     * @param {string} [optionalQueryParam] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public testCasePostRequiredParameters(requiredPathItemQueryParam: string, requiredPathItemPathParam: string, requiredQueryParam: string, simpleTestEntity: SimpleTestEntity, optionalPathItemQueryParam?: string, optionalQueryParam?: string, options?: any) {
+        return DefaultApiFp(this.configuration).testCasePostRequiredParameters(requiredPathItemQueryParam, requiredPathItemPathParam, requiredQueryParam, simpleTestEntity, optionalPathItemQueryParam, optionalQueryParam, options).then((request) => request(this.axios, this.basePath));
     }
 }

--- a/test-packages/test-services/openapi/test-service/openapi/api/default-api.ts
+++ b/test-packages/test-services/openapi/test-service/openapi/api/default-api.ts
@@ -195,6 +195,56 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
+         * @param {string} duplicateParam 
+         * @param {string} duplicateParam2 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        testCaseGetDuplicateParameters: async (duplicateParam: string, duplicateParam2: string, options: any = {}): Promise<RequestArgs> => {
+            // verify required parameter 'duplicateParam' is not null or undefined
+            if (duplicateParam === null || duplicateParam === undefined) {
+                throw new RequiredError('duplicateParam','Required parameter duplicateParam was null or undefined when calling testCaseGetDuplicateParameters.');
+            }
+            // verify required parameter 'duplicateParam2' is not null or undefined
+            if (duplicateParam2 === null || duplicateParam2 === undefined) {
+                throw new RequiredError('duplicateParam2','Required parameter duplicateParam2 was null or undefined when calling testCaseGetDuplicateParameters.');
+            }
+            const localVarPath = `/test-cases/parameters/{duplicateParam}`
+                .replace(`{${"duplicateParam"}}`, encodeURIComponent(String(duplicateParam2)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (duplicateParam !== undefined) {
+                localVarQueryParameter['duplicateParam'] = duplicateParam;
+            }
+
+
+    
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {string} requiredPathItemQueryParam 
          * @param {string} requiredPathItemPathParam 
          * @param {string} requiredQueryParam 
@@ -412,6 +462,20 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {string} duplicateParam 
+         * @param {string} duplicateParam2 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async testCaseGetDuplicateParameters(duplicateParam: string, duplicateParam2: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).testCaseGetDuplicateParameters(duplicateParam, duplicateParam2, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * 
          * @param {string} requiredPathItemQueryParam 
          * @param {string} requiredPathItemPathParam 
          * @param {string} requiredQueryParam 
@@ -497,6 +561,16 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
+         * @param {string} duplicateParam 
+         * @param {string} duplicateParam2 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        testCaseGetDuplicateParameters(duplicateParam: string, duplicateParam2: string, options?: any): AxiosPromise<void> {
+            return DefaultApiFp(configuration).testCaseGetDuplicateParameters(duplicateParam, duplicateParam2, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @param {string} requiredPathItemQueryParam 
          * @param {string} requiredPathItemPathParam 
          * @param {string} requiredQueryParam 
@@ -579,6 +653,18 @@ export class DefaultApi extends BaseAPI {
      */
     public getEntityByKey(entityId: string, options?: any) {
         return DefaultApiFp(this.configuration).getEntityByKey(entityId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {string} duplicateParam 
+     * @param {string} duplicateParam2 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public testCaseGetDuplicateParameters(duplicateParam: string, duplicateParam2: string, options?: any) {
+        return DefaultApiFp(this.configuration).testCaseGetDuplicateParameters(duplicateParam, duplicateParam2, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/test-resources/openapi-service-specs/test-service.json
+++ b/test-resources/openapi-service-specs/test-service.json
@@ -273,6 +273,34 @@
           }
         }
       }
+    },
+    "/test-cases/parameters/{duplicateParam}": {
+      "get": {
+        "operationId": "testCaseGetDuplicateParameters",
+        "parameters": [
+          {
+            "name": "duplicateParam",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "duplicateParam",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/test-resources/openapi-service-specs/test-service.json
+++ b/test-resources/openapi-service-specs/test-service.json
@@ -130,7 +130,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/TestEntity"
                   }
@@ -163,6 +162,114 @@
           },
           "400": {
             "description": "bad input parameter"
+          }
+        }
+      }
+    },
+    "/test-cases/parameters/required-parameters/{requiredPathItemPathParam}": {
+      "parameters": [
+        {
+          "name": "optionalPathItemQueryParam",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "requiredPathItemQueryParam",
+          "in": "query",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "requiredPathItemPathParam",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "testCaseGetRequiredParameters",
+        "parameters": [
+          {
+            "name": "optionalQueryParam",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requiredQueryParam",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "optionalPathItemQueryParam",
+            "description": "Overrides original path item query parameter.",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SimpleTestEntity"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        }
+      },
+      "post": {
+        "operationId": "testCasePostRequiredParameters",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SimpleTestEntity"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "optionalQueryParam",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requiredQueryParam",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "no content"
           }
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,14 +2156,6 @@
     "@typescript-eslint/typescript-estree" "4.9.1"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.9.0.tgz#5eefe305d6b71d1c85af6587b048426bfd4d3708"
-  integrity sha512-q/81jtmcDtMRE+nfFt5pWqO0R41k46gpVLnuefqVOXl4QV1GdQoBWfk5REcipoJNQH9+F5l+dwa9Li5fbALjzg==
-  dependencies:
-    "@typescript-eslint/types" "4.9.0"
-    "@typescript-eslint/visitor-keys" "4.9.0"
-
 "@typescript-eslint/scope-manager@4.9.1":
   version "4.9.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.9.1.tgz#cc2fde310b3f3deafe8436a924e784eaab265103"
@@ -2172,29 +2164,10 @@
     "@typescript-eslint/types" "4.9.1"
     "@typescript-eslint/visitor-keys" "4.9.1"
 
-"@typescript-eslint/types@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.0.tgz#3fe8c3632abd07095c7458f7451bd14c85d0033c"
-  integrity sha512-luzLKmowfiM/IoJL/rus1K9iZpSJK6GlOS/1ezKplb7MkORt2dDcfi8g9B0bsF6JoRGhqn0D3Va55b+vredFHA==
-
 "@typescript-eslint/types@4.9.1":
   version "4.9.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.9.1.tgz#a1a7dd80e4e5ac2c593bc458d75dd1edaf77faa2"
   integrity sha512-fjkT+tXR13ks6Le7JiEdagnwEFc49IkOyys7ueWQ4O8k4quKPwPJudrwlVOJCUQhXo45PrfIvIarcrEjFTNwUA==
-
-"@typescript-eslint/typescript-estree@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.9.0.tgz#38a98df6ee281cfd6164d6f9d91795b37d9e508c"
-  integrity sha512-rmDR++PGrIyQzAtt3pPcmKWLr7MA+u/Cmq9b/rON3//t5WofNR4m/Ybft2vOLj0WtUzjn018ekHjTsnIyBsQug==
-  dependencies:
-    "@typescript-eslint/types" "4.9.0"
-    "@typescript-eslint/visitor-keys" "4.9.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.9.1":
   version "4.9.1"
@@ -2222,14 +2195,6 @@
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.9.0.tgz#f284e9fac43f2d6d35094ce137473ee321f266c8"
-  integrity sha512-sV45zfdRqQo1A97pOSx3fsjR+3blmwtdCt8LDrXgCX36v4Vmz4KHrhpV6Fo2cRdXmyumxx11AHw0pNJqCNpDyg==
-  dependencies:
-    "@typescript-eslint/types" "4.9.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.9.1":
   version "4.9.1"


### PR DESCRIPTION
Fixes the order of parameters. The parameters in the default api are - required params, optional params, depending on order in the spec file. The order in our api is - required path params, required body, required query params, optional path params, optional query params.

After I had already implemented that, I had an insightful conversation with @jjtang1985: We should probably have a parameter object instead of multiple parameters, because if this gets bigger the API gets quite ugly. That way the order wouldn't matter, we would have to only keep it to call the default api.

@FrankEssenberger @florian-richter - I left the reordering for now, but I will be happy to still improve this on this PR.