### PR TITLE
fix: pipeline-improvement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             **/dist
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-        if: steps.cache.outputs.cache-hit == 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn lerna run compile --since origin/main
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn test:unit
@@ -59,7 +59,7 @@ jobs:
             **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-        if: steps.cache.outputs.cache-hit == 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn lerna run compile --since origin/main
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn lint
@@ -95,7 +95,7 @@ jobs:
             **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-        if: steps.cache.outputs.cache-hit == 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn lerna run compile --since origin/main
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn test:e2e     
@@ -118,7 +118,7 @@ jobs:
             **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
-        if: steps.cache.outputs.cache-hit == 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn lerna run compile --since origin/main
         if: steps.cache.outputs.cache-hit == 'true'
       - name: Canary Release
@@ -147,7 +147,7 @@ jobs:
             **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}    
       - run: yarn install --frozen-lockfile
-        if: steps.cache.outputs.cache-hit == 'false'
+        if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn lerna run compile --since origin/main
         if: steps.cache.outputs.cache-hit == 'true'
       - uses: ./.github/actions/get-changelog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit == 'false'
-      - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
+      - run: yarn lerna run compile --since origin/main
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn test:unit
         env:
@@ -60,7 +60,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit == 'false'
-      - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
+      - run: yarn lerna run compile --since origin/main
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn lint
         name: Static Code Check
@@ -96,7 +96,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit == 'false'
-      - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
+      - run: yarn lerna run compile --since origin/main
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn test:e2e     
   canary-release:
@@ -119,7 +119,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit == 'false'
-      - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
+      - run: yarn lerna run compile --since origin/main
         if: steps.cache.outputs.cache-hit == 'true'
       - name: Canary Release
         run: |
@@ -148,7 +148,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}    
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit == 'false'
-      - run: yarn lerna run compile --since origin/${{ github.event.pull_request.base.ref }}
+      - run: yarn lerna run compile --since origin/main
         if: steps.cache.outputs.cache-hit == 'true'
       - uses: ./.github/actions/get-changelog
         name: Get Changelog

--- a/packages/cli/src/commands/add-approuter.ts
+++ b/packages/cli/src/commands/add-approuter.ts
@@ -26,7 +26,7 @@ export default class AddApprouter extends Command {
       description: 'Show help for the add-approuter command.'
     })
   };
-// trigger diff
+
   static args = [
     {
       name: 'projectDir',

--- a/packages/cli/src/commands/add-approuter.ts
+++ b/packages/cli/src/commands/add-approuter.ts
@@ -26,7 +26,7 @@ export default class AddApprouter extends Command {
       description: 'Show help for the add-approuter command.'
     })
   };
-
+// trigger diff
   static args = [
     {
       name: 'projectDir',


### PR DESCRIPTION
- Fixes the branch reference (previous one relied on `pull_request` event, which passes the pipeline in a pull request, but fails when pushing to main
- Change `== 'false'` to `!= 'true'`, `steps.outputs.cache.cache-hit` doesn't return `false` when no cache is hit, instead it returns `null`, already reported [bug](https://github.com/actions/cache/issues/533)

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
