### PR TITLE
fix: typedoc config

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -10,7 +10,8 @@
     "**/node_modules/**/*",
     "**/dist/**/*",
     "**/test/**/*",
-    "test-packages/**/*"
+    "test-packages/**/*",
+    "knowledge-base/**/*"
   ],
   "name": "SAP Cloud SDK for JavaScript / TypeScript",
   "readme": "DOCUMENTATION.md",


### PR DESCRIPTION
To fix the error below when triggering a new release:
```
Error: Command failed: npx typedoc .
No lerna package found for /../cloud-sdk-js/knowledge-base/adr/0017-code-snippets.ts
```
