### PR TITLE
chore: Moment poc ADR

### DIFF
--- a/knowledge-base/adr/0015-date-time-handling.md
+++ b/knowledge-base/adr/0015-date-time-handling.md
@@ -151,14 +151,14 @@ As mentioned above, the PoC example only has two generic types for mapping `Edm.
 ```
 - Implementation with unit tests about how custom deserializer affects the return value of the `GetAllRequestBuilder`.
 
-### How to get rid of moment lib
+### How to get rid of `moment` lib
 #### Prerequisites
 - The middleware pattern is implemented so the SDK supports custom (de)serializer middleware in addition to the default one.
-- The temporal lib (or other alternatives) is ready to replace moment as the default (de)serialzier.
+- The `temporal` lib (or other alternatives) is ready to replace `moment` as the default (de)serialzier.
 
 #### Steps
-1. Switch the default (de)seralizer from moment to e.g., temporal, so our sdk core will not have moment as a dependency but temporal. (breaking change)
-2. Realease a new package which contains a prebuild consts as a (de)serializer middleware, using moment as a dependency, so a user can switch the (de)serializer on demand. This allows you to use latest sdk core with moment instead of the default (de)serializer.
+1. Switch the default (de)seralizer from `moment` to e.g., `temporal`, so our sdk core will not have `moment` as a dependency but `temporal`. (breaking change)
+2. Realease a new package which contains a prebuild consts as a moment (de)serializer middleware, using `moment` as a dependency, so a user can switch the (de)serializer on demand. This allows you to use latest sdk core with `moment` instead of the default (de)serializer.
 
 ### Next steps
 - Refactor the middleware structure to align with the design mentioned above

--- a/knowledge-base/adr/0015-date-time-handling.md
+++ b/knowledge-base/adr/0015-date-time-handling.md
@@ -96,6 +96,7 @@ interface DeSerializationMiddlewareInterface<T1>{
 With the api design above, when applying it for replacing the moment lib, we will introduce multiple generic types for `Entity`, `RequestBuilder`, `TestEntity` and `TestEntityRequestBuilder`, which makes our code more complicated, but the users should not be affected.
 The number of generic types depends on the number of related edm types. 
 For example, for `ODataV4`, 4 edm types (`Edm.DateTimeOffset`, `Edm.Date`, `Edm.Duration` and `Edm.TimeOfDay`) are relevant, which means it will introduce 4 generic types for all the classes mentioned above.
+In the PoC example, the string/number example looks like below, where only two generic types are used:
 
 ### Assumption
 - Request builders has the same complexity.

--- a/knowledge-base/adr/0015-date-time-handling.md
+++ b/knowledge-base/adr/0015-date-time-handling.md
@@ -102,6 +102,7 @@ For example, for `ODataV4`, 4 edm types (`Edm.DateTimeOffset`, `Edm.Date`, `Edm.
 - Serializer has the same complexity as the Deserializer.
 - The URL converter uses the serialiser, so it might not be part of the middleware.
 - OData V2 has the same complexity as the OData V4.
+- Advanced data type like Complex/Collection type can be handled like the basic edm type.
 
 ### Scope
 - Type tests of the entity created by the entity builder with/without the middleware.

--- a/knowledge-base/adr/0015-date-time-handling.md
+++ b/knowledge-base/adr/0015-date-time-handling.md
@@ -100,6 +100,7 @@ For example, for `ODataV4`, 4 edm types (`Edm.DateTimeOffset`, `Edm.Date`, `Edm.
 ### Assumption
 - Request builders has the same complexity.
 - Serializer has the same complexity as the Deserializer.
+- The URL converter uses the serialiser, so it might not be part of the middleware.
 - OData V2 has the same complexity as the OData V4.
 
 ### Scope

--- a/knowledge-base/adr/0015-date-time-handling.md
+++ b/knowledge-base/adr/0015-date-time-handling.md
@@ -165,4 +165,5 @@ As mentioned above, the PoC example only has two generic types for mapping `Edm.
 - In addition to the `GetAllRequestBuilder`, handle all kinds of the request builders.
 - In addition to `deserialzer`, handle `serializer` and `uri-converter`.
 - In addition to `ODataV4`, handle `ODataV2`.
+- In addition to basic edm types, handle advances types like collection and complex types
 - Release a new package (`@sap-cloud-sdk/date-time-temporal`/`@sap-cloud-sdk/date-time-moment`) as a middleware component, so users can consume directly.

--- a/knowledge-base/adr/0015-date-time-handling.md
+++ b/knowledge-base/adr/0015-date-time-handling.md
@@ -98,7 +98,11 @@ The number of generic types depends on the number of related edm types.
 For example, for `ODataV4`, 4 edm types (`Edm.DateTimeOffset`, `Edm.Date`, `Edm.Duration` and `Edm.TimeOfDay`) are relevant, which means it will introduce 4 generic types for all the classes mentioned above.
 In the PoC example, the string/number example looks like below, where only two generic types are used for two edm types (`Edm.String` and `Edm.Int32`):
 ```ts
-export class TestEntityTemporal<T1 = string, T2 = number> extends EntityV4<T1, T2> implements TestEntityType<T1, T2> {}
+export class TestEntityTemporal<T1 = string, T2 = number> extends EntityV4<T1, T2> implements TestEntityType<T1, T2> {
+  stringProperty?: T1;
+  int32Property?: T2;
+  ...
+}
 ```
 
 ### Assumption


### PR DESCRIPTION
In the ADR `0015-date-time-handling.md`, we decided to make an interface so users could choose the date time lib and custom the (de)serialiser. 
The [PoC](https://github.com/SAP/cloud-sdk-js/pull/921) of such design was successful.
This PR reflects the status of the PoC in the aspects:
- new api design
- assumption
- scope
- how to get rid of moment
- next steps