### PR TITLE
Fix: force compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since origin/main
+      - run: yarn lerna run compile
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn test:unit
         env:


### PR DESCRIPTION
The compilation fo the `main` branch was skipped withe the option `--since`. Without the compilation, packages like `type-tests`/`integration-tests` use the old version (cache) of the `core`, making the failing pipeline. 
