### PR TITLE
chore: adjust the repo and homepage url

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cloud-sdk",
     "sap-cloud-platform"
   ],
-  "repository": "github:SAP/cloud-sdk",
+  "repository": "github:SAP/cloud-sdk-js",
   "workspaces": [
     "packages/analytics",
     "packages/core",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -21,7 +21,7 @@
     "dist/**/*.d.ts",
     "dist/**/*.d.ts.map"
   ],
-  "repository": "github:SAP/cloud-sdk",
+  "repository": "github:SAP/cloud-sdk-js",
   "scripts": {
     "compile": "yarn tsc -b",
     "prepare": "yarn compile",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -2,7 +2,7 @@
   "name": "@sap-cloud-sdk/analytics",
   "version": "1.32.1",
   "description": "SAP Cloud SDK Analytics Usage",
-  "homepage": "https://community.sap.com/topics/cloud-sdk",
+  "homepage": "https://sap.github.io/cloud-sdk/docs/js/overview-cloud-sdk-for-javascript",
   "license": "Apache-2.0",
   "keywords": [
     "sap-cloud-sdk",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@sap-cloud-sdk/core",
   "version": "1.32.1",
   "description": "SAP Cloud SDK for JavaScript core",
-  "homepage": "https://community.sap.com/topics/cloud-sdk",
+  "homepage": "https://sap.github.io/cloud-sdk/docs/js/overview-cloud-sdk-for-javascript",
   "license": "Apache-2.0",
   "keywords": [
     "sap-cloud-sdk",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "dist/**/*.d.ts.map",
     "usage-analytics.js"
   ],
-  "repository": "github:SAP/cloud-sdk",
+  "repository": "github:SAP/cloud-sdk-js",
   "scripts": {
     "compile": "yarn tsc -b",
     "prepare": "yarn compile",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -24,7 +24,7 @@
     "dist/**/*.d.ts",
     "dist/**/*.d.ts.map"
   ],
-  "repository": "github:SAP/cloud-sdk",
+  "repository": "github:SAP/cloud-sdk-js",
   "scripts": {
     "compile": "yarn tsc -b",
     "prepare": "yarn compile",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -2,7 +2,7 @@
   "name": "@sap-cloud-sdk/generator",
   "version": "1.32.1",
   "description": "SAP Cloud SDK for JavaScript OData client generator",
-  "homepage": "https://community.sap.com/topics/cloud-sdk",
+  "homepage": "https://sap.github.io/cloud-sdk/docs/js/overview-cloud-sdk-for-javascript",
   "license": "Apache-2.0",
   "keywords": [
     "sap-cloud-sdk",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -11,7 +11,7 @@
     "generator"
   ],
   "private": true,
-  "repository": "github:SAP/cloud-sdk",
+  "repository": "github:SAP/cloud-sdk-js",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -2,7 +2,7 @@
   "name": "@sap-cloud-sdk/openapi-generator",
   "version": "1.32.1",
   "description": "SAP Cloud SDK for JavaScript OpenApi client generator",
-  "homepage": "https://www.sap.com/cloud-sdk",
+  "homepage": "https://sap.github.io/cloud-sdk/docs/js/overview-cloud-sdk-for-javascript",
   "license": "Apache-2.0",
   "keywords": [
     "sap-cloud-sdk",

--- a/packages/test-util/package.json
+++ b/packages/test-util/package.json
@@ -21,7 +21,7 @@
     "dist/**/*.d.ts",
     "dist/**/*.d.ts.map"
   ],
-  "repository": "github:SAP/cloud-sdk",
+  "repository": "github:SAP/cloud-sdk-js",
   "scripts": {
     "compile": "yarn tsc -b",
     "prepare": "yarn compile",

--- a/packages/test-util/package.json
+++ b/packages/test-util/package.json
@@ -2,7 +2,7 @@
   "name": "@sap-cloud-sdk/test-util",
   "version": "1.32.1",
   "description": "SAP Cloud SDK for JavaScript test utilities",
-  "homepage": "https://community.sap.com/topics/cloud-sdk",
+  "homepage": "https://sap.github.io/cloud-sdk/docs/js/overview-cloud-sdk-for-javascript",
   "license": "Apache-2.0",
   "keywords": [
     "sap-cloud-sdk",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -21,7 +21,7 @@
     "dist/**/*.d.ts",
     "dist/**/*.d.ts.map"
   ],
-  "repository": "github:SAP/cloud-sdk",
+  "repository": "github:SAP/cloud-sdk-js",
   "scripts": {
     "compile": "yarn tsc -b",
     "prepare": "yarn compile",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -2,7 +2,7 @@
   "name": "@sap-cloud-sdk/util",
   "version": "1.32.1",
   "description": "SAP Cloud SDK for JavaScript general utilities",
-  "homepage": "https://community.sap.com/topics/cloud-sdk",
+  "homepage": "https://sap.github.io/cloud-sdk/docs/js/overview-cloud-sdk-for-javascript",
   "license": "Apache-2.0",
   "keywords": [
     "sap-cloud-sdk",

--- a/test-packages/e2e-tests/package.json
+++ b/test-packages/e2e-tests/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://www.sap.com/cloud-sdk",
   "license": "Apache-2.0",
   "private": true,
-  "repository": "github:SAP/cloud-sdk",
+  "repository": "github:SAP/cloud-sdk-js",
   "scripts": {
     "pretest": "yarn deploy && yarn start",
     "posttest": "yarn stop",

--- a/test-packages/e2e-tests/package.json
+++ b/test-packages/e2e-tests/package.json
@@ -2,7 +2,7 @@
   "name": "@sap-cloud-sdk/e2e-tests",
   "version": "1.32.1",
   "description": "End to end tests of the SAP Cloud SDK for JavaScript",
-  "homepage": "https://www.sap.com/cloud-sdk",
+  "homepage": "https://sap.github.io/cloud-sdk/docs/js/overview-cloud-sdk-for-javascript",
   "license": "Apache-2.0",
   "private": true,
   "repository": "github:SAP/cloud-sdk-js",

--- a/test-packages/integration-tests/package.json
+++ b/test-packages/integration-tests/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://www.sap.com/cloud-sdk",
   "license": "Apache-2.0",
   "private": true,
-  "repository": "github:SAP/cloud-sdk",
+  "repository": "github:SAP/cloud-sdk-js",
   "scripts": {
     "test": "yarn jest --coverage ",
     "test:local": "yarn jest",

--- a/test-packages/integration-tests/package.json
+++ b/test-packages/integration-tests/package.json
@@ -2,7 +2,7 @@
   "name": "@sap-cloud-sdk/integration-tests",
   "version": "1.32.1",
   "description": "SAP Cloud SDK for JavaScript integration tests",
-  "homepage": "https://www.sap.com/cloud-sdk",
+  "homepage": "https://sap.github.io/cloud-sdk/docs/js/overview-cloud-sdk-for-javascript",
   "license": "Apache-2.0",
   "private": true,
   "repository": "github:SAP/cloud-sdk-js",

--- a/test-packages/type-tests/package.json
+++ b/test-packages/type-tests/package.json
@@ -2,7 +2,7 @@
   "name": "@sap-cloud-sdk/type-tests",
   "version": "1.32.1",
   "description": "Tests to ensure correct types in the SAP Cloud SDK for JavaScript.",
-  "homepage": "https://www.sap.com/cloud-sdk",
+  "homepage": "https://sap.github.io/cloud-sdk/docs/js/overview-cloud-sdk-for-javascript",
   "license": "Apache-2.0",
   "private": true,
   "types": "types",

--- a/test-packages/type-tests/package.json
+++ b/test-packages/type-tests/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "private": true,
   "types": "types",
-  "repository": "github:SAP/cloud-sdk",
+  "repository": "github:SAP/cloud-sdk-js",
   "scripts": {
     "test": "yarn dtslint --expectOnly --localTs ../../node_modules/typescript/lib test",
     "check:dependencies": "echo Nothing to check here."


### PR DESCRIPTION
In the `package.json` the `repository` was still pointing to the `cloud-sdk` repo which is now the doc repo. And the `homepage` used the community url which I thought is also not that informative than our github pages.