### PR TITLE
chore: check api doc generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,9 @@ jobs:
       - run: yarn check:test-service
         name: Test Service Version Check
       - run: yarn check:dependencies
-        name: Undeclared dependency check
+        name: Undeclared dependency Check
+      - run: yarn doc
+        name: API Doc Check
       - run: yarn check:vulnerability
         name: Dependency Vulnerability Check
       - run: yarn check:license


### PR DESCRIPTION
Add a new check for the api doc generation so we detect potential issues before merging to master.