### PR TITLE
chore: Reduce the usage of Mac OS in the tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
         node-version: [10.x, 12.x]
+        exclude:
+          - os: macos-latest
+            node: 10.x
     steps:
       - uses: actions/checkout@v1
       - name: Get yarn cache directory path

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         node-version: [10.x, 12.x]
         exclude:
           - os: macos-latest
-            node: 10.x
+            node-version: 10.x
     steps:
       - uses: actions/checkout@v1
       - name: Get yarn cache directory path


### PR DESCRIPTION
It happened 5+ times (on Feb.12th) that the GH Actions cost 20+ minute, because of the waiting time of the Mac OS containers.
I guess with more people working on it, it's harder to get the containers.

In this PR, I would like to minimise the usage of the Mac OS container and only keep using one.

I disabled the combination of Mac OS and node 10, since we still have two cases below:
- Mac OS and node 12
- ubuntu and node 10 

Let me know your opinion.