### PR TITLE
fix: dependabot write privileges

### DIFF
--- a/.github/workflows/dependabot-autofix.yml
+++ b/.github/workflows/dependabot-autofix.yml
@@ -1,7 +1,8 @@
 name: dependabot-autofix
 
 on:
-  push:
+  pull_request_target:
+    types: [ opened, reopened ]
     branches: [ dependabot/npm_and_yarn/** ]
 
 jobs:
@@ -49,8 +50,8 @@ jobs:
         # use personal access token to allow triggering new workflow
         BASIC_AUTH=$(echo -n "x-access-token:$TOKEN" | base64)
         echo "::add-mask::$BASIC_AUTH"
-        git config --global user.name '${{ github.event.commits[0].author.name }}'
-        git config --global user.email '${{ github.event.commits[0].author.email }}'
+        git config --global user.name 'cloud-sdk-js'
+        git config --global user.email 'cloud-sdk-js@github.com'
         git config --local http.$GITHUB_SERVER_URL/.extraheader "AUTHORIZATION: basic $BASIC_AUTH"
     - name: Commit changes
       run: |


### PR DESCRIPTION
With this change, dependable receives write privileges and can therefore push to our repository.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
