### PR TITLE
chore: use common copyright header

### DIFF
--- a/packages/core/test/test-util/test-services/v2/multiple-schemas-service/BatchRequest.ts
+++ b/packages/core/test/test-util/test-services/v2/multiple-schemas-service/BatchRequest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/multiple-schemas-service/MultiSchemaTestEntity.ts
+++ b/packages/core/test/test-util/test-services/v2/multiple-schemas-service/MultiSchemaTestEntity.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/multiple-schemas-service/MultiSchemaTestEntityRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v2/multiple-schemas-service/MultiSchemaTestEntityRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/multiple-schemas-service/index.ts
+++ b/packages/core/test/test-util/test-services/v2/multiple-schemas-service/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/BatchRequest.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/BatchRequest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestComplexType.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestComplexType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntity.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntity.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityCircularLinkChild.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityCircularLinkChild.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityCircularLinkChildRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityCircularLinkChildRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityCircularLinkParent.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityCircularLinkParent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityCircularLinkParentRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityCircularLinkParentRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityEndsWith.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityEndsWith.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityEndsWithRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityEndsWithRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityEndsWithSomethingElse.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityEndsWithSomethingElse.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityEndsWithSomethingElseRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityEndsWithSomethingElseRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityLvl2MultiLink.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityLvl2MultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityLvl2MultiLinkRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityLvl2MultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityLvl2SingleLink.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityLvl2SingleLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityLvl2SingleLinkRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityLvl2SingleLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityMultiLink.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityMultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityMultiLinkRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityMultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityOtherMultiLink.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityOtherMultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityOtherMultiLinkRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityOtherMultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntityRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntityRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntitySingleLink.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntitySingleLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestEntitySingleLinkRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestEntitySingleLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestLvl2NestedComplexType.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestLvl2NestedComplexType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/TestNestedComplexType.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/TestNestedComplexType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/Testentity_1.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/Testentity_1.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/Testentity_1RequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/Testentity_1RequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/function-imports.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/function-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v2/test-service/index.ts
+++ b/packages/core/test/test-util/test-services/v2/test-service/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/BatchRequest.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/BatchRequest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestComplexType1.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestComplexType1.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestComplexType2.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestComplexType2.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity1.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity1.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity1RequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity1RequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity2.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity2.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity2RequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity2RequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity3.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity3.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity3RequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity3RequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity4.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity4.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity4RequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEntity4RequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEnumType1.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEnumType1.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEnumType2.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/TestEnumType2.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/action-imports.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/action-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/function-imports.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/function-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/multiple-schemas-service/index.ts
+++ b/packages/core/test/test-util/test-services/v4/multiple-schemas-service/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/BatchRequest.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/BatchRequest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestComplexBaseType.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestComplexBaseType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestComplexType.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestComplexType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntity.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntity.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityCircularLinkChild.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityCircularLinkChild.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityCircularLinkChildRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityCircularLinkChildRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityCircularLinkParent.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityCircularLinkParent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityCircularLinkParentRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityCircularLinkParentRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityEndsWith.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityEndsWith.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityEndsWithRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityEndsWithRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityEndsWithSomethingElse.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityEndsWithSomethingElse.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityEndsWithSomethingElseRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityEndsWithSomethingElseRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityLvl2MultiLink.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityLvl2MultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityLvl2MultiLinkRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityLvl2MultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityLvl2SingleLink.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityLvl2SingleLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityLvl2SingleLinkRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityLvl2SingleLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityLvl3MultiLink.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityLvl3MultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityLvl3MultiLinkRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityLvl3MultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityMultiLink.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityMultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityMultiLinkRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityMultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityOtherMultiLink.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityOtherMultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityOtherMultiLinkRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityOtherMultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntityRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntityRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntitySingleLink.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntitySingleLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEntitySingleLinkRequestBuilder.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEntitySingleLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEnumType.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEnumType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestEnumTypeWithOneMember.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestEnumTypeWithOneMember.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestLvl2NestedComplexType.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestLvl2NestedComplexType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/TestNestedComplexType.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/TestNestedComplexType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/action-imports.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/action-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/function-imports.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/function-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/core/test/test-util/test-services/v4/test-service/index.ts
+++ b/packages/core/test/test-util/test-services/v4/test-service/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/packages/generator/src/file-generator.ts
+++ b/packages/generator/src/file-generator.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { createLogger, getCopyrightHeader } from '@sap-cloud-sdk/util';
+import { codeBlock, createLogger } from '@sap-cloud-sdk/util';
 import { Directory, SourceFile, SourceFileStructure } from 'ts-morph';
 
 const logger = createLogger({
@@ -56,4 +56,15 @@ export function copyFile(
 function addFileComment(content: SourceFileStructure): SourceFileStructure {
   content.leadingTrivia = getCopyrightHeader();
   return content;
+}
+
+// TODO 1728 move to a new package for reduce code duplication.
+function getCopyrightHeader(): string {
+  return codeBlock`
+/*
+ * Copyright (c) ${new Date().getFullYear()} SAP SE or an SAP affiliate company. All rights reserved.
+ *
+ * This is a generated file powered by the SAP Cloud SDK for JavaScript.
+ */
+ `;
 }

--- a/packages/generator/src/file-generator.ts
+++ b/packages/generator/src/file-generator.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { createLogger } from '@sap-cloud-sdk/util';
+import { createLogger, getCopyrightHeader } from '@sap-cloud-sdk/util';
 import { Directory, SourceFile, SourceFileStructure } from 'ts-morph';
 
 const logger = createLogger({
@@ -54,13 +54,6 @@ export function copyFile(
 }
 
 function addFileComment(content: SourceFileStructure): SourceFileStructure {
-  content.leadingTrivia = [
-    '/*',
-    ' * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.',
-    ' *',
-    ' * This is a generated file powered by the SAP Cloud SDK for JavaScript.',
-    ' */',
-    ''
-  ].join('\n');
+  content.leadingTrivia = getCopyrightHeader();
   return content;
 }

--- a/packages/openapi-generator/src/file-writer/create-file.ts
+++ b/packages/openapi-generator/src/file-writer/create-file.ts
@@ -1,6 +1,6 @@
 import { promises } from 'fs';
 import { join } from 'path';
-import { codeBlock, getCopyrightHeader } from '@sap-cloud-sdk/util';
+import { codeBlock } from '@sap-cloud-sdk/util';
 const { writeFile } = promises;
 
 /**
@@ -36,4 +36,15 @@ ${getCopyrightHeader()}
 ${content}
 ` + '\n'
   );
+}
+
+// TODO 1728 move to a new package for reduce code duplication.
+function getCopyrightHeader(): string {
+  return codeBlock`
+/*
+ * Copyright (c) ${new Date().getFullYear()} SAP SE or an SAP affiliate company. All rights reserved.
+ *
+ * This is a generated file powered by the SAP Cloud SDK for JavaScript.
+ */
+ `;
 }

--- a/packages/openapi-generator/src/file-writer/create-file.ts
+++ b/packages/openapi-generator/src/file-writer/create-file.ts
@@ -1,6 +1,6 @@
 import { promises } from 'fs';
 import { join } from 'path';
-import { codeBlock } from '@sap-cloud-sdk/util';
+import { codeBlock, getCopyrightHeader } from '@sap-cloud-sdk/util';
 const { writeFile } = promises;
 
 /**
@@ -32,11 +32,7 @@ export async function createFile(
 function wrapContent(content: string): string {
   return (
     codeBlock`
-/*
- * Copyright (c) ${new Date().getFullYear()} SAP SE or an SAP affiliate company. All rights reserved.
- *
- * This is a generated file powered by the SAP Cloud SDK for JavaScript.
- */
+${getCopyrightHeader()}
 ${content}
 ` + '\n'
   );

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -1,1 +1,13 @@
+import { codeBlock } from './code-block';
+
 export const VALUE_IS_UNDEFINED = 'VALUE_IS_UNDEFINED';
+
+export function getCopyrightHeader(): string {
+  return codeBlock`
+/*
+ * Copyright (c) ${new Date().getFullYear()} SAP SE or an SAP affiliate company. All rights reserved.
+ *
+ * This is a generated file powered by the SAP Cloud SDK for JavaScript.
+ */
+ `;
+}

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -1,13 +1,1 @@
-import { codeBlock } from './code-block';
-
 export const VALUE_IS_UNDEFINED = 'VALUE_IS_UNDEFINED';
-
-export function getCopyrightHeader(): string {
-  return codeBlock`
-/*
- * Copyright (c) ${new Date().getFullYear()} SAP SE or an SAP affiliate company. All rights reserved.
- *
- * This is a generated file powered by the SAP Cloud SDK for JavaScript.
- */
- `;
-}

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airlines.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airlines.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.Airlines = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airlines.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airlines.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/AirlinesRequestBuilder.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/AirlinesRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.AirlinesRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/AirlinesRequestBuilder.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/AirlinesRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/AirportLocation.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/AirportLocation.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.AirportLocation = exports.AirportLocationField = exports.createAirportLocation = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/AirportLocation.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/AirportLocation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airports.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airports.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.Airports = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airports.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/AirportsRequestBuilder.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/AirportsRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.AirportsRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/AirportsRequestBuilder.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/AirportsRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/BatchRequest.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/BatchRequest.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.defaultMicrosoftODataServiceSampleTrippinInMemoryModelsServicePath = exports.changeset = exports.batch = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/BatchRequest.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/BatchRequest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/City.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/City.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.City = exports.CityField = exports.createCity = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/City.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/City.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/EventLocation.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/EventLocation.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.EventLocation = exports.EventLocationField = exports.createEventLocation = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/EventLocation.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/EventLocation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Location.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Location.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.Location = exports.LocationField = exports.createLocation = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Location.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Location.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/People.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/People.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.People = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/People.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/People.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/PeopleRequestBuilder.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/PeopleRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.PeopleRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/PeopleRequestBuilder.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/PeopleRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/PersonGender.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/PersonGender.js
@@ -1,6 +1,6 @@
 'use strict';
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/PersonGender.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/PersonGender.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Photos.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Photos.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.Photos = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Photos.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Photos.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/PhotosRequestBuilder.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/PhotosRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/action-imports.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/action-imports.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.actionImports = exports.resetDataSource = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/action-imports.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/action-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/function-imports.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/function-imports.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.functionImports = exports.getNearestAirport = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/function-imports.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/function-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/index.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/index.js
@@ -24,7 +24,7 @@ var __exportStar =
   };
 Object.defineProperty(exports, '__esModule', { value: true });
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/index.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/BatchRequest.js
+++ b/test-packages/test-services-e2e/v4/test-service/BatchRequest.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.defaultTestServicePath = exports.changeset = exports.batch = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/BatchRequest.ts
+++ b/test-packages/test-services-e2e/v4/test-service/BatchRequest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/TestEntity.js
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntity.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntity = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/TestEntity.ts
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntity.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/TestEntityLink.js
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntityLink.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityLink = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/TestEntityLink.ts
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntityLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/TestEntityLinkRequestBuilder.js
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntityLinkRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityLinkRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/TestEntityLinkRequestBuilder.ts
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntityLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/TestEntityRequestBuilder.js
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntityRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/TestEntityRequestBuilder.ts
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntityRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/action-imports.js
+++ b/test-packages/test-services-e2e/v4/test-service/action-imports.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.actionImports = exports.createTestEntityByIdReturnId = exports.createTestEntityById = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/action-imports.ts
+++ b/test-packages/test-services-e2e/v4/test-service/action-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/function-imports.js
+++ b/test-packages/test-services-e2e/v4/test-service/function-imports.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.functionImports = exports.returnSapCloudSdk = exports.returnInt = exports.returnCollection = exports.getByKey = exports.getAll = exports.concatStrings = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/function-imports.ts
+++ b/test-packages/test-services-e2e/v4/test-service/function-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/index.js
+++ b/test-packages/test-services-e2e/v4/test-service/index.js
@@ -24,7 +24,7 @@ var __exportStar =
   };
 Object.defineProperty(exports, '__esModule', { value: true });
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services-e2e/v4/test-service/index.ts
+++ b/test-packages/test-services-e2e/v4/test-service/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/multiple-schemas-service/BatchRequest.js
+++ b/test-packages/test-services/v2/multiple-schemas-service/BatchRequest.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.defaultMultipleSchemasServicePath = exports.changeset = exports.batch = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/multiple-schemas-service/BatchRequest.ts
+++ b/test-packages/test-services/v2/multiple-schemas-service/BatchRequest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/multiple-schemas-service/MultiSchemaTestEntity.js
+++ b/test-packages/test-services/v2/multiple-schemas-service/MultiSchemaTestEntity.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.MultiSchemaTestEntity = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/multiple-schemas-service/MultiSchemaTestEntity.ts
+++ b/test-packages/test-services/v2/multiple-schemas-service/MultiSchemaTestEntity.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/multiple-schemas-service/MultiSchemaTestEntityRequestBuilder.js
+++ b/test-packages/test-services/v2/multiple-schemas-service/MultiSchemaTestEntityRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.MultiSchemaTestEntityRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/multiple-schemas-service/MultiSchemaTestEntityRequestBuilder.ts
+++ b/test-packages/test-services/v2/multiple-schemas-service/MultiSchemaTestEntityRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/multiple-schemas-service/index.js
+++ b/test-packages/test-services/v2/multiple-schemas-service/index.js
@@ -24,7 +24,7 @@ var __exportStar =
   };
 Object.defineProperty(exports, '__esModule', { value: true });
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/multiple-schemas-service/index.ts
+++ b/test-packages/test-services/v2/multiple-schemas-service/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/BatchRequest.js
+++ b/test-packages/test-services/v2/test-service/BatchRequest.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.defaultTestServicePath = exports.changeset = exports.batch = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/BatchRequest.ts
+++ b/test-packages/test-services/v2/test-service/BatchRequest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestComplexType.ts
+++ b/test-packages/test-services/v2/test-service/TestComplexType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntity.js
+++ b/test-packages/test-services/v2/test-service/TestEntity.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntity = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntity.ts
+++ b/test-packages/test-services/v2/test-service/TestEntity.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityCircularLinkChild.js
+++ b/test-packages/test-services/v2/test-service/TestEntityCircularLinkChild.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityCircularLinkChild = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityCircularLinkChild.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityCircularLinkChild.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityCircularLinkChildRequestBuilder.js
+++ b/test-packages/test-services/v2/test-service/TestEntityCircularLinkChildRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityCircularLinkChildRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityCircularLinkChildRequestBuilder.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityCircularLinkChildRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityCircularLinkParent.js
+++ b/test-packages/test-services/v2/test-service/TestEntityCircularLinkParent.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityCircularLinkParent = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityCircularLinkParent.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityCircularLinkParent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityCircularLinkParentRequestBuilder.js
+++ b/test-packages/test-services/v2/test-service/TestEntityCircularLinkParentRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityCircularLinkParentRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityCircularLinkParentRequestBuilder.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityCircularLinkParentRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityEndsWith.js
+++ b/test-packages/test-services/v2/test-service/TestEntityEndsWith.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityEndsWith = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityEndsWith.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityEndsWith.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityEndsWithRequestBuilder.js
+++ b/test-packages/test-services/v2/test-service/TestEntityEndsWithRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityEndsWithRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityEndsWithRequestBuilder.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityEndsWithRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityEndsWithSomethingElse.js
+++ b/test-packages/test-services/v2/test-service/TestEntityEndsWithSomethingElse.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityEndsWithSomethingElse = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityEndsWithSomethingElse.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityEndsWithSomethingElse.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityEndsWithSomethingElseRequestBuilder.js
+++ b/test-packages/test-services/v2/test-service/TestEntityEndsWithSomethingElseRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityEndsWithSomethingElseRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityEndsWithSomethingElseRequestBuilder.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityEndsWithSomethingElseRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityLvl2MultiLink.js
+++ b/test-packages/test-services/v2/test-service/TestEntityLvl2MultiLink.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityLvl2MultiLink = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityLvl2MultiLink.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityLvl2MultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityLvl2MultiLinkRequestBuilder.js
+++ b/test-packages/test-services/v2/test-service/TestEntityLvl2MultiLinkRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityLvl2MultiLinkRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityLvl2MultiLinkRequestBuilder.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityLvl2MultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityLvl2SingleLink.js
+++ b/test-packages/test-services/v2/test-service/TestEntityLvl2SingleLink.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityLvl2SingleLink = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityLvl2SingleLink.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityLvl2SingleLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityLvl2SingleLinkRequestBuilder.js
+++ b/test-packages/test-services/v2/test-service/TestEntityLvl2SingleLinkRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityLvl2SingleLinkRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityLvl2SingleLinkRequestBuilder.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityLvl2SingleLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityMultiLink.js
+++ b/test-packages/test-services/v2/test-service/TestEntityMultiLink.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityMultiLink = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityMultiLink.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityMultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityMultiLinkRequestBuilder.js
+++ b/test-packages/test-services/v2/test-service/TestEntityMultiLinkRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityMultiLinkRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityMultiLinkRequestBuilder.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityMultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityOtherMultiLink.js
+++ b/test-packages/test-services/v2/test-service/TestEntityOtherMultiLink.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityOtherMultiLink = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityOtherMultiLink.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityOtherMultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityOtherMultiLinkRequestBuilder.js
+++ b/test-packages/test-services/v2/test-service/TestEntityOtherMultiLinkRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityOtherMultiLinkRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityOtherMultiLinkRequestBuilder.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityOtherMultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityRequestBuilder.js
+++ b/test-packages/test-services/v2/test-service/TestEntityRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntityRequestBuilder.ts
+++ b/test-packages/test-services/v2/test-service/TestEntityRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntitySingleLink.js
+++ b/test-packages/test-services/v2/test-service/TestEntitySingleLink.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntitySingleLink = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntitySingleLink.ts
+++ b/test-packages/test-services/v2/test-service/TestEntitySingleLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntitySingleLinkRequestBuilder.js
+++ b/test-packages/test-services/v2/test-service/TestEntitySingleLinkRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntitySingleLinkRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestEntitySingleLinkRequestBuilder.ts
+++ b/test-packages/test-services/v2/test-service/TestEntitySingleLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestLvl2NestedComplexType.js
+++ b/test-packages/test-services/v2/test-service/TestLvl2NestedComplexType.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestLvl2NestedComplexType = exports.TestLvl2NestedComplexTypeField = exports.createTestLvl2NestedComplexType = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestLvl2NestedComplexType.ts
+++ b/test-packages/test-services/v2/test-service/TestLvl2NestedComplexType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestNestedComplexType.js
+++ b/test-packages/test-services/v2/test-service/TestNestedComplexType.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestNestedComplexType = exports.TestNestedComplexTypeField = exports.createTestNestedComplexType = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/TestNestedComplexType.ts
+++ b/test-packages/test-services/v2/test-service/TestNestedComplexType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/Testentity_1.js
+++ b/test-packages/test-services/v2/test-service/Testentity_1.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.Testentity_1 = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/Testentity_1.ts
+++ b/test-packages/test-services/v2/test-service/Testentity_1.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/Testentity_1RequestBuilder.js
+++ b/test-packages/test-services/v2/test-service/Testentity_1RequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.Testentity_1RequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/Testentity_1RequestBuilder.ts
+++ b/test-packages/test-services/v2/test-service/Testentity_1RequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/function-imports.js
+++ b/test-packages/test-services/v2/test-service/function-imports.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.functionImports = exports.fContinue = exports.createTestComplexType = exports.testFunctionImportMultipleParams = exports.testFunctionImportPost = exports.testFunctionImportGet = exports.testFunctionImportComplexReturnTypeCollection = exports.testFunctionImportUnsupportedEdmTypes = exports.testFunctionImportComplexReturnType = exports.testFunctionImportEntityReturnTypeCollection = exports.testFunctionImportEntityReturnType = exports.testFunctionImportEdmReturnTypeCollection = exports.testFunctionImportEdmReturnType = exports.testFunctionImportNoReturnType = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/function-imports.ts
+++ b/test-packages/test-services/v2/test-service/function-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/index.js
+++ b/test-packages/test-services/v2/test-service/index.js
@@ -24,7 +24,7 @@ var __exportStar =
   };
 Object.defineProperty(exports, '__esModule', { value: true });
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v2/test-service/index.ts
+++ b/test-packages/test-services/v2/test-service/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/BatchRequest.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/BatchRequest.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.defaultMultipleSchemasServicePath = exports.changeset = exports.batch = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/BatchRequest.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/BatchRequest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestComplexType1.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestComplexType1.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestComplexType1 = exports.TestComplexType1Field = exports.createTestComplexType1 = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestComplexType1.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestComplexType1.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestComplexType2.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestComplexType2.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestComplexType2 = exports.TestComplexType2Field = exports.createTestComplexType2 = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestComplexType2.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestComplexType2.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity1.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity1.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntity1 = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity1.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity1.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity1RequestBuilder.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity1RequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntity1RequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity1RequestBuilder.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity1RequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity2.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity2.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntity2 = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity2.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity2.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity2RequestBuilder.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity2RequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntity2RequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity2RequestBuilder.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity2RequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity3.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity3.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntity3 = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity3.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity3.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity3RequestBuilder.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity3RequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntity3RequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity3RequestBuilder.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity3RequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity4.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity4.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntity4 = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity4.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity4.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity4RequestBuilder.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity4RequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntity4RequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEntity4RequestBuilder.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEntity4RequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEnumType1.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEnumType1.js
@@ -1,6 +1,6 @@
 'use strict';
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEnumType1.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEnumType1.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEnumType2.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEnumType2.js
@@ -1,6 +1,6 @@
 'use strict';
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/TestEnumType2.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/TestEnumType2.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/action-imports.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/action-imports.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.actionImports = exports.testActionImportNoParameterComplexReturnType2 = exports.testActionImportNoParameterComplexReturnType1 = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/action-imports.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/action-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/function-imports.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/function-imports.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.functionImports = exports.testFunctionImportEntityReturnType2 = exports.testFunctionImportEntityReturnType1 = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/function-imports.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/function-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/index.js
+++ b/test-packages/test-services/v4/multiple-schemas-service/index.js
@@ -24,7 +24,7 @@ var __exportStar =
   };
 Object.defineProperty(exports, '__esModule', { value: true });
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/multiple-schemas-service/index.ts
+++ b/test-packages/test-services/v4/multiple-schemas-service/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/BatchRequest.js
+++ b/test-packages/test-services/v4/test-service/BatchRequest.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.defaultTestServicePath = exports.changeset = exports.batch = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/BatchRequest.ts
+++ b/test-packages/test-services/v4/test-service/BatchRequest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestComplexBaseType.js
+++ b/test-packages/test-services/v4/test-service/TestComplexBaseType.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestComplexBaseType = exports.TestComplexBaseTypeField = exports.createTestComplexBaseType = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestComplexBaseType.ts
+++ b/test-packages/test-services/v4/test-service/TestComplexBaseType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestComplexType.ts
+++ b/test-packages/test-services/v4/test-service/TestComplexType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntity.js
+++ b/test-packages/test-services/v4/test-service/TestEntity.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntity = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntity.ts
+++ b/test-packages/test-services/v4/test-service/TestEntity.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityCircularLinkChild.js
+++ b/test-packages/test-services/v4/test-service/TestEntityCircularLinkChild.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityCircularLinkChild = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityCircularLinkChild.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityCircularLinkChild.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityCircularLinkChildRequestBuilder.js
+++ b/test-packages/test-services/v4/test-service/TestEntityCircularLinkChildRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityCircularLinkChildRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityCircularLinkChildRequestBuilder.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityCircularLinkChildRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityCircularLinkParent.js
+++ b/test-packages/test-services/v4/test-service/TestEntityCircularLinkParent.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityCircularLinkParent = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityCircularLinkParent.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityCircularLinkParent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityCircularLinkParentRequestBuilder.js
+++ b/test-packages/test-services/v4/test-service/TestEntityCircularLinkParentRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityCircularLinkParentRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityCircularLinkParentRequestBuilder.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityCircularLinkParentRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityEndsWith.js
+++ b/test-packages/test-services/v4/test-service/TestEntityEndsWith.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityEndsWith = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityEndsWith.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityEndsWith.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityEndsWithRequestBuilder.js
+++ b/test-packages/test-services/v4/test-service/TestEntityEndsWithRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityEndsWithRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityEndsWithRequestBuilder.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityEndsWithRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityEndsWithSomethingElse.js
+++ b/test-packages/test-services/v4/test-service/TestEntityEndsWithSomethingElse.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityEndsWithSomethingElse = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityEndsWithSomethingElse.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityEndsWithSomethingElse.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityEndsWithSomethingElseRequestBuilder.js
+++ b/test-packages/test-services/v4/test-service/TestEntityEndsWithSomethingElseRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityEndsWithSomethingElseRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityEndsWithSomethingElseRequestBuilder.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityEndsWithSomethingElseRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityLvl2MultiLink.js
+++ b/test-packages/test-services/v4/test-service/TestEntityLvl2MultiLink.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityLvl2MultiLink = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityLvl2MultiLink.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityLvl2MultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityLvl2MultiLinkRequestBuilder.js
+++ b/test-packages/test-services/v4/test-service/TestEntityLvl2MultiLinkRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityLvl2MultiLinkRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityLvl2MultiLinkRequestBuilder.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityLvl2MultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityLvl2SingleLink.js
+++ b/test-packages/test-services/v4/test-service/TestEntityLvl2SingleLink.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityLvl2SingleLink = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityLvl2SingleLink.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityLvl2SingleLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityLvl2SingleLinkRequestBuilder.js
+++ b/test-packages/test-services/v4/test-service/TestEntityLvl2SingleLinkRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityLvl2SingleLinkRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityLvl2SingleLinkRequestBuilder.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityLvl2SingleLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityLvl3MultiLink.js
+++ b/test-packages/test-services/v4/test-service/TestEntityLvl3MultiLink.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityLvl3MultiLink = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityLvl3MultiLink.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityLvl3MultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityLvl3MultiLinkRequestBuilder.js
+++ b/test-packages/test-services/v4/test-service/TestEntityLvl3MultiLinkRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityLvl3MultiLinkRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityLvl3MultiLinkRequestBuilder.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityLvl3MultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityMultiLink.js
+++ b/test-packages/test-services/v4/test-service/TestEntityMultiLink.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityMultiLink = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityMultiLink.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityMultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityMultiLinkRequestBuilder.js
+++ b/test-packages/test-services/v4/test-service/TestEntityMultiLinkRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityMultiLinkRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityMultiLinkRequestBuilder.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityMultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityOtherMultiLink.js
+++ b/test-packages/test-services/v4/test-service/TestEntityOtherMultiLink.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityOtherMultiLink = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityOtherMultiLink.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityOtherMultiLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityOtherMultiLinkRequestBuilder.js
+++ b/test-packages/test-services/v4/test-service/TestEntityOtherMultiLinkRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityOtherMultiLinkRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityOtherMultiLinkRequestBuilder.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityOtherMultiLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityRequestBuilder.js
+++ b/test-packages/test-services/v4/test-service/TestEntityRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntityRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntityRequestBuilder.ts
+++ b/test-packages/test-services/v4/test-service/TestEntityRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntitySingleLink.js
+++ b/test-packages/test-services/v4/test-service/TestEntitySingleLink.js
@@ -44,7 +44,7 @@ var __assign =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntitySingleLink = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntitySingleLink.ts
+++ b/test-packages/test-services/v4/test-service/TestEntitySingleLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntitySingleLinkRequestBuilder.js
+++ b/test-packages/test-services/v4/test-service/TestEntitySingleLinkRequestBuilder.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestEntitySingleLinkRequestBuilder = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEntitySingleLinkRequestBuilder.ts
+++ b/test-packages/test-services/v4/test-service/TestEntitySingleLinkRequestBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEnumType.js
+++ b/test-packages/test-services/v4/test-service/TestEnumType.js
@@ -1,6 +1,6 @@
 'use strict';
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEnumType.ts
+++ b/test-packages/test-services/v4/test-service/TestEnumType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEnumTypeWithOneMember.js
+++ b/test-packages/test-services/v4/test-service/TestEnumTypeWithOneMember.js
@@ -1,6 +1,6 @@
 'use strict';
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestEnumTypeWithOneMember.ts
+++ b/test-packages/test-services/v4/test-service/TestEnumTypeWithOneMember.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestLvl2NestedComplexType.js
+++ b/test-packages/test-services/v4/test-service/TestLvl2NestedComplexType.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestLvl2NestedComplexType = exports.TestLvl2NestedComplexTypeField = exports.createTestLvl2NestedComplexType = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestLvl2NestedComplexType.ts
+++ b/test-packages/test-services/v4/test-service/TestLvl2NestedComplexType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestNestedComplexType.js
+++ b/test-packages/test-services/v4/test-service/TestNestedComplexType.js
@@ -29,7 +29,7 @@ var __extends =
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.TestNestedComplexType = exports.TestNestedComplexTypeField = exports.createTestNestedComplexType = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/TestNestedComplexType.ts
+++ b/test-packages/test-services/v4/test-service/TestNestedComplexType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/action-imports.js
+++ b/test-packages/test-services/v4/test-service/action-imports.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.actionImports = exports.testActionImportNoParameterEntityReturnType = exports.testActionImportUnsupportedEdmTypes = exports.testActionImportMultipleParameterComplexReturnType = exports.testActionImportNoParameterNoReturnType = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/action-imports.ts
+++ b/test-packages/test-services/v4/test-service/action-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/function-imports.js
+++ b/test-packages/test-services/v4/test-service/function-imports.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.functionImports = exports.testFunctionImportWithDifferentName = exports.testFunctionImportMultipleParams = exports.testFunctionImportComplexReturnTypeCollection = exports.testFunctionImportComplexReturnType = exports.testFunctionImportEntityReturnTypeCollection = exports.testFunctionImportEntityReturnType = exports.testFunctionImportEdmReturnTypeCollection = exports.testFunctionImportEdmReturnType = void 0;
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/function-imports.ts
+++ b/test-packages/test-services/v4/test-service/function-imports.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/index.js
+++ b/test-packages/test-services/v4/test-service/index.js
@@ -24,7 +24,7 @@ var __exportStar =
   };
 Object.defineProperty(exports, '__esModule', { value: true });
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */

--- a/test-packages/test-services/v4/test-service/index.ts
+++ b/test-packages/test-services/v4/test-service/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+ * Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
  *
  * This is a generated file powered by the SAP Cloud SDK for JavaScript.
  */


### PR DESCRIPTION
While working on the docs I realized that the copy right header was there twice and only in one case with the year beeing auto filled. This PR uses a central place and updates the clients to have the new year.

For the review only consider these three files: 

![image](https://user-images.githubusercontent.com/56544999/113875511-1d38c080-97b7-11eb-9b5f-6c5a0ac71d69.png)
