### PR TITLE
fix: openapi cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- [openapi-generator] Fix the error `TypeError: Class constructor Command cannot be invoked without 'new'` due to the incompatibility of ES5 and oclif.
 
 
 # 1.36.0

--- a/packages/openapi-generator/tsconfig.json
+++ b/packages/openapi-generator/tsconfig.json
@@ -4,7 +4,8 @@
     "rootDir": "./src",
     "outDir": "./dist",
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
-    "composite": true
+    "composite": true,
+    "target": "es2017"
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
The openapi cli fails with the error ``TypeError: Class constructor Command cannot be invoked without 'new'``, due to the incompatibility of ES5 and oclif (ES2017).

The internal generator e2e tests are added.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
