### PR TITLE
chore: Move transpilation to generators

### DIFF
--- a/packages/generator/src/generator-utils.ts
+++ b/packages/generator/src/generator-utils.ts
@@ -1,5 +1,6 @@
 import { EdmTypeShared } from '@sap-cloud-sdk/core';
 import { createLogger, ODataVersion } from '@sap-cloud-sdk/util';
+import execa from 'execa';
 import {
   VdmNavigationProperty,
   VdmProperty,
@@ -315,4 +316,19 @@ const npmRegex = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
 
 export function hasEntities(service: VdmServiceMetadata): boolean {
   return !!service.entities?.length;
+}
+
+// TODO: The following is duplicate in the openapi generator
+/**
+ * Executes the type script compiler for the given directory.
+ * A valid tsconfig.json needs to be present in the directory.
+ * @param path - Directory to be compiled
+ */
+export async function transpileDirectory(path: string): Promise<void> {
+  logger.debug(`Transpiling files in the directory: ${path} started.`);
+  await execa('tsc', { cwd: path }).catch(err => {
+    logger.error(`Error: Failed to generate js files: ${err}`);
+    process.exit(1);
+  });
+  logger.debug(`Transpiling files in directory: ${path} finished.`);
 }

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -2,8 +2,7 @@ import { PathLike, readFileSync } from 'fs';
 import { resolve, basename } from 'path';
 import {
   createLogger,
-  splitInChunks,
-  transpileDirectory
+  splitInChunks
 } from '@sap-cloud-sdk/util';
 import { emptyDirSync } from 'fs-extra';
 import {
@@ -31,7 +30,8 @@ import {
 import {
   cloudSdkVdmHack,
   hasEntities,
-  npmCompliantName
+  npmCompliantName,
+  transpileDirectory
 } from './generator-utils';
 import {
   genericDescription,

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -1,9 +1,6 @@
 import { PathLike, readFileSync } from 'fs';
 import { resolve, basename } from 'path';
-import {
-  createLogger,
-  splitInChunks
-} from '@sap-cloud-sdk/util';
+import { createLogger, splitInChunks } from '@sap-cloud-sdk/util';
 import { emptyDirSync } from 'fs-extra';
 import {
   Directory,

--- a/packages/openapi-generator/src/generator-utils.ts
+++ b/packages/openapi-generator/src/generator-utils.ts
@@ -1,0 +1,22 @@
+import execa from 'execa';
+import { createLogger } from '@sap-cloud-sdk/util';
+
+const logger = createLogger({
+  package: 'openapi-generator',
+  messageContext: 'generator-utils'
+});
+
+// TODO: The following is duplicate in the OData generator
+/**
+ * Executes the type script compiler for the given directory.
+ * A valid tsconfig.json needs to be present in the directory.
+ * @param path - Directory to be compiled
+ */
+export async function transpileDirectory(path: string): Promise<void> {
+  logger.debug(`Transpiling files in the directory: ${path} started.`);
+  await execa('tsc', { cwd: path }).catch(err => {
+    logger.error(`Error: Failed to generate js files: ${err}`);
+    process.exit(1);
+  });
+  logger.debug(`Transpiling files in directory: ${path} finished.`);
+}

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -5,7 +5,6 @@ import { resolve, parse } from 'path';
 import {
   createLogger,
   ErrorWithCause,
-  transpileDirectory,
   UniqueNameGenerator
 } from '@sap-cloud-sdk/util';
 import execa = require('execa');
@@ -22,6 +21,7 @@ import { parseOpenApiDocument } from './parser';
 import { convertOpenApiSpec } from './document-converter';
 import { readServiceMapping, VdmMapping } from './service-mapping';
 import { tsconfigJson } from './wrapper-files/tsconfig-json';
+import { transpileDirectory } from './generator-utils';
 
 const { readdir, writeFile, rmdir, mkdir, lstat, readFile } = promisesFs;
 const logger = createLogger('openapi-generator');

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -32,7 +32,6 @@
     "check:dependencies": "depcheck ."
   },
   "dependencies": {
-    "execa": "^5.0.0",
     "chalk": "^4.1.0",
     "logform": "^2.2.0",
     "voca": "^1.4.0",

--- a/packages/util/src/fs.ts
+++ b/packages/util/src/fs.ts
@@ -1,6 +1,5 @@
 import { existsSync, PathLike, readdirSync, readFileSync } from 'fs';
 import { resolve } from 'path';
-import execa from 'execa';
 import { createLogger } from './logger';
 
 const logger = createLogger({
@@ -35,18 +34,4 @@ export function readJSON(path: PathLike): { [key: string]: any } {
   }
   logger.warn(`File "${path}" does not exist, return empty object.`);
   return {};
-}
-
-/**
- * Executes the type script compiler for the given directory.
- * A valid tsconfig.json needs to be present in the directory.
- * @param path - Directory to be compiled
- */
-export async function transpileDirectory(path: string): Promise<void> {
-  logger.debug(`Transpiling files in the directory: ${path} started.`);
-  await execa('tsc', { cwd: path }).catch(err => {
-    logger.error(`Error: Failed to generate js files: ${err}`);
-    process.exit(1);
-  });
-  logger.debug(`Transpiling files in directory: ${path} finished.`);
 }


### PR DESCRIPTION
Having `execa` in utils breaks the frontend e2e tests. I was able to fix that to a certain degree, but this will also break for users who use the SDK in the frontend. In order to avoid that, I thought it might be nice, to for now just duplicate this one function and later on put this into a separate library as discussed.

Let me know if this makes sense for you.