### PR TITLE
fix: Proxy and client cert authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## Known Issues
 
--
+- 
 
 ## Compatibility Notes
 
@@ -22,7 +22,7 @@
 
 ## Improvements
 
--
+- [http-agent] Fix client certificate authentication in conjunction with proxies - depends on [this PR](https://github.com/TooTallNate/node-https-proxy-agent/pull/111).
 
 ## Fixed Issues
 

--- a/packages/core/src/connectivity/scp-cf/connectivity-service.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/connectivity-service.spec.ts
@@ -21,7 +21,7 @@ describe('connectivity-service', () => {
     jest.restoreAllMocks();
   });
 
-  it('adds a proxy configuration containing at least the host, the port, and the "Proxy-Authorization" header to a destination', done => {
+  it('adds a proxy configuration containing at least the host, the port, and the "Proxy-Authorization" header to a destination', async() => {
     mockServiceBindings();
     mockServiceToken();
 
@@ -41,17 +41,11 @@ describe('connectivity-service', () => {
       }
     };
 
-    addProxyConfiguration(input)
-      .then(actual => {
-        expect(actual).toEqual(expected);
-        done();
-      })
-      .catch(error => {
-        testLogger.error(error);
-      });
+    const withProxy = await addProxyConfiguration(input);
+    expect(withProxy).toEqual(expected);
   });
 
-  it('also contains the "SAP-Connectivity-Authentication" header if a JWT is present', done => {
+  it('also contains the "SAP-Connectivity-Authentication" header if a JWT is present', async() => {
     mockServiceBindings();
     mockServiceToken();
 
@@ -72,14 +66,8 @@ describe('connectivity-service', () => {
       }
     };
 
-    addProxyConfiguration(input, providerUserJwt)
-      .then(actual => {
-        expect(actual).toEqual(expected);
-        done();
-      })
-      .catch(error => {
-        testLogger.error(error);
-      });
+    const withProxy = await addProxyConfiguration(input, providerUserJwt);
+      expect(withProxy).toEqual(expected);
   });
 
   it('throws an error if there is no connectivity service bound', done => {

--- a/packages/core/src/connectivity/scp-cf/proxy-util.ts
+++ b/packages/core/src/connectivity/scp-cf/proxy-util.ts
@@ -270,6 +270,14 @@ export function proxyAgent(
     throw new Error('Proxy config must not be undefined.');
   }
 
+  if(options?.host){
+    logger.warn(`The agent options you passed to the proxy agent creation contains the host "${options.host}" which will overwrite the host from the proxy config.`)
+  }
+
+  if(options?.port){
+    logger.warn(`The agent options you passed to the proxy agent creation contains the port "${options.host}" which will overwrite the port from the proxy config.`)
+  }
+
   const agentConfig = {
     host: proxyConfig.host,
     protocol: proxyConfig.protocol,

--- a/packages/core/src/connectivity/scp-cf/proxy-util.ts
+++ b/packages/core/src/connectivity/scp-cf/proxy-util.ts
@@ -271,11 +271,11 @@ export function proxyAgent(
   }
 
   if(options?.host){
-    logger.warn(`The agent options you passed to the proxy agent creation contains the host "${options.host}" which will overwrite the host from the proxy config.`)
+    logger.warn(`The agent options you passed to the proxy agent creation contains the host "${options.host}" which will overwrite the host from the proxy config.`);
   }
 
   if(options?.port){
-    logger.warn(`The agent options you passed to the proxy agent creation contains the port "${options.host}" which will overwrite the port from the proxy config.`)
+    logger.warn(`The agent options you passed to the proxy agent creation contains the port "${options.host}" which will overwrite the port from the proxy config.`);
   }
 
   const agentConfig = {

--- a/packages/core/src/connectivity/scp-cf/proxy-util.ts
+++ b/packages/core/src/connectivity/scp-cf/proxy-util.ts
@@ -275,7 +275,7 @@ export function proxyAgent(
   }
 
   if(options?.port){
-    logger.warn(`The agent options you passed to the proxy agent creation contains the port "${options.host}" which will overwrite the port from the proxy config.`);
+    logger.warn(`The agent options you passed to the proxy agent creation contains the port "${options.port}" which will overwrite the port from the proxy config.`);
   }
 
   const agentConfig = {

--- a/packages/core/src/connectivity/scp-cf/proxy-util.ts
+++ b/packages/core/src/connectivity/scp-cf/proxy-util.ts
@@ -1,3 +1,4 @@
+import { AgentOptions } from 'https';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { createLogger } from '@sap-cloud-sdk/util';
@@ -252,12 +253,15 @@ export function addProxyConfigurationInternet(destination: any): Destination {
 /**
  * Builds the http(s)-agent config. Note that the proxy agent type like http or https is determined by the destination RUL protocol.
  * The protocol from the proxy is unrelated to this and in most cases http.
+ * All additional options are forwarded to tls.connect and net.connect see https://github.com/TooTallNate/node-https-proxy-agent#new-httpsproxyagentobject-options
  *
  * @param destination - Destination containing the proxy configurations
+ * @param options - Addiotional options for the agent
  * @returns The http(s)-agent containing the proxy configuration
  */
 export function proxyAgent(
-  destination: Destination
+  destination: Destination,
+  options?: AgentOptions
 ): HttpAgentConfig | HttpsAgentConfig {
   const targetProtocol = getProtocolOrDefault(destination);
   const proxyConfig = destination.proxyConfiguration;
@@ -266,18 +270,21 @@ export function proxyAgent(
     throw new Error('Proxy config must not be undefined.');
   }
 
+  const agentConfig = {
+    host: proxyConfig.host,
+    protocol: proxyConfig.protocol,
+    port: proxyConfig.port,
+    ...options
+  };
+
   switch (targetProtocol) {
     case Protocol.HTTP:
       return {
-        httpAgent: new HttpProxyAgent(
-          `${proxyConfig.protocol}://${proxyConfig.host}:${proxyConfig.port}`
-        )
+        httpAgent: new HttpProxyAgent(agentConfig)
       };
     case Protocol.HTTPS:
       return {
-        httpsAgent: new HttpsProxyAgent(
-          `${proxyConfig.protocol}://${proxyConfig.host}:${proxyConfig.port}`
-        )
+        httpsAgent: new HttpsProxyAgent(agentConfig)
       };
   }
 }

--- a/packages/core/src/http-client/http-agent.spec.ts
+++ b/packages/core/src/http-client/http-agent.spec.ts
@@ -32,7 +32,7 @@ describe('createAgent', () => {
 
   it('returns a proxy agent if there is a proxy setting on the destination', () => {
     expect(getAgentConfig(proxyDestination)['httpsAgent']).toEqual(
-      new HttpsProxyAgent(mockedConnectivityServiceProxyConfig)
+      new HttpsProxyAgent({ ...mockedConnectivityServiceProxyConfig,        rejectUnauthorized:true })
     );
   });
 

--- a/packages/core/src/http-client/http-agent.ts
+++ b/packages/core/src/http-client/http-agent.ts
@@ -65,6 +65,8 @@ const certificateOptions = (destination: Destination) => (
   if (destination.keyStoreName && destination.keyStorePassword) {
     const certificate = selectCertificate(destination);
 
+    logger.debug(`Certifcate with name "${certificate.name}" selected.`)
+
     return {
       ...options,
       pfx: Buffer.from(certificate.content, 'base64'),

--- a/packages/core/src/http-client/http-agent.ts
+++ b/packages/core/src/http-client/http-agent.ts
@@ -85,9 +85,10 @@ const certificateOptions = (destination: Destination) => (
 function getCertificateOption(destination: Destination): Record<string, any>  {
   // http case: no certificate needed
   if(getProtocolOrDefault(destination) === Protocol.HTTP){
-  if (destination.isTrustingAllCertificates) {
-    logger.warn('"isTrustingAllCertificates" is not available for HTTP.');
-  }
+    if (destination.isTrustingAllCertificates) {
+      logger.warn('"isTrustingAllCertificates" is not available for HTTP.');
+    }
+
     return {};
   }
   // https case: get certificate options

--- a/packages/core/src/http-client/http-agent.ts
+++ b/packages/core/src/http-client/http-agent.ts
@@ -65,7 +65,7 @@ const certificateOptions = (destination: Destination) => (
   if (destination.keyStoreName && destination.keyStorePassword) {
     const certificate = selectCertificate(destination);
 
-    logger.debug(`Certifcate with name "${certificate.name}" selected.`)
+    logger.debug(`Certifcate with name "${certificate.name}" selected.`);
 
     return {
       ...options,

--- a/packages/core/src/http-client/http-agent.ts
+++ b/packages/core/src/http-client/http-agent.ts
@@ -32,9 +32,9 @@ export function getAgentConfig(
   // eslint-disable-next-line @typescript-eslint/no-shadow
   const certificateOptions = getCertificateOption(destination);
   if (agentType === AgentType.PROXY) {
-    return createProxyAgent(destination,certificateOptions);
+    return createProxyAgent(destination, certificateOptions);
   }
-  return createDefaultAgent(destination,certificateOptions);
+  return createDefaultAgent(destination, certificateOptions);
 }
 
 enum AgentType {

--- a/packages/core/test/test-util/environment-mocks.ts
+++ b/packages/core/test/test-util/environment-mocks.ts
@@ -36,14 +36,14 @@ export const mockDestinationServiceBinding: Service = {
   }
 };
 
-export const mockedConnectivityServiceProxyConfig: ProxyConfiguration = {
+export const mockedConnectivityServiceProxyConfig: ProxyConfiguration &{rejectUnauthorized: boolean} = {
   host: 'proxy.example.com',
   port: 12345,
   protocol: Protocol.HTTP,
-  headers: undefined
+  rejectUnauthorized:true
 };
 
-export const mockedConnectivityServiceProxyURL = `${mockedConnectivityServiceProxyConfig.protocol}://${mockedConnectivityServiceProxyConfig.host}:${mockedConnectivityServiceProxyConfig.port}`;
+// export const mockedConnectivityServiceProxyURL = `${mockedConnectivityServiceProxyConfig.protocol}://${mockedConnectivityServiceProxyConfig.host}:${mockedConnectivityServiceProxyConfig.port}`;
 
 export const mockConnectivityServiceBinding: Service = {
   plan: 'application',

--- a/packages/core/test/test-util/environment-mocks.ts
+++ b/packages/core/test/test-util/environment-mocks.ts
@@ -36,11 +36,10 @@ export const mockDestinationServiceBinding: Service = {
   }
 };
 
-export const mockedConnectivityServiceProxyConfig: ProxyConfiguration &{rejectUnauthorized: boolean} = {
+export const mockedConnectivityServiceProxyConfig: ProxyConfiguration = {
   host: 'proxy.example.com',
   port: 12345,
-  protocol: Protocol.HTTP,
-  rejectUnauthorized:true
+  protocol: Protocol.HTTP
 };
 
 // export const mockedConnectivityServiceProxyURL = `${mockedConnectivityServiceProxyConfig.protocol}://${mockedConnectivityServiceProxyConfig.host}:${mockedConnectivityServiceProxyConfig.port}`;

--- a/test-packages/integration-tests/test/auth-flows/auth-flow-util.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow-util.ts
@@ -38,6 +38,7 @@ export interface UserAccessTokens {
 export interface Systems {
   s4: {
     providerBasic: string;
+    providerClientCert: string;
     providerOAuth2SAMLBearerAssertion: string;
     subscriberBasic: string;
   };

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -126,8 +126,8 @@ describe('OAuth flows', () => {
   }, 60000);
 
   xit('ClientCertificate: Fetches the certificate and uses it',async ()=>{
-    process.env.HTTPS_PROXY = 'http://someHost:1234'
-    process.env.NO_PROXY = 'https://s4sdk.authentication.sap.hana.ondemand.com/oauth/token'
+    process.env.HTTPS_PROXY = 'http://someHost:1234';
+    process.env.NO_PROXY = 'https://s4sdk.authentication.sap.hana.ondemand.com/oauth/token';
 
     const destination = await getDestination('CC8-HTTP-CERT');
     expect(destination!.certificates!.length).toBe(1);

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -1,6 +1,6 @@
 import {
   executeHttpRequest,
-  fetchDestination,
+  fetchDestination, getDestination,
   getService,
   serviceToken,
   userApprovedServiceToken,
@@ -124,6 +124,13 @@ describe('OAuth flows', () => {
 
     expect(response.status).toBe(200);
   }, 60000);
+
+  it('ClientCertificate: Fetches the certificate and uses it',async ()=>{
+    const destination = await getDestination('CC8-HTTP-CERT');
+    expect(destination!.certificates!.length).toBe(1);
+    const bps = await BusinessPartner.requestBuilder().getAll().top(5).execute(destination!);
+    expect(bps.length).toBeGreaterThan(0);
+  },10000);
 
   xit('OAuth2UserTokenExchange: Subscriber destination and Subscriber Jwt', async () => {
     const subscriberDestToken = await serviceToken('destination', {

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -125,7 +125,10 @@ describe('OAuth flows', () => {
     expect(response.status).toBe(200);
   }, 60000);
 
-  it('ClientCertificate: Fetches the certificate and uses it',async ()=>{
+  xit('ClientCertificate: Fetches the certificate and uses it',async ()=>{
+    process.env.HTTPS_PROXY = 'http://someHost:1234'
+    process.env.NO_PROXY = 'https://s4sdk.authentication.sap.hana.ondemand.com/oauth/token'
+
     const destination = await getDestination('CC8-HTTP-CERT');
     expect(destination!.certificates!.length).toBe(1);
     const bps = await BusinessPartner.requestBuilder().getAll().top(5).execute(destination!);


### PR DESCRIPTION
I realized while working on BAS that client certificate authentication is not working when also proxies are used.
I adjusted our code that the proxy settings are also passed to the http-agent. Unfortunately also the proxy agent itself does not forward the presented certificates to the target system. So they stay on the proxy and you get a 401.

I checked by locally adjusting the node modules that this PR https://github.com/TooTallNate/node-https-proxy-agent/pull/111 fixes the issue, but the repo seems to be not very active. We can merge the code on our side but it will not work until we get an update on the node-https-proxy and this could take a while...