### PR TITLE
fix: Fix Redirect issue in latest BAS on CF

### DIFF
--- a/packages/core/src/connectivity/scp-cf/authorization-header.ts
+++ b/packages/core/src/connectivity/scp-cf/authorization-header.ts
@@ -233,7 +233,7 @@ async function getAuthenticationRelatedHeaders(
       return headerForPrincipalPropagation(destination);
     default:
       throw Error(
-        'Failed to build authorization header for the given destination. Make sure to either correctly configure your destination for principal propagation, provide both a username and a password or select "NoAuthentication" in your destination configuration.'
+        `The destination used "${destination.authentication}" as authentication type which is not supported by the SDK.`
       );
   }
 }


### PR DESCRIPTION
Relates to #1037 and changes the logic that first the call is made against the URL with a `/` in the end.