### PR TITLE
fix: Improve swagger path generation to actually check for file paths

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -50,6 +50,7 @@
     "yargs": "^16.0.3"
   },
   "devDependencies": {
-    "@types/yargs": "^16.0.0"
+    "@types/yargs": "^16.0.0",
+    "mock-fs": "^4.13.0"
   }
 }

--- a/packages/generator/src/input-path-provider.spec.ts
+++ b/packages/generator/src/input-path-provider.spec.ts
@@ -1,18 +1,42 @@
+import mock from 'mock-fs';
 import { swaggerPathForEdmx } from './input-path-provider';
+
 describe('swaggerPathForEdmx', () => {
-  it('replaces .edmx with .json', () => {
-    expect(swaggerPathForEdmx('service.edmx')).toEqual('service.json');
+  it('replaces path ending with .json', () => {
+    mock({
+      '/service-specs': {
+        'service.edmx': '',
+        'service.json': ''
+      }
+    });
+    expect(swaggerPathForEdmx('/service-specs/service.edmx')).toEqual(
+      '/service-specs/service.json'
+    );
+    mock.restore();
   });
 
-  it('replaces .EDMX with .json', () => {
-    expect(swaggerPathForEdmx('service.EDMX')).toEqual('service.json');
+  it('replaces path ending with .JSON', () => {
+    mock({
+      '/service-specs': {
+        'service.edmx': '',
+        'service.JSON': ''
+      }
+    });
+    expect(swaggerPathForEdmx('/service-specs/service.edmx')).toEqual(
+      '/service-specs/service.JSON'
+    );
+    mock.restore();
   });
 
-  it('replaces .xml with .json', () => {
-    expect(swaggerPathForEdmx('service.xml')).toEqual('service.json');
-  });
-
-  it('only replaces extension in the end', () => {
-    expect(swaggerPathForEdmx('service.edmx.')).toEqual('service.edmx.json');
+  it('returns undefined if there is no equally named json file', () => {
+    mock({
+      '/service-specs': {
+        'service.edmx': '',
+        'SERVICE.json': '',
+        'service.txt': ''
+      }
+    });
+    expect(swaggerPathForEdmx('/service-specs/service.edmx')).toBeUndefined();
+    mock.restore();
   });
 });

--- a/packages/generator/src/input-path-provider.ts
+++ b/packages/generator/src/input-path-provider.ts
@@ -1,5 +1,5 @@
-import { lstatSync, PathLike, readdirSync } from 'fs';
-import { join, extname } from 'path';
+import { lstatSync, PathLike, readdirSync, existsSync } from 'fs';
+import { join, extname, parse } from 'path';
 
 const validFileExtensions = ['.edmx', '.xml'];
 
@@ -30,9 +30,12 @@ export function inputPaths(
   });
 }
 
-export function swaggerPathForEdmx(edmxPath: PathLike): PathLike {
-  const extension = new RegExp(`${extname(edmxPath.toString())}\$`);
-  return edmxPath.toString().replace(extension, '.json');
+export function swaggerPathForEdmx(edmxPath: PathLike): PathLike | undefined {
+  const { dir, name } = parse(edmxPath.toString());
+  const validSwaggerExtensions = ['.json', '.JSON'];
+  return validSwaggerExtensions
+    .map(ext => join(dir, `${name}${ext}`))
+    .find(swaggerPath => existsSync(swaggerPath.toString()));
 }
 
 function hasEdmxFileExtension(fileName: string): boolean {


### PR DESCRIPTION
This is a further improvement, because the old version actually fails in some cases (e. g. if swagger enhancement is enabled and there is a .xml, but no .json file, we currently return the original .xml filepath. Later on JSON.parse generation will fail).