### PR TITLE
chore: reduce hard coded paths

### DIFF
--- a/packages/generator/src/edmx-parser/edmx-file-reader.spec.ts
+++ b/packages/generator/src/edmx-parser/edmx-file-reader.spec.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'path';
+import { oDataServiceSpecs } from '../../../../test-resources/odata-service-specs';
 import { readEdmxFile } from './edmx-file-reader';
 import {
   parseActionImport,
@@ -14,14 +16,14 @@ describe('edmx-file-reader', () => {
   it('does not fail for multiple schema entries in the edmx file', () => {
     expect(() =>
       readEdmxFile(
-        '../../test-resources/odata-service-specs/v2/API_MULTIPLE_SCHEMAS_SRV/API_MULTIPLE_SCHEMAS_SRV.edmx'
+        resolve(oDataServiceSpecs,'v2','API_MULTIPLE_SCHEMAS_SRV','API_MULTIPLE_SCHEMAS_SRV.edmx')
       )
     ).not.toThrow();
   });
 
   it('v4: parses edmx file that contains multiple schemas to JSON and coerces properties to arrays', () => {
     const metadataEdmx = readEdmxFile(
-      '../../test-resources/odata-service-specs/v4/API_MULTIPLE_SCHEMAS_SRV/API_MULTIPLE_SCHEMAS_SRV.edmx'
+      resolve(oDataServiceSpecs,'v4','API_MULTIPLE_SCHEMAS_SRV','API_MULTIPLE_SCHEMAS_SRV.edmx')
     );
 
     expect(parseEntitySets(metadataEdmx.root).length).toBe(4);

--- a/packages/generator/src/edmx-parser/v2/edmx-parser.spec.ts
+++ b/packages/generator/src/edmx-parser/v2/edmx-parser.spec.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'path';
 import { readEdmxFile } from '../../../src/edmx-parser/edmx-file-reader';
 import { parseComplexTypesBase } from '../../../src/edmx-parser/common/edmx-parser';
 import {
@@ -7,11 +8,12 @@ import {
   parseEntityTypes as parseEntityTypesV2,
   parseFunctionImports as parseFunctionImportsV2
 } from '../../../src/edmx-parser/v2';
+import { oDataServiceSpecs } from '../../../../../test-resources/odata-service-specs';
 
 describe('edmx-edmx-parser', () => {
   it('v2: parses edmx file to JSON and coerces properties to arrays', () => {
     const metadataEdmx = readEdmxFile(
-      '../../test-resources/odata-service-specs/v2/API_TEST_SRV/API_TEST_SRV.edmx'
+      resolve(oDataServiceSpecs,'v2','API_TEST_SRV','API_TEST_SRV.edmx')
     );
 
     expect(parseEntitySetsV2(metadataEdmx.root).length).toBe(11);

--- a/packages/generator/src/edmx-parser/v4/edmx-parser.spec.ts
+++ b/packages/generator/src/edmx-parser/v4/edmx-parser.spec.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'path';
 import { readEdmxFile } from '../edmx-file-reader';
 import { parseComplexTypesBase } from '../common/edmx-parser';
 import {
@@ -10,11 +11,12 @@ import {
   parseFunctionImports,
   parseFunctions
 } from '../../../src/edmx-parser/v4';
+import { oDataServiceSpecs } from '../../../../../test-resources/odata-service-specs';
 
 describe('edmx-edmx-parser', () => {
   it('v4: parses edmx file to JSON and coerces properties to arrays', () => {
     const metadataEdmx = readEdmxFile(
-      '../../test-resources/odata-service-specs/v4/API_TEST_SRV/API_TEST_SRV.edmx'
+      resolve(oDataServiceSpecs,'v4','API_TEST_SRV','API_TEST_SRV.edmx')
     );
 
     expect(parseEntitySets(metadataEdmx.root).length).toBe(11);

--- a/packages/generator/src/generator-cli.spec.ts
+++ b/packages/generator/src/generator-cli.spec.ts
@@ -1,10 +1,11 @@
 import * as path from 'path';
 import execa = require('execa');
 import * as fs from 'fs-extra';
+import { oDataServiceSpecs } from '../../../test-resources/odata-service-specs';
 
 describe('generator-cli', () => {
   const pathToGenerator = path.resolve(__dirname, 'generator-cli.ts');
-  const inputDir = '../../test-resources/odata-service-specs/v2/API_TEST_SRV/';
+  const inputDir = path.resolve(oDataServiceSpecs,'v2','API_TEST_SRV');
   const outputDir = path.resolve(__dirname, '../test/generator-test-output');
 
   beforeEach(() => {

--- a/packages/generator/src/generator.spec.ts
+++ b/packages/generator/src/generator.spec.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'path';
 import { FunctionDeclaration, SourceFile } from 'ts-morph';
 import { createOptions } from '../test/test-util/create-generator-options';
 import {
@@ -5,6 +6,7 @@ import {
   getFunctionImportDeclarations,
   getGeneratedFiles
 } from '../test/test-util/generator';
+import { oDataServiceSpecs } from '../../../test-resources/odata-service-specs';
 import { generateProject } from './generator';
 import { GeneratorOptions } from './generator-options';
 import * as csnGeneration from './service/csn';
@@ -14,7 +16,7 @@ describe('generator', () => {
     it('copies the additional files matching the glob.', async () => {
       const project = await generateProject(
         createOptions({
-          inputDir: '../../test-resources/odata-service-specs/v2/API_TEST_SRV',
+          inputDir:resolve(oDataServiceSpecs,'v2','API_TEST_SRV'),
           additionalFiles: '../../test-resources/*.md'
         })
       );
@@ -31,7 +33,7 @@ describe('generator', () => {
     it('generates the api hub metadata',async ()=>{
       const project = await generateProject(
         createOptions({
-          inputDir: '../../test-resources/odata-service-specs/v2/API_TEST_SRV',
+          inputDir:resolve(oDataServiceSpecs,'v2','API_TEST_SRV'),
           generateSdkMetadata:true
         })
       );
@@ -46,8 +48,7 @@ describe('generator', () => {
   });
   describe('edmx-to-csn', () => {
     const testGeneratorOptions: GeneratorOptions = createOptions({
-      inputDir:
-        '../../test-resources/odata-service-specs/v2/API_TEST_SRV/API_TEST_SRV.edmx',
+      inputDir:resolve(oDataServiceSpecs,'v2','API_TEST_SRV','API_TEST_SRV.edmx'),
       outputDir: 'foo',
       generateCSN: true
     });

--- a/packages/generator/src/service-generator.spec.ts
+++ b/packages/generator/src/service-generator.spec.ts
@@ -1,4 +1,6 @@
+import { resolve } from 'path';
 import { createOptions } from '../test/test-util/create-generator-options';
+import { oDataServiceSpecs } from '../../../test-resources/odata-service-specs';
 import { GlobalNameFormatter } from './global-name-formatter';
 import { ServiceMapping } from './service-mapping';
 import { VdmReturnTypeCategory, VdmProperty } from './vdm-types';
@@ -11,7 +13,7 @@ describe('service-generator', () => {
         const serviceMetadata = parseService(
           {
             edmxPath:
-              '../../test-resources/odata-service-specs/v2/API_TEST_SRV/API_TEST_SRV.edmx'
+              resolve(oDataServiceSpecs,'v2','API_TEST_SRV','API_TEST_SRV.edmx')
           },
           createOptions(),
           {},
@@ -30,7 +32,7 @@ describe('service-generator', () => {
         const serviceMetadata = parseService(
           {
             edmxPath:
-              '../../test-resources/odata-service-specs/v2/API_TEST_SRV/API_TEST_SRV.edmx'
+              resolve(oDataServiceSpecs,'v2','API_TEST_SRV','API_TEST_SRV.edmx')
           },
           createOptions(),
           {
@@ -54,8 +56,8 @@ describe('service-generator', () => {
         const services = parseAllServices(
           createOptions({
             inputDir:
-              '../../test-resources/odata-service-specs/v2/API_TEST_SRV',
-            useSwagger: false
+            resolve(oDataServiceSpecs,'v2','API_TEST_SRV'),
+        useSwagger: false
           })
         );
 
@@ -70,8 +72,8 @@ describe('service-generator', () => {
         const services = parseAllServices(
           createOptions({
             inputDir:
-              '../../test-resources/odata-service-specs/v2/API_TEST_SRV',
-            useSwagger: true
+            resolve(oDataServiceSpecs,'v2','API_TEST_SRV'),
+        useSwagger: true
           })
         );
 
@@ -84,7 +86,7 @@ describe('service-generator', () => {
       it('entity properties are read correctly', () => {
         const services = parseAllServices(
           createOptions({
-            inputDir: '../../test-resources/odata-service-specs/v2/API_TEST_SRV'
+            inputDir: resolve(oDataServiceSpecs,'v2','API_TEST_SRV')
           })
         );
         const properties = services[0].entities.find(
@@ -132,7 +134,7 @@ describe('service-generator', () => {
       it('entities are read correctly', () => {
         const services = parseAllServices(
           createOptions({
-            inputDir: '../../test-resources/odata-service-specs/v2/API_TEST_SRV'
+            inputDir: resolve(oDataServiceSpecs,'v2','API_TEST_SRV')
           })
         );
 
@@ -216,7 +218,7 @@ describe('service-generator', () => {
       it('complex types are parsed correctly', () => {
         const services = parseAllServices(
           createOptions({
-            inputDir: '../../test-resources/odata-service-specs/v2/API_TEST_SRV'
+            inputDir: resolve(oDataServiceSpecs,'v2','API_TEST_SRV')
           })
         );
 
@@ -247,7 +249,7 @@ describe('service-generator', () => {
         const services = parseAllServices(
           createOptions({
             inputDir:
-              '../../test-resources/odata-service-specs/v2/API_TEST_SRV',
+              resolve(oDataServiceSpecs,'v2','API_TEST_SRV'),
             useSwagger: false
           })
         );
@@ -278,7 +280,7 @@ describe('service-generator', () => {
         const services = parseAllServices(
           createOptions({
             inputDir:
-              '../../test-resources/odata-service-specs/v2/API_TEST_SRV',
+              resolve(oDataServiceSpecs,'v2','API_TEST_SRV'),
             useSwagger: false
           })
         );
@@ -313,7 +315,7 @@ describe('service-generator', () => {
         const services = parseAllServices(
           createOptions({
             inputDir:
-              '../../test-resources/odata-service-specs/v2/API_TEST_SRV',
+              resolve(oDataServiceSpecs,'v2','API_TEST_SRV'),
             useSwagger: false
           })
         );
@@ -329,7 +331,7 @@ describe('service-generator', () => {
         const [service] = parseAllServices(
           createOptions({
             inputDir:
-              '../../test-resources/odata-service-specs/v2/API_TEST_SRV',
+              resolve(oDataServiceSpecs,'v2','API_TEST_SRV'),
             useSwagger: false
           })
         );
@@ -361,7 +363,7 @@ describe('service-generator', () => {
         const services = parseAllServices(
           createOptions({
             inputDir:
-              '../../test-resources/odata-service-specs/v2/API_TEST_SRV',
+              resolve(oDataServiceSpecs,'v2','API_TEST_SRV'),
             useSwagger: false
           })
         );
@@ -385,7 +387,7 @@ describe('service-generator', () => {
         const services = parseAllServices(
           createOptions({
             inputDir:
-              '../../test-resources/odata-service-specs/v2/API_TEST_SRV',
+              resolve(oDataServiceSpecs,'v2','API_TEST_SRV'),
             useSwagger: false
           })
         );
@@ -401,7 +403,7 @@ describe('service-generator', () => {
         const services = parseAllServices(
           createOptions({
             inputDir:
-              '../../test-resources/odata-service-specs/v2/API_MULTIPLE_SCHEMAS_SRV',
+            resolve(oDataServiceSpecs,'v2','API_MULTIPLE_SCHEMAS_SRV'),
             useSwagger: false
           })
         );
@@ -416,7 +418,7 @@ describe('service-generator', () => {
       it('enum property is read correctly', () => {
         const services = parseAllServices(
           createOptions({
-            inputDir: '../../test-resources/odata-service-specs/v4/API_TEST_SRV'
+            inputDir: resolve(oDataServiceSpecs,'v4','API_TEST_SRV')
           })
         );
         const properties = services[0].entities.find(
@@ -446,7 +448,7 @@ describe('service-generator', () => {
         const [service] = parseAllServices(
           createOptions({
             inputDir:
-              '../../test-resources/odata-service-specs/v4/API_TEST_SRV',
+              resolve(oDataServiceSpecs,'v4','API_TEST_SRV'),
             useSwagger: false
           })
         );
@@ -465,7 +467,7 @@ describe('service-generator', () => {
         const services = parseAllServices(
           createOptions({
             inputDir:
-              '../../test-resources/odata-service-specs/v4/API_TEST_SRV',
+              resolve(oDataServiceSpecs,'v4','API_TEST_SRV'),
             useSwagger: false
           })
         );

--- a/packages/generator/src/swagger-parser/swagger-parser.spec.ts
+++ b/packages/generator/src/swagger-parser/swagger-parser.spec.ts
@@ -1,10 +1,12 @@
+import { resolve } from 'path';
+import { oDataServiceSpecs } from '../../../../test-resources/odata-service-specs';
 import { readSwaggerFile } from './swagger-parser';
 
 describe('swagger-parser', () => {
   it('parseSwaggerFromPath should parse service info', () => {
     const json = readSwaggerFile(
-      '../../test-resources/odata-service-specs/v2/API_TEST_SRV/API_TEST_SRV.json'
-    );
+    resolve(oDataServiceSpecs,'v2','API_TEST_SRV','API_TEST_SRV.json')
+  );
     expect(json).toBeDefined();
     expect(json.info).toEqual({
       title: 'Test Service Title (Swagger)',

--- a/packages/generator/test/test-util/generator.ts
+++ b/packages/generator/test/test-util/generator.ts
@@ -1,6 +1,8 @@
+import { resolve } from 'path';
 import { ClassDeclaration, FunctionDeclaration, SourceFile } from 'ts-morph';
 import { ODataVersion } from '@sap-cloud-sdk/util';
 import { generateProject } from '../../src';
+import { oDataServiceSpecs } from '../../../../test-resources/odata-service-specs';
 import { createOptions } from './create-generator-options';
 
 export function checkStaticProperties(entityClass: ClassDeclaration): void {
@@ -23,7 +25,7 @@ export async function getGeneratedFiles(
 ): Promise<SourceFile[]> {
   const project = await generateProject(
     createOptions({
-      inputDir: `../../test-resources/odata-service-specs/${oDataVersion}/API_TEST_SRV`,
+      inputDir: resolve(oDataServiceSpecs,oDataVersion,'API_TEST_SRV'),
       useSwagger: false
     })
   );


### PR DESCRIPTION
In the sdk metadata PR I introduced a `index.ts` giving the location of the OData service specs. Using this file one can get rid of the hard coded file paths which makes the code more resilient to refactoring in the future. Also due to operating system differences in the file paths it is always better to use `resolve` to build paths for read methods.