### PR TITLE
fix: workflow-run-variaton

### DIFF
--- a/.github/workflows/dependabot-autofix.yml
+++ b/.github/workflows/dependabot-autofix.yml
@@ -1,7 +1,8 @@
 name: dependabot-autofix
 
 on:
-  pull_request:
+  workflow_run:
+    workflows: [ build ]
     branches: [ dependabot/npm_and_yarn/** ]
 
 jobs:


### PR DESCRIPTION
This is the `workflow_run` variation to potentially solve the dependabot issue.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
