### PR TITLE
feat: Use CSRF token in OpenAPI request builder by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 
 ## New Functionality
 
-- [http-client] Added an option to the generic http client, so users are able to delegate the csrf token handling for non-get requests.
+- [http-client] Add a `fetchCsrfToken` option to `executeHttpRequest` to allow automatic fetching of CSRF tokens for write operations.
+- [openapi-generator] Fetch CSRF tokens for write operations automatically.
 
 ## Improvements
 

--- a/packages/core/src/openapi/openapi-request-builder.spec.ts
+++ b/packages/core/src/openapi/openapi-request-builder.spec.ts
@@ -15,13 +15,17 @@ describe('openapi-request-builder', () => {
   it('executeRaw executes a request without parameters', () => {
     const requestBuilder = new OpenApiRequestBuilder('get', '/test');
     requestBuilder.executeRaw(destination);
-    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(destination, {
-      method: 'get',
-      url: '/test',
-      headers: {},
-      params: undefined,
-      data: undefined
-    });
+    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(
+      destination,
+      {
+        method: 'get',
+        url: '/test',
+        headers: {},
+        params: undefined,
+        data: undefined
+      },
+      { fetchCsrfToken: false }
+    );
   });
 
   it('executeRaw executes a request with query parameters', () => {
@@ -31,15 +35,19 @@ describe('openapi-request-builder', () => {
       }
     });
     requestBuilder.executeRaw(destination);
-    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(destination, {
-      method: 'get',
-      url: '/test',
-      headers: {},
-      params: {
-        limit: 100
+    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(
+      destination,
+      {
+        method: 'get',
+        url: '/test',
+        headers: {},
+        params: {
+          limit: 100
+        },
+        data: undefined
       },
-      data: undefined
-    });
+      { fetchCsrfToken: false }
+    );
   });
 
   it('executeRaw executes a request with body', () => {
@@ -49,15 +57,19 @@ describe('openapi-request-builder', () => {
       }
     });
     requestBuilder.executeRaw(destination);
-    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(destination, {
-      method: 'post',
-      url: '/test',
-      headers: {},
-      params: undefined,
-      data: {
-        limit: 100
-      }
-    });
+    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(
+      destination,
+      {
+        method: 'post',
+        url: '/test',
+        headers: {},
+        params: undefined,
+        data: {
+          limit: 100
+        }
+      },
+      { fetchCsrfToken: true }
+    );
   });
 
   it('addCustomHeaders', () => {
@@ -65,13 +77,17 @@ describe('openapi-request-builder', () => {
     requestBuilder
       .addCustomHeaders({ myCustomHeader: 'custom-header' })
       .executeRaw(destination);
-    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(destination, {
-      method: 'get',
-      url: '/test',
-      headers: { mycustomheader: 'custom-header' },
-      params: undefined,
-      data: undefined
-    });
+    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(
+      destination,
+      {
+        method: 'get',
+        url: '/test',
+        headers: { mycustomheader: 'custom-header' },
+        params: undefined,
+        data: undefined
+      },
+      { fetchCsrfToken: false }
+    );
   });
 
   it('throws an error if the path parameters do not match the path pattern', async () => {
@@ -91,12 +107,16 @@ describe('openapi-request-builder', () => {
       pathParameters: { id: '#test' }
     });
     requestBuilder.executeRaw(destination);
-    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(destination, {
-      method: 'get',
-      url: '/test/%23test',
-      headers: {},
-      params: undefined,
-      data: undefined
-    });
+    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(
+      destination,
+      {
+        method: 'get',
+        url: '/test/%23test',
+        headers: {},
+        params: undefined,
+        data: undefined
+      },
+      { fetchCsrfToken: false }
+    );
   });
 });

--- a/packages/core/src/openapi/openapi-request-builder.ts
+++ b/packages/core/src/openapi/openapi-request-builder.ts
@@ -59,6 +59,7 @@ export class OpenApiRequestBuilder<ResponseT = any> {
         params: this.parameters?.queryParameters,
         data: this.parameters?.body
       },
+      // TODO: Remove this in v 2.0, when this becomes true becomes the default
       { fetchCsrfToken }
     );
   }

--- a/packages/core/src/openapi/openapi-request-builder.ts
+++ b/packages/core/src/openapi/openapi-request-builder.ts
@@ -47,13 +47,20 @@ export class OpenApiRequestBuilder<ResponseT = any> {
   async executeRaw(
     destination: Destination | DestinationNameAndJwt
   ): Promise<HttpResponse> {
-    return executeHttpRequest(destination, {
-      method: this.method,
-      url: this.getPath(),
-      headers: this.customHeaders,
-      params: this.parameters?.queryParameters,
-      data: this.parameters?.body
-    });
+    const fetchCsrfToken = ['post', 'put', 'patch', 'delete'].includes(
+      this.method.toLowerCase()
+    );
+    return executeHttpRequest(
+      destination,
+      {
+        method: this.method,
+        url: this.getPath(),
+        headers: this.customHeaders,
+        params: this.parameters?.queryParameters,
+        data: this.parameters?.body
+      },
+      { fetchCsrfToken }
+    );
   }
 
   /**

--- a/test-resources/openapi-service-specs/test-service.json
+++ b/test-resources/openapi-service-specs/test-service.json
@@ -24,7 +24,6 @@
     }
   ],
   "paths": {
-    
     "/entities": {
       "get": {
         "tags": ["entity"],

--- a/test-resources/openapi-service-specs/test-service.json
+++ b/test-resources/openapi-service-specs/test-service.json
@@ -24,6 +24,7 @@
     }
   ],
   "paths": {
+    
     "/entities": {
       "get": {
         "tags": ["entity"],


### PR DESCRIPTION
Fetches a CSRF token before making the modifying request.