### PR TITLE
improve pipeline

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -10,7 +10,7 @@ jobs:
   push-to-documentation-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Add key
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
           - os: macos-latest
             node-version: 10.x
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v2
@@ -44,8 +44,8 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
       - uses: actions/cache@v2
@@ -79,8 +79,8 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
       - uses: actions/cache@v2
@@ -100,8 +100,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests, checks]
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
       - uses: actions/cache@v2
@@ -128,11 +128,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests, checks]
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+            **/dist
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}    
       - run: yarn install --frozen-lockfile
+        if: steps.cache.outputs.cache-hit != 'true'
+      - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
+        if: steps.cache.outputs.cache-hit == 'true'
       - uses: ./.github/actions/get-changelog
         name: Get Changelog
         id: get-changelog 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,8 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
-      - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
-        run: |
-          yarn install --frozen-lockfile
-          echo "test if cache hits"
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
       - run: yarn test:unit
         env:
           SANDBOX_TOKEN: ${{ secrets.API_HUB_SANDBOX_TOKEN }}
@@ -56,7 +54,7 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+      - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - run: yarn lint
         name: Static Code Check
@@ -89,7 +87,7 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+      - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile && echo "it didnt hit"
       - run: yarn test:e2e
   canary-release:
@@ -109,7 +107,7 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+      - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Canary Release
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
             */*/node_modules
             **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn test:e2e   
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,7 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile
       - run: yarn test:unit
         env:
           SANDBOX_TOKEN: ${{ secrets.API_HUB_SANDBOX_TOKEN }}
@@ -52,7 +51,7 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-        run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile
       - run: yarn lint
         name: Static Code Check
       - run: yarn check:test-service
@@ -83,7 +82,7 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-        run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile
       - run: yarn test:e2e
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
@@ -101,7 +100,7 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-        run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile
       - name: Canary Release
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
+        if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
       - run: yarn test:unit
         env:
           SANDBOX_TOKEN: ${{ secrets.API_HUB_SANDBOX_TOKEN }}
@@ -54,6 +55,7 @@ jobs:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
+        if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
       - run: yarn lint
         name: Static Code Check
       - run: yarn check:test-service
@@ -86,6 +88,7 @@ jobs:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
+        if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
       - run: yarn test:e2e
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
@@ -105,6 +108,7 @@ jobs:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
+        if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
       - name: Canary Release
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since ${{ github.event.pull_request.base.ref }}
+      - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn test:unit
         env:
@@ -58,7 +58,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since ${{ github.event.pull_request.base.ref }}
+      - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn lint
         name: Static Code Check
@@ -93,7 +93,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since ${{ github.event.pull_request.base.ref }}
+      - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
@@ -114,7 +114,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since ${{ github.event.pull_request.base.ref }}
+      - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
       - name: Canary Release
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,16 +21,13 @@ jobs:
             node-version: 10.x
     steps:
       - uses: actions/checkout@v1
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/cache@v2
         id: cache
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: '**/node_modules'
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -43,16 +40,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
       - uses: actions/cache@v2
         id: cache
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -76,16 +70,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
       - uses: actions/cache@v2
         id: cache
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile && echo "it didnt hit"
@@ -96,16 +87,13 @@ jobs:
     needs: [tests, checks]
     steps:
       - uses: actions/checkout@v1
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
       - uses: actions/cache@v2
         id: cache
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: '**/node_modules'
+          path: node_modules
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: '**/node_modules'
+          path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: '**/node_modules'
+          path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile && echo "it didnt hit"
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: '**/node_modules'
+          path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,10 @@ jobs:
           path: |
             node_modules
             */*/node_modules
+            **/dist
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
+        if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn test:unit
         env:
           SANDBOX_TOKEN: ${{ secrets.API_HUB_SANDBOX_TOKEN }}
@@ -50,8 +52,10 @@ jobs:
           path: |
             node_modules
             */*/node_modules
+            **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
+        if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn lint
         name: Static Code Check
       - run: yarn check:test-service
@@ -81,8 +85,10 @@ jobs:
           path: |
             node_modules
             */*/node_modules
+            **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
+        if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn test:e2e
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
@@ -99,8 +105,10 @@ jobs:
           path: |
             node_modules
             */*/node_modules
+            **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
+        if: steps.cache.outputs.cache-hit != 'true'
       - name: Canary Release
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
-      - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+      - name: Does this change?
+        if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - run: yarn test:unit
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since main
+      - run: yarn lerna run compile --since ${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn test:unit
         env:
@@ -58,7 +58,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since main
+      - run: yarn lerna run compile --since ${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn lint
         name: Static Code Check
@@ -93,7 +93,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since main
+      - run: yarn lerna run compile --since ${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
@@ -114,7 +114,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since main
+      - run: yarn lerna run compile --since ${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
       - name: Canary Release
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,7 @@ jobs:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
-        run: echo "it didn't hit"
+        run: yarn install --frozen-lockfile && echo "it didnt hit"
       - run: yarn test:e2e
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-        if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+      - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
       - run: yarn test:unit
         env:
           SANDBOX_TOKEN: ${{ secrets.API_HUB_SANDBOX_TOKEN }}
@@ -54,8 +54,8 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-        if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+      - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
       - run: yarn lint
         name: Static Code Check
       - run: yarn check:test-service
@@ -87,8 +87,8 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-        if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+      - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
       - run: yarn test:e2e
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
@@ -107,8 +107,8 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-        if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+      - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
       - name: Canary Release
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,6 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - run: yarn lint
         name: Static Code Check
@@ -84,7 +83,6 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - run: yarn test:e2e
   canary-release:
@@ -103,7 +101,6 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Canary Release
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,11 +94,11 @@ jobs:
             */*/node_modules
             **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn test:e2e   
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
+      - run: yarn test:e2e     
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,7 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
-      - name: Does this change?
-        if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
+      - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - run: yarn test:unit
         env:
@@ -90,6 +89,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
+        run: echo "it didn't hit"
       - run: yarn test:e2e
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,7 @@ jobs:
             node-version: 10.x
     steps:
       - uses: actions/checkout@v2 
-        run: git fetch --depth=1
-        run: git fetch --depth=1
+      - run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
@@ -47,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 
-        run: git fetch --depth=1
+      - run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
@@ -83,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 
-        run: git fetch --depth=1
+      - run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
@@ -105,7 +104,7 @@ jobs:
     needs: [tests, checks]
     steps:
       - uses: actions/checkout@v2 
-        run: git fetch --depth=1
+      - run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
@@ -134,7 +133,7 @@ jobs:
     needs: [tests, checks]
     steps:
       - uses: actions/checkout@v2 
-        run: git fetch --depth=1
+      - run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
+      - run: yarn lerna run compile --since main
+        if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn test:unit
         env:
           SANDBOX_TOKEN: ${{ secrets.API_HUB_SANDBOX_TOKEN }}
@@ -56,6 +58,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
+      - run: yarn lerna run compile --since main
+        if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn lint
         name: Static Code Check
       - run: yarn check:test-service
@@ -89,7 +93,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn test:e2e
+      - run: yarn lerna run compile --since main
+        if: steps.cache.outputs.cache-hit == 'true'
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
@@ -109,6 +114,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
+      - run: yarn lerna run compile --since main
+        if: steps.cache.outputs.cache-hit == 'true'
       - name: Canary Release
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,9 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: '**/node_modules'
+          path: |
+            node_modules
+            */*/node_modules
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -46,7 +48,9 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: '**/node_modules'
+          path: |
+            node_modules
+            */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -76,7 +80,9 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: '**/node_modules'
+          path: |
+            node_modules
+            */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -93,7 +99,9 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: '**/node_modules'
+          path: |
+            node_modules
+            */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
-        run: yarn install --frozen-lockfile && echo "it didnt hit"
+        run: yarn install --frozen-lockfile
       - run: yarn test:e2e
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
@@ -116,7 +116,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - uses: ./.github/actions/get-changelog
         name: Get Changelog
-        id: get-changelog
+        id: get-changelog 
       - uses: actions/create-release@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
           - os: macos-latest
             node-version: 10.x
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2 
+        run: git fetch --depth=1
+        run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
@@ -44,7 +46,8 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2 
+        run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
@@ -79,7 +82,8 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2 
+        run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
@@ -100,7 +104,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests, checks]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2 
+        run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
@@ -128,7 +133,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests, checks]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2 
+        run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: node_modules
+          path: '**/node_modules'
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: node_modules
+          path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: node_modules
+          path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: node_modules
+          path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.cache.cache-hit != 'true'
         run: yarn install --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             **/dist
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit == 'false'
       - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn test:unit
@@ -59,7 +59,7 @@ jobs:
             **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit == 'false'
       - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn lint
@@ -95,7 +95,7 @@ jobs:
             **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit == 'false'
       - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn test:e2e     
@@ -118,7 +118,7 @@ jobs:
             **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit == 'false'
       - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
       - name: Canary Release
@@ -147,7 +147,7 @@ jobs:
             **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}    
       - run: yarn install --frozen-lockfile
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit == 'false'
       - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
         if: steps.cache.outputs.cache-hit == 'true'
       - uses: ./.github/actions/get-changelog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - if: steps.yarn-cache-dir-path.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+        run: |
+          yarn install --frozen-lockfile
+          echo "test if cache hits"
       - run: yarn test:unit
         env:
           SANDBOX_TOKEN: ${{ secrets.API_HUB_SANDBOX_TOKEN }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ jobs:
   stable-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
       - run: yarn install --frozen-lockfile

--- a/packages/cli/src/commands/add-approuter.ts
+++ b/packages/cli/src/commands/add-approuter.ts
@@ -10,7 +10,7 @@ import {
   getProjectNameFromManifest,
   getTemplatePaths
 } from '../utils';
-
+// some diff
 export default class AddApprouter extends Command {
   static description =
     'Setup your Cloud Foundry app to authenticate through the app router';

--- a/packages/cli/src/commands/add-approuter.ts
+++ b/packages/cli/src/commands/add-approuter.ts
@@ -10,7 +10,7 @@ import {
   getProjectNameFromManifest,
   getTemplatePaths
 } from '../utils';
-
+// dif
 export default class AddApprouter extends Command {
   static description =
     'Setup your Cloud Foundry app to authenticate through the app router';

--- a/packages/cli/src/commands/add-approuter.ts
+++ b/packages/cli/src/commands/add-approuter.ts
@@ -10,7 +10,7 @@ import {
   getProjectNameFromManifest,
   getTemplatePaths
 } from '../utils';
-// some diff
+
 export default class AddApprouter extends Command {
   static description =
     'Setup your Cloud Foundry app to authenticate through the app router';

--- a/packages/cli/src/commands/add-approuter.ts
+++ b/packages/cli/src/commands/add-approuter.ts
@@ -10,7 +10,7 @@ import {
   getProjectNameFromManifest,
   getTemplatePaths
 } from '../utils';
-// dif
+
 export default class AddApprouter extends Command {
   static description =
     'Setup your Cloud Foundry app to authenticate through the app router';


### PR DESCRIPTION
## Changes
- `yarn install --frozen-lockfile` is now only run if changes to the `yarn.lock` were made
- we don't cache the `yarn` cache anymore, instead, we cache `node_modules` and our transpiled typescript (e.g. `**/dist`)
- if the `yarn.lock` didn't change, we only compile the packages that were changed, with `yarn lerna run compile --since origin/<branch>` (e.g. `origin/main`)
- update all standard actions to `@v2` from `@v1`

## Benefits
- Average 1min faster, because `yarn install` becomes redundant in most cases
- Especially faster when multiple build workflows are queued, 5x`yarn install` less/workflow results in a lot less resource usage

## Findings
- The macOS environment is very flaky, which results in random test durations, this is apparently due to GitHub limitations
- `build once` (caching the entire repo after `yarn install`) is good from a theoretical standpoint, but takes a ridiculous amount of time and is therefore not recommended, [example](https://github.com/SAP/cloud-sdk-js/actions/runs/665749539)
- caching the yarn cache as we did so far accelerates `yarn install` a lot, but can be slightly improved because with the current method it is still necessary to run `yarn install` every run on every job

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
