### PR TITLE
fix: gh action authentication issue

### DIFF
--- a/.github/workflows/dependabot-autofix.yml
+++ b/.github/workflows/dependabot-autofix.yml
@@ -49,8 +49,8 @@ jobs:
         # use personal access token to allow triggering new workflow
         BASIC_AUTH=$(echo -n "x-access-token:$TOKEN" | base64)
         echo "::add-mask::$BASIC_AUTH"
-        git config --global user.name '${{ github.event.commits[0].author.name }}'
-        git config --global user.email '${{ github.event.commits[0].author.email }}'
+        git config --global user.name 'cloud-sdk-js'
+        git config --global user.email 'cloud-sdk-js@github.com'
         git config --local http.$GITHUB_SERVER_URL/.extraheader "AUTHORIZATION: basic $BASIC_AUTH"
     - name: Commit changes
       run: |


### PR DESCRIPTION
This fix tries to use a generic user instead of the bot user in an attempt to use the right secrets, it works on a branch, but we can only be sure that it really works after merging (previous fixes also worked on branches ...)

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
