### PR TITLE
chore: Remove openapi tools json

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "5.0.0-beta2"
-  }
-}

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -116,7 +116,9 @@ async function generateOpenApiService(
   logger.debug(`OpenAPI generator CLI arguments: ${generationArguments}`);
 
   try {
-    const response = await execa('npx', generationArguments);
+    const response = await execa('npx', generationArguments, {
+      cwd: resolve(__dirname, '..')
+    });
     if (response.stderr) {
       throw new Error(response.stderr);
     }


### PR DESCRIPTION
Locks the cwd of the execution of the java openapi generator to the generator directory. Prevents creation of a new openapi-tools.json and thereby ensures usage of the version we specified.