### PR TITLE
fix: dist cache overlap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,6 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-            **/dist
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,10 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-            **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since origin/main
+      - run: yarn lerna run compile
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn lint
         name: Static Code Check
@@ -92,11 +91,10 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-            **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since origin/main
+      - run: yarn lerna run compile
         if: steps.cache.outputs.cache-hit == 'true'
       - run: yarn test:e2e
   canary-release:
@@ -115,11 +113,10 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-            **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since origin/main
+      - run: yarn lerna run compile
         if: steps.cache.outputs.cache-hit == 'true'
       - name: Canary Release
         run: |
@@ -144,11 +141,10 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-            **/dist
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
         if: steps.cache.outputs.cache-hit != 'true'
-      - run: yarn lerna run compile --since origin/main
+      - run: yarn lerna run compile
         if: steps.cache.outputs.cache-hit == 'true'
       - uses: ./.github/actions/get-changelog
         name: Get Changelog


### PR DESCRIPTION
## Changes:
- Removes `dist` from the cache in the pipeline
- Transpiles entire code instead of difference to main

## Reason:
If a previous `build` workflow had the same `yarn.lock` and `os`, its `dist` folder got used in the following `build` workflow, which leads to issues if the code had any bugs and worked on different packages than the following `build` workflow (e.g. triggered by a different PR), since only the difference to `origin/main` got transpiled, which can (and did!) lead to an unwanted cache overlap.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
