### PR TITLE
fix: Allow duplicate and no operationIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,12 @@
 
 ## Improvements
 
--
+- [openapi-generator] Fix generation for duplicate operation names.
 
 ## Fixed Issues
 
 - [openapi-generator] Remove the copyright comments from the generated package.json.
-
+- [util] Don't fail on undefined template arguments when using `codeBlock`.
 
 # 1.36.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## Improvements
 
-- [openapi-generator] Fix generation for duplicate operation names.
+- [openapi-generator] Improve generation for duplicate operation names and non existing `operationId`s.
 
 ## Fixed Issues
 

--- a/packages/openapi-generator/src/document-converter.spec.ts
+++ b/packages/openapi-generator/src/document-converter.spec.ts
@@ -1,8 +1,10 @@
 import { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import { emptyApiDefinition } from '../test/test-util';
 import {
+  convertDocToUniqueOperationIds,
   convertDocToGlobalTag,
   convertDocToOpenApiV3,
+  getOperationNameFromPatternAndMethod,
   parseFileAsJson
 } from './document-converter';
 
@@ -217,5 +219,118 @@ describe('parseFileAsJson', () => {
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       '"Could not parse OpenAPI specification at /path/other-extension.test. Only JSON and YAML files are allowed."'
     );
+  });
+});
+
+describe('convertDocToUniqueOperationIds', () => {
+  it('replaces duplicate names, while prioritizing original names', () => {
+    const newSpec = convertDocToUniqueOperationIds({
+      ...emptyApiDefinition,
+      paths: {
+        '/pattern1': {
+          get: {
+            operationId: 'getX'
+          },
+          post: {
+            operationId: 'getX'
+          }
+        },
+        '/pattern2': {
+          get: {
+            operationId: 'getX_1'
+          }
+        }
+      }
+    });
+
+    expect(newSpec.paths).toEqual({
+      '/pattern1': {
+        get: {
+          operationId: 'getX'
+        },
+        post: {
+          operationId: 'getX_2'
+        }
+      },
+      '/pattern2': {
+        get: {
+          operationId: 'getX_1'
+        }
+      }
+    });
+  });
+
+  it('adds names when there is no operationId, while prioritizing original names', () => {
+    const newSpec = convertDocToUniqueOperationIds({
+      ...emptyApiDefinition,
+      paths: {
+        '/x': {
+          get: {},
+          post: {}
+        },
+        '/pattern2': {
+          get: {
+            operationId: 'getX'
+          },
+          post: {
+            operationId: 'createX'
+          }
+        }
+      }
+    });
+
+    expect(newSpec.paths).toEqual({
+      '/x': {
+        get: {
+          operationId: 'getX_1'
+        },
+        post: {
+          operationId: 'createX_1'
+        }
+      },
+      '/pattern2': {
+        get: {
+          operationId: 'getX'
+        },
+        post: {
+          operationId: 'createX'
+        }
+      }
+    });
+  });
+});
+
+describe('getOperationNameFromPatternAndMethod', () => {
+  it('parses the operation name from the pattern and method', () => {
+    expect(getOperationNameFromPatternAndMethod('/entity', 'get')).toEqual(
+      'getEntity'
+    );
+  });
+
+  it('parses the operation name from the pattern and method for post', () => {
+    expect(
+      getOperationNameFromPatternAndMethod('/entity/property', 'post')
+    ).toEqual('createEntityProperty');
+  });
+
+  it('parses the operation name from the pattern and method with one placeholder', () => {
+    expect(
+      getOperationNameFromPatternAndMethod('/entity/{entityId}/property', 'get')
+    ).toEqual('getEntityPropertyByEntityId');
+  });
+
+  it('parses the operation name from the pattern and method with multiple placeholders', () => {
+    expect(
+      getOperationNameFromPatternAndMethod(
+        '/entity/{entityId}/property/{propertyId}',
+        'get'
+      )
+    ).toEqual('getEntityPropertyByEntityIdAndPropertyId');
+  });
+
+  it('parses the operation name from the pattern and method with only placeholders', () => {
+    expect(
+      getOperationNameFromPatternAndMethod('/{placeholder}', 'get')
+    ).toEqual('getByPlaceholder');
   });
 });

--- a/packages/openapi-generator/src/document-converter.spec.ts
+++ b/packages/openapi-generator/src/document-converter.spec.ts
@@ -237,7 +237,7 @@ describe('convertDocToUniqueOperationIds', () => {
         },
         '/pattern2': {
           get: {
-            operationId: 'getX_1'
+            operationId: 'getX1'
           }
         }
       }
@@ -249,12 +249,12 @@ describe('convertDocToUniqueOperationIds', () => {
           operationId: 'getX'
         },
         post: {
-          operationId: 'getX_2'
+          operationId: 'getX2'
         }
       },
       '/pattern2': {
         get: {
-          operationId: 'getX_1'
+          operationId: 'getX1'
         }
       }
     });
@@ -282,10 +282,10 @@ describe('convertDocToUniqueOperationIds', () => {
     expect(newSpec.paths).toEqual({
       '/x': {
         get: {
-          operationId: 'getX_1'
+          operationId: 'getX1'
         },
         post: {
-          operationId: 'createX_1'
+          operationId: 'createX1'
         }
       },
       '/pattern2': {

--- a/packages/openapi-generator/src/openapi-types.ts
+++ b/packages/openapi-generator/src/openapi-types.ts
@@ -17,7 +17,7 @@ export interface OpenApiDocument {
  * Representation of an operation.
  */
 export interface OpenApiOperation extends OpenAPIV3.OperationObject {
-  operationName: string;
+  operationId: string;
   method: string;
   pattern: string;
   requestBody?: OpenApiRequestBody;

--- a/packages/openapi-generator/src/openapi-types.ts
+++ b/packages/openapi-generator/src/openapi-types.ts
@@ -31,7 +31,8 @@ const supportedMethods = {
   patch: 'patch',
   delete: 'delete',
   head: 'head',
-  options: 'options'
+  options: 'options',
+  trace: 'trace'
 } as const;
 
 /**
@@ -45,9 +46,7 @@ export type Method = typeof supportedMethods[keyof typeof supportedMethods];
  * Get supported methods.
  * @returns Methods supported by OpenApi and SAP Cloud SDK.
  */
-export function methods(): Method[] {
-  return Object.values(supportedMethods);
-}
+export const methods: Method[] = Object.values(supportedMethods);
 
 /**
  * @experimental This API is experimental and might change in newer versions. Use with caution.

--- a/packages/openapi-generator/src/parser/document.ts
+++ b/packages/openapi-generator/src/parser/document.ts
@@ -43,7 +43,7 @@ export function parseAllOperations(
   return Object.entries(document.paths).reduce(
     (allOperations, [pattern, pathDefinition]) => [
       ...allOperations,
-      ...methods()
+      ...methods
         .filter(method => pathDefinition?.[method])
         // Undefined path definitions have been filtered out in the line before
         .map(method => parseOperation(pattern, pathDefinition!, method, refs))

--- a/packages/openapi-generator/src/parser/operation.spec.ts
+++ b/packages/openapi-generator/src/parser/operation.spec.ts
@@ -1,47 +1,5 @@
 import { OpenAPIV3 } from 'openapi-types';
-import { parseOperationName, getOperation } from './operation';
-
-describe('parseOperationName', () => {
-  it('parses the operation name from the operationId', () => {
-    expect(
-      parseOperationName({ operationId: 'testOperationId' }, 'pattern', 'get')
-    ).toEqual('testOperationId');
-  });
-
-  it('parses the operation name from the description', () => {
-    expect(
-      parseOperationName({ description: 'Do something' }, 'pattern', 'get')
-    ).toEqual('doSomething');
-  });
-
-  it('parses the operation name from the pattern and method', () => {
-    expect(parseOperationName({}, '/entity', 'get')).toEqual('getEntity');
-  });
-
-  it('parses the operation name from the pattern and method for post', () => {
-    expect(parseOperationName({}, '/entity/property', 'post')).toEqual(
-      'createEntityProperty'
-    );
-  });
-
-  it('parses the operation name from the pattern and method with one placeholders', () => {
-    expect(
-      parseOperationName({}, '/entity/{entityId}/property', 'get')
-    ).toEqual('getEntityPropertyByEntityId');
-  });
-
-  it('parses the operation name from the pattern and method with multiple placeholders', () => {
-    expect(
-      parseOperationName({}, '/entity/{entityId}/property/{propertyId}', 'get')
-    ).toEqual('getEntityPropertyByEntityIdAndPropertyId');
-  });
-
-  it('parses the operation name from the pattern and method with only placeholders', () => {
-    expect(parseOperationName({}, '/{placeholder}', 'get')).toEqual(
-      'getByPlaceholder'
-    );
-  });
-});
+import { getOperation } from './operation';
 
 describe('getOperation', () => {
   const operationParam = { in: 'query', name: 'operationParam' };

--- a/packages/openapi-generator/src/parser/operation.ts
+++ b/packages/openapi-generator/src/parser/operation.ts
@@ -21,7 +21,7 @@ export function parseOperation(
     method,
     requestBody,
     parameters,
-    operationName: operation.operationId!
+    operationId: operation.operationId!
   };
 }
 

--- a/packages/openapi-generator/src/parser/operation.ts
+++ b/packages/openapi-generator/src/parser/operation.ts
@@ -1,6 +1,5 @@
 import { $Refs } from '@apidevtools/swagger-parser';
 import { OpenAPIV3 } from 'openapi-types';
-import { camelCase, partition, pascalCase } from '@sap-cloud-sdk/util';
 import { Method, OpenApiOperation } from '../openapi-types';
 import { parseRequestBody } from './request-body';
 import { parseParameters } from './parameters';
@@ -15,7 +14,6 @@ export function parseOperation(
   // TODO: What does the OpenApi generator do in this case?
   const requestBody = parseRequestBody(operation.requestBody, refs);
   const parameters = parseParameters(operation, refs);
-  const operationName = parseOperationName(operation, pattern, method);
 
   return {
     ...operation,
@@ -23,7 +21,7 @@ export function parseOperation(
     method,
     requestBody,
     parameters,
-    operationName
+    operationName: operation.operationId!
   };
 }
 
@@ -48,57 +46,4 @@ export function getOperation(
     ...(operation.parameters || [])
   ];
   return operation;
-}
-
-export function parseOperationName(
-  operation: OpenAPIV3.OperationObject,
-  pattern: string,
-  method: Method
-): string {
-  // TODO: this function does not check for uniqueness
-  return (
-    parseOperationNameFromOperation(operation) ||
-    parseOperationNameFromPatternAndMethod(pattern, method)
-  );
-}
-
-function parseOperationNameFromOperation(
-  operation: OpenAPIV3.OperationObject
-): string | undefined {
-  if (operation.operationId) {
-    return operation.operationId;
-  }
-  if (operation.description) {
-    return camelCase(operation.description);
-  }
-}
-
-function parseOperationNameFromPatternAndMethod(
-  pattern: string,
-  method: Method
-): string {
-  const [placeholders, pathParts] = partition(pattern.split('/'), part =>
-    /^\{.*\}$/.test(part)
-  );
-  const prefix = getSpeakingNameForMethod(method).toLowerCase();
-  const base = pathParts.map(part => pascalCase(part)).join('');
-  const suffix = placeholders.length
-    ? 'By' + placeholders.map(part => pascalCase(part)).join('And')
-    : '';
-
-  return prefix + base + suffix;
-}
-
-function getSpeakingNameForMethod(method: Method): string {
-  const nameMapping = {
-    get: 'get',
-    post: 'create',
-    patch: 'update',
-    put: 'update',
-    delete: 'delete',
-    head: 'getHeadersFor',
-    options: 'getOptionsFor'
-  };
-
-  return nameMapping[method];
 }

--- a/packages/openapi-generator/src/wrapper-files/api-file.spec.ts
+++ b/packages/openapi-generator/src/wrapper-files/api-file.spec.ts
@@ -13,7 +13,7 @@ describe('api-file', () => {
       apiName: 'TestApi',
       operations: [
         {
-          operationName: 'getFn',
+          operationId: 'getFn',
           method: 'get',
           parameters: [
             {
@@ -31,7 +31,7 @@ describe('api-file', () => {
           pattern: 'test/{id}'
         },
         {
-          operationName: 'deleteFn',
+          operationId: 'deleteFn',
           method: 'delete',
           parameters: [
             {
@@ -54,7 +54,7 @@ describe('api-file', () => {
       apiName: 'TestApi',
       operations: [
         {
-          operationName: 'createFn',
+          operationId: 'createFn',
           method: 'post',
           parameters: [],
           requestBody: {
@@ -69,7 +69,7 @@ describe('api-file', () => {
           pattern: 'test'
         },
         {
-          operationName: 'updateFn',
+          operationId: 'updateFn',
           method: 'patch',
           parameters: [
             {
@@ -102,7 +102,7 @@ describe('api-file', () => {
       apiName: 'TestApi',
       operations: [
         {
-          operationName: 'getFn',
+          operationId: 'getFn',
           method: 'get',
           parameters: [],
           pattern: 'test'
@@ -118,7 +118,7 @@ describe('api-file', () => {
       apiName: 'TestApi',
       operations: [
         {
-          operationName: 'createFn',
+          operationId: 'createFn',
           method: 'post',
           parameters: [
             {
@@ -162,7 +162,7 @@ describe('api-file', () => {
       apiName: 'TestApi',
       operations: [
         {
-          operationName: 'getFn',
+          operationId: 'getFn',
           method: 'get',
           parameters: [
             {

--- a/packages/openapi-generator/src/wrapper-files/api-file.ts
+++ b/packages/openapi-generator/src/wrapper-files/api-file.ts
@@ -78,15 +78,15 @@ function getOperation(operation: OpenApiOperation): string {
     : '';
   const requestBuilderParams = [
     'DefaultApi',
-    `'${operation.operationName}'`,
+    `'${operation.operationId}'`,
     ...params.map(param => `args${argsQuestionMark}.${param.name}`)
   ];
 
   return codeBlock`
 ${
-  operation.operationName
+  operation.operationId
 }: (${paramsArg}) => new OpenApiRequestBuilder<DefaultApi, '${
-    operation.operationName
+    operation.operationId
   }'>(
   ${requestBuilderParams.join(',\n')}
 )`;

--- a/packages/util/src/code-block.spec.ts
+++ b/packages/util/src/code-block.spec.ts
@@ -39,4 +39,8 @@ C
     A ${nested}
 `).toMatchInlineSnapshot('"    A 1"');
   });
+
+  it('does not throw on undefined values', () => {
+    expect(() => codeBlock`A + ${undefined} + B`).not.toThrow();
+  });
 });

--- a/packages/util/src/code-block.ts
+++ b/packages/util/src/code-block.ts
@@ -24,8 +24,7 @@ export function codeBlock(strings: TemplateStringsArray, ...args: any[]) {
     return !indentation.trim() ? indentation : '';
   });
   const post = args.map((arg, i) =>
-    arg
-      .toString()
+    ('' + arg)
       .split('\n')
       .map(subArg => indents[i] + subArg)
       .join('\n')

--- a/test-packages/test-services/openapi/test-service/api.ts
+++ b/test-packages/test-services/openapi/test-service/api.ts
@@ -110,5 +110,21 @@ export const TestServiceApi = {
     'testCaseGetDuplicateParameters',
     args.duplicateParam,
     args.duplicateParam2
+  ),
+  getTestCasesNoOperationId: () => new OpenApiRequestBuilder<DefaultApi, 'getTestCasesNoOperationId'>(
+    DefaultApi,
+    'getTestCasesNoOperationId'
+  ),
+  duplicateOperationId: () => new OpenApiRequestBuilder<DefaultApi, 'duplicateOperationId'>(
+    DefaultApi,
+    'duplicateOperationId'
+  ),
+  duplicateOperationId_1: () => new OpenApiRequestBuilder<DefaultApi, 'duplicateOperationId_1'>(
+    DefaultApi,
+    'duplicateOperationId_1'
+  ),
+  duplicateOperationId_2: () => new OpenApiRequestBuilder<DefaultApi, 'duplicateOperationId_2'>(
+    DefaultApi,
+    'duplicateOperationId_2'
   )
 };

--- a/test-packages/test-services/openapi/test-service/api.ts
+++ b/test-packages/test-services/openapi/test-service/api.ts
@@ -119,12 +119,16 @@ export const TestServiceApi = {
     DefaultApi,
     'duplicateOperationId'
   ),
-  duplicateOperationId_1: () => new OpenApiRequestBuilder<DefaultApi, 'duplicateOperationId_1'>(
+  duplicateOperationId2: () => new OpenApiRequestBuilder<DefaultApi, 'duplicateOperationId2'>(
     DefaultApi,
-    'duplicateOperationId_1'
+    'duplicateOperationId2'
   ),
-  duplicateOperationId_2: () => new OpenApiRequestBuilder<DefaultApi, 'duplicateOperationId_2'>(
+  duplicateOperationId3: () => new OpenApiRequestBuilder<DefaultApi, 'duplicateOperationId3'>(
     DefaultApi,
-    'duplicateOperationId_2'
+    'duplicateOperationId3'
+  ),
+  duplicateOperationId1: () => new OpenApiRequestBuilder<DefaultApi, 'duplicateOperationId1'>(
+    DefaultApi,
+    'duplicateOperationId1'
   )
 };

--- a/test-packages/test-services/openapi/test-service/open-api.json
+++ b/test-packages/test-services/openapi/test-service/open-api.json
@@ -454,6 +454,54 @@
           "default"
         ]
       }
+    },
+    "/test-cases/no-operation-id": {
+      "get": {
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        },
+        "operationId": "getTestCasesNoOperationId",
+        "tags": [
+          "default"
+        ]
+      }
+    },
+    "/test-cases/duplicate-operation-ids": {
+      "get": {
+        "operationId": "duplicateOperationId",
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        },
+        "tags": [
+          "default"
+        ]
+      },
+      "post": {
+        "operationId": "duplicateOperationId_2",
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        },
+        "tags": [
+          "default"
+        ]
+      },
+      "put": {
+        "operationId": "duplicateOperationId_1",
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        },
+        "tags": [
+          "default"
+        ]
+      }
     }
   },
   "components": {

--- a/test-packages/test-services/openapi/test-service/open-api.json
+++ b/test-packages/test-services/openapi/test-service/open-api.json
@@ -481,7 +481,7 @@
         ]
       },
       "post": {
-        "operationId": "duplicateOperationId_2",
+        "operationId": "duplicateOperationId3",
         "responses": {
           "201": {
             "description": "no content"
@@ -492,7 +492,18 @@
         ]
       },
       "put": {
-        "operationId": "duplicateOperationId_1",
+        "operationId": "duplicateOperationId2",
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        },
+        "tags": [
+          "default"
+        ]
+      },
+      "patch": {
+        "operationId": "duplicateOperationId1",
         "responses": {
           "201": {
             "description": "no content"

--- a/test-packages/test-services/openapi/test-service/openapi/api/default-api.ts
+++ b/test-packages/test-services/openapi/test-service/openapi/api/default-api.ts
@@ -193,7 +193,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             if (configuration) {
                 baseOptions = configuration.baseOptions;
             }
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -221,6 +221,41 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @throws {RequiredError}
          */
         duplicateOperationId2: async (options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/test-cases/duplicate-operation-ids`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        duplicateOperationId3: async (options: any = {}): Promise<RequestArgs> => {
             const localVarPath = `/test-cases/duplicate-operation-ids`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, 'https://example.com');
@@ -771,6 +806,18 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             };
         },
         /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async duplicateOperationId3(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).duplicateOperationId3(options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
          * Get all entities
          * @summary Get entities
          * @param {string} [stringParameter] A parameter of type string
@@ -955,6 +1002,14 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return DefaultApiFp(configuration).duplicateOperationId2(options).then((request) => request(axios, basePath));
         },
         /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        duplicateOperationId3(options?: any): AxiosPromise<void> {
+            return DefaultApiFp(configuration).duplicateOperationId3(options).then((request) => request(axios, basePath));
+        },
+        /**
          * Get all entities
          * @summary Get entities
          * @param {string} [stringParameter] A parameter of type string
@@ -1117,6 +1172,16 @@ export class DefaultApi extends BaseAPI {
      */
     public duplicateOperationId2(options?: any) {
         return DefaultApiFp(this.configuration).duplicateOperationId2(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public duplicateOperationId3(options?: any) {
+        return DefaultApiFp(this.configuration).duplicateOperationId3(options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/test-packages/test-services/openapi/test-service/openapi/api/default-api.ts
+++ b/test-packages/test-services/openapi/test-service/openapi/api/default-api.ts
@@ -146,6 +146,111 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        duplicateOperationId: async (options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/test-cases/duplicate-operation-ids`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        duplicateOperationId1: async (options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/test-cases/duplicate-operation-ids`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        duplicateOperationId2: async (options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/test-cases/duplicate-operation-ids`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Get all entities
          * @summary Get entities
          * @param {string} [stringParameter] A parameter of type string
@@ -235,6 +340,41 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             }
             const localVarPath = `/entities/{entityId}`
                 .replace(`{${"entityId"}}`, encodeURIComponent(String(entityId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, 'https://example.com');
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            const query = new URLSearchParams(localVarUrlObj.search);
+            for (const key in localVarQueryParameter) {
+                query.set(key, localVarQueryParameter[key]);
+            }
+            for (const key in options.query) {
+                query.set(key, options.query[key]);
+            }
+            localVarUrlObj.search = (new URLSearchParams(query)).toString();
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: localVarUrlObj.pathname + localVarUrlObj.search + localVarUrlObj.hash,
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getTestCasesNoOperationId: async (options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/test-cases/no-operation-id`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, 'https://example.com');
             let baseOptions;
@@ -595,6 +735,42 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             };
         },
         /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async duplicateOperationId(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).duplicateOperationId(options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async duplicateOperationId1(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).duplicateOperationId1(options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async duplicateOperationId2(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).duplicateOperationId2(options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
          * Get all entities
          * @summary Get entities
          * @param {string} [stringParameter] A parameter of type string
@@ -624,6 +800,18 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          */
         async getEntityByKey(entityId: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<TestEntity>>> {
             const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).getEntityByKey(entityId, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getTestCasesNoOperationId(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await DefaultApiAxiosParamCreator(configuration).getTestCasesNoOperationId(options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {...localVarAxiosArgs.options, url: basePath + localVarAxiosArgs.url};
                 return axios.request(axiosRequestArgs);
@@ -743,6 +931,30 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return DefaultApiFp(configuration).deleteEntity(requestBody, options).then((request) => request(axios, basePath));
         },
         /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        duplicateOperationId(options?: any): AxiosPromise<void> {
+            return DefaultApiFp(configuration).duplicateOperationId(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        duplicateOperationId1(options?: any): AxiosPromise<void> {
+            return DefaultApiFp(configuration).duplicateOperationId1(options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        duplicateOperationId2(options?: any): AxiosPromise<void> {
+            return DefaultApiFp(configuration).duplicateOperationId2(options).then((request) => request(axios, basePath));
+        },
+        /**
          * Get all entities
          * @summary Get entities
          * @param {string} [stringParameter] A parameter of type string
@@ -768,6 +980,14 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         getEntityByKey(entityId: string, options?: any): AxiosPromise<Array<TestEntity>> {
             return DefaultApiFp(configuration).getEntityByKey(entityId, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getTestCasesNoOperationId(options?: any): AxiosPromise<void> {
+            return DefaultApiFp(configuration).getTestCasesNoOperationId(options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -870,6 +1090,36 @@ export class DefaultApi extends BaseAPI {
     }
 
     /**
+     * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public duplicateOperationId(options?: any) {
+        return DefaultApiFp(this.configuration).duplicateOperationId(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public duplicateOperationId1(options?: any) {
+        return DefaultApiFp(this.configuration).duplicateOperationId1(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public duplicateOperationId2(options?: any) {
+        return DefaultApiFp(this.configuration).duplicateOperationId2(options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
      * Get all entities
      * @summary Get entities
      * @param {string} [stringParameter] A parameter of type string
@@ -898,6 +1148,16 @@ export class DefaultApi extends BaseAPI {
      */
     public getEntityByKey(entityId: string, options?: any) {
         return DefaultApiFp(this.configuration).getEntityByKey(entityId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public getTestCasesNoOperationId(options?: any) {
+        return DefaultApiFp(this.configuration).getTestCasesNoOperationId(options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/test-resources/openapi-service-specs/test-service.json
+++ b/test-resources/openapi-service-specs/test-service.json
@@ -443,6 +443,41 @@
           }
         }
       }
+    },
+    "/test-cases/no-operation-id": {
+      "get": {
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        }
+      }
+    },
+    "/test-cases/duplicate-operation-ids": {
+      "get": {
+        "operationId": "duplicateOperationId",
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        }
+      },
+      "post": {
+        "operationId": "duplicateOperationId",
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        }
+      },
+      "put": {
+        "operationId": "duplicateOperationId_1",
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/test-resources/openapi-service-specs/test-service.json
+++ b/test-resources/openapi-service-specs/test-service.json
@@ -477,6 +477,14 @@
             "description": "no content"
           }
         }
+      },
+      "patch": {
+        "operationId": "duplicateOperationId1",
+        "responses": {
+          "201": {
+            "description": "no content"
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
This should allow us to generate for erroneous specifications as well.