### PR TITLE
chore: Add bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,29 @@
+name: bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump to be used. Can either be 'patch' or 'minor'.
+        required: false
+        default: 'patch'
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - run: yarn install --frozen-lockfile
+      - name: Setup git
+        run: |
+          git config --global user.email "cloud-sdk-js@github.com"
+          git config --global user.name "cloud-sdk-js"
+      - name: Bump minor version
+        if: github.event.inputs.bump == 'minor'
+        run: yarn lerna version minor --force-publish -y
+      - name: Bump patch version
+        if: github.event.inputs.bump == 'patch'
+        run: yarn lerna version patch --force-publish -y

--- a/knowledge-base/how-tos/release.md
+++ b/knowledge-base/how-tos/release.md
@@ -3,27 +3,32 @@ All SAP Cloud SDK modules will be published with the same version regardless whe
 
 ## Preparations for a Release
 
-Sometimes external libraries introduce breaking changing in minor version options.
-In order to ensure that the SDK works with the current versions of external libraries run `yarn install` to update the `yarn.lock`.
-If changes are there commit them to the main branch before releasing.
+Ensure that the changelog is up to date and correct.
+Move up high priority changes, so that they are easier to spot.
+
+## How to bump a version
+The release process can only be triggered by owners of the repository.
+If you are not in the owner list you will not be able to proceed.
+
+Releases are triggered by bumping the version using `lerna`.
+We have a github [workflow](https://github.com/sap/cloud-sdk-js/actions?query=workflow%3Abump) to do this.
+To trigger it, press "Run workflow" and enter "patch" or "minor" depending which version increase you want to have.
+This will create a version tag (e. g. `v1.18.0`), which in turn triggers the build workflow.
+If the build is successful a Github release will be drafted.
+The name of the release will be the name of the tag.
 
 ## How to trigger a release
-The release process can only be triggered by owners of the repository.
-If you are not in the owner list you will receive errors that the main branch is protected.
-
-It is triggered by bumping the version using `lerna`. For convenience we added two scripts for patch and minor version bumps (`bump:patch` and `bump:minor`).
-Running one of those commands will increase the version and commit this change to the main branch. It will also create a version tag (e. g. `v1.18.0`), which in turn triggers a build to run.
-If this run is successful a Github release will be drafted. The name of the release will be the name of the tag.
-
 The information from the CHANGELOG.md is automatically copied as description for the draft.
-If you are not happy with this, adjust the release notes on this tag.
+If you are not happy with this, adjust the release notes on this tag, but keep in mind to also update the CHANGELOG.md.
 ![Adjust release notes](../img/adjust-notes.png)
 
- When you decide that you are ready for releasing, publish the release by pressing the green button.
+ Once all checks have passed, you can publish the release by pressing the green "Publish" button.
  This will trigger the release pipeline, that publishes all modules to npm.
 
  As a last follow-up task you can adjust the value for the release date in the CHANGELOG.md and if you already have the link to the blog post as well.
 
 ### What to do when the build fails
-You should only trigger a release, when the last build on the main branch succeeded. If the pipeline still fails for some reason, remove the tag locally and on Github, before fixing the issue.
-Once the issue is fixed, you will have to create a tag manually. Creating the tag should trigger the process as described above.
+You should only trigger a release, when the last build on the main branch succeeded.
+If the pipeline still fails for some reason, remove the tag on Github (and locally if you pulled it), before fixing the issue.
+Once the issue is fixed, you will have to create a tag manually.
+Creating the tag should trigger the process as described above.

--- a/package.json
+++ b/package.json
@@ -48,8 +48,6 @@
     "check:license": "node scripts/check-licenses.js",
     "check:vulnerability": "yarn audit-ci -h",
     "check:test-service": "yarn generate:test-services && yarn ts-node scripts/check-test-service-for-changes.ts",
-    "bump:patch": "yarn lerna version patch --force-publish -y",
-    "bump:minor": "yarn lerna version minor --force-publish -y",
     "analytics": "yarn workspace @sap-cloud-sdk/analytics",
     "core": "yarn workspace @sap-cloud-sdk/core",
     "generator": "yarn workspace @sap-cloud-sdk/generator",


### PR DESCRIPTION
There were multiple occurrences where we published files that we had lying around locally because the release was triggered manually from our workspaces. In order to never run into those issues again, I created this script. I tested it on a different repository.