### PR TITLE
fix: Double encoding of filter parameters in batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 - [odata-generator] Fix a type error of one-to-one navigation properties, so they can set `null` as valid values.
 - [core] Fix a runtime error of `fromJson` function, when passing an object containing one-to-one navigation properties with `null` value.
+- [batch] Fix wrong double encoding of filter values.
 
 
 # 1.40.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 - [odata-generator] Fix a type error of one-to-one navigation properties, so they can set `null` as valid values.
 - [core] Fix a runtime error of `fromJson` function, when passing an object containing one-to-one navigation properties with `null` value.
-- [batch] Fix wrong double encoding of filter values.
+- [odata-batch] Fix wrong double encoding of filter values in batch requests.
 - [openapi-generator] Use string as default type for enums.
 
 

--- a/packages/core/src/odata-common/request-builder/batch/__snapshots__/batch-request-serializer.spec.ts.snap
+++ b/packages/core/src/odata-common/request-builder/batch/__snapshots__/batch-request-serializer.spec.ts.snap
@@ -201,7 +201,7 @@ exports[`batch request serializer serializeRequest serializes getAll request wit
 "Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-GET /sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$format=json&$filter=(StringProperty%20eq%20'test') HTTP/1.1
+GET /sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$format=json&$filter=(StringProperty eq 'test') HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 

--- a/packages/core/src/odata-common/request-builder/batch/batch-request-serializer.spec.ts
+++ b/packages/core/src/odata-common/request-builder/batch/batch-request-serializer.spec.ts
@@ -39,6 +39,10 @@ describe('batch request serializer', () => {
       ).toMatchSnapshot();
     });
 
+    it('encodes user provided filter parameters only once',()=>{
+      expect(serializeRequest(TestEntity.requestBuilder().getAll().filter(TestEntity.STRING_PROPERTY.equals('with EmptySpace')))).toMatch(/filter=\(StringProperty eq 'with%20EmptySpace'\)/);
+    });
+
     it('serializes getAll request with custom headers', () => {
       expect(
         serializeRequest(

--- a/packages/core/src/odata-common/request-builder/batch/batch-request-serializer.spec.ts
+++ b/packages/core/src/odata-common/request-builder/batch/batch-request-serializer.spec.ts
@@ -39,8 +39,14 @@ describe('batch request serializer', () => {
       ).toMatchSnapshot();
     });
 
-    it('encodes user provided filter parameters only once',()=>{
-      expect(serializeRequest(TestEntity.requestBuilder().getAll().filter(TestEntity.STRING_PROPERTY.equals('with EmptySpace')))).toMatch(/filter=\(StringProperty eq 'with%20EmptySpace'\)/);
+    it('encodes user provided filter parameters only once', () => {
+      expect(
+        serializeRequest(
+          TestEntity.requestBuilder()
+            .getAll()
+            .filter(TestEntity.STRING_PROPERTY.equals('with EmptySpace'))
+        )
+      ).toMatch(/filter=\(StringProperty eq 'with%20EmptySpace'\)/);
     });
 
     it('serializes getAll request with custom headers', () => {

--- a/packages/core/src/odata-common/request-builder/batch/batch-request-serializer.ts
+++ b/packages/core/src/odata-common/request-builder/batch/batch-request-serializer.ts
@@ -60,9 +60,9 @@ export function serializeRequest(
     'Content-Type: application/http',
     'Content-Transfer-Encoding: binary',
     '',
-    `${request.requestConfig.method.toUpperCase()} ${encodeURI(
+    `${request.requestConfig.method.toUpperCase()} ${
       getUrl(odataRequest, options.subRequestPathType)
-    )} HTTP/1.1`,
+    } HTTP/1.1`,
     ...(requestHeaders.length ? requestHeaders : ['']),
     '',
     ...getPayload(request),

--- a/packages/core/src/odata-common/request-builder/batch/batch-request-serializer.ts
+++ b/packages/core/src/odata-common/request-builder/batch/batch-request-serializer.ts
@@ -60,9 +60,10 @@ export function serializeRequest(
     'Content-Type: application/http',
     'Content-Transfer-Encoding: binary',
     '',
-    `${request.requestConfig.method.toUpperCase()} ${
-      getUrl(odataRequest, options.subRequestPathType)
-    } HTTP/1.1`,
+    `${request.requestConfig.method.toUpperCase()} ${getUrl(
+      odataRequest,
+      options.subRequestPathType
+    )} HTTP/1.1`,
     ...(requestHeaders.length ? requestHeaders : ['']),
     '',
     ...getPayload(request),


### PR DESCRIPTION
Fix double encoding of filter parameters in batch requests.