### PR TITLE
fix: Use string as default for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 - [odata-generator] Fix a type error of one-to-one navigation properties, so they can set `null` as valid values.
 - [core] Fix a runtime error of `fromJson` function, when passing an object containing one-to-one navigation properties with `null` value.
+- [openapi-generator] Use string as default type for enums.
 
 
 # 1.40.0

--- a/packages/openapi-generator/src/parser/schema.spec.ts
+++ b/packages/openapi-generator/src/parser/schema.spec.ts
@@ -116,6 +116,16 @@ describe('parseSchema', () => {
     });
   });
 
+  it("parses enum schema with 'string' as default", () => {
+    const schema: OpenAPIV3.SchemaObject = {
+      enum: ['one', 'two', 'three']
+    };
+    expect(parseSchema(schema)).toEqual({
+      type: 'string',
+      enum: ["'one'", "'two'", "'three'"]
+    });
+  });
+
   it('parses oneOf, anyOf, allOf schemas', () => {
     const schema: OpenAPIV3.SchemaObject = {
       oneOf: [

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -143,7 +143,7 @@ function parseObjectSchemaProperties(
 function parseEnumSchema(
   schema: OpenAPIV3.NonArraySchemaObject
 ): OpenApiEnumSchema {
-  const type = getType(schema.type);
+  const type = schema.type ? getType(schema.type) : 'string';
   return {
     type,
     enum: (schema.enum || []).map(entry =>


### PR DESCRIPTION
Use string as a default for enums.