### PR TITLE
chore: commit openapi jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ packages/**/*.jar
 *.jar
 local-docs/_site
 
+# openapi generator
+!**/5.0.0.jar
+
 sqlite.db
 sqlite.db-journal
 

--- a/packages/openapi-generator/openapitools.json
+++ b/packages/openapi-generator/openapitools.json
@@ -2,6 +2,7 @@
   "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "5.0.0"
+    "version": "5.0.0",
+    "storageDir": "./bin/openapi-jar"
   }
 }


### PR DESCRIPTION
The jar file needs to be downloaded on the fly when necessary. The URL (maven central) for downloading the jar file is not configurable. This is the solution when downloading from external target URL is not allowed.