### PR TITLE
feat: support disabling csrf token request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
 
 ## New Functionality
 
-- Support custom axios options for all request builders.
-- Support disabling csrf token request as an option for all request builders.
+- [core] Support custom axios options for all request builders.
+- [core] Support disabling csrf token request as an option for all request builders.
 
 ## Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ## New Functionality
 
 - Support custom axios options for all request builders.
+- Support disabling csrf token request as an option for all request builders.
 
 ## Improvements
 

--- a/packages/core/src/odata-common/request-builder/request-builder-base.ts
+++ b/packages/core/src/odata-common/request-builder/request-builder-base.ts
@@ -132,6 +132,16 @@ export abstract class MethodRequestBuilder<
     return this;
   }
 
+  /**
+   * Replace the default value of fetching csrf token configuration with a given value.
+   * @param fetchCsrfToken The new value of the configuration.
+   * @returns The request builder itself, to facilitate method chaining.
+   */
+  fetchCsrfToken(fetchCsrfToken: boolean): this {
+    this.requestConfig.fetchCsrfToken = fetchCsrfToken;
+    return this;
+  }
+
   build(): ODataRequest<RequestConfigT>;
   build(
     destination: Destination | DestinationNameAndJwt,

--- a/packages/core/src/odata-common/request-builder/request-builder-base.ts
+++ b/packages/core/src/odata-common/request-builder/request-builder-base.ts
@@ -133,12 +133,11 @@ export abstract class MethodRequestBuilder<
   }
 
   /**
-   * Replace the default value of fetching csrf token configuration with a given value.
-   * @param fetchCsrfToken The new value of the configuration.
+   * Skip fetching csrf token for this request, which is typically useful when the csrf token is not required.
    * @returns The request builder itself, to facilitate method chaining.
    */
-  fetchCsrfToken(fetchCsrfToken: boolean): this {
-    this.requestConfig.fetchCsrfToken = fetchCsrfToken;
+  skipCsrfTokenFetching(): this {
+    this.requestConfig.fetchCsrfToken = false;
     return this;
   }
 

--- a/packages/core/src/odata-common/request/odata-request-config.ts
+++ b/packages/core/src/odata-common/request/odata-request-config.ts
@@ -16,7 +16,6 @@ const logger = createLogger({
 export abstract class ODataRequestConfig {
   payload: Record<string, any> | string;
   customServicePath: string;
-  fetchCsrfToken = true;
 
   readonly defaultHeaders: Record<string, any> = {
     'content-type': 'application/json',
@@ -26,6 +25,7 @@ export abstract class ODataRequestConfig {
   private _customHeaders: Record<string, string> = {};
   private _customQueryParameters: Record<string, string> = {};
   private _customRequestConfiguration: Record<string, string> = {};
+  private _fetchCsrfToken = true;
 
   /**
    * @deprecated Since v1.30.0. Use [[defaultHeaders]] instead.
@@ -97,6 +97,14 @@ export abstract class ODataRequestConfig {
 
   get customRequestConfiguration(): Record<string, string> {
     return this._customRequestConfiguration;
+  }
+
+  set fetchCsrfToken(fetchCsrfToken: boolean) {
+    this._fetchCsrfToken = fetchCsrfToken;
+  }
+
+  get fetchCsrfToken(): boolean {
+    return this._fetchCsrfToken;
   }
 
   /**

--- a/packages/core/src/odata-common/request/odata-request.ts
+++ b/packages/core/src/odata-common/request/odata-request.ts
@@ -35,7 +35,6 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
    *
    * @param config - Configuration of the request
    * @param _destination - Destination to setup the request against
-   * @param fetchCsrfToken - Destination to setup the request against
    * @memberof ODataRequest
    */
   constructor(

--- a/packages/core/src/odata-v2/request-builder/create-request-builder.spec.ts
+++ b/packages/core/src/odata-v2/request-builder/create-request-builder.spec.ts
@@ -2,6 +2,7 @@ import nock = require('nock');
 import { v4 as uuid } from 'uuid';
 import {
   defaultDestination,
+  defaultHost,
   mockCreateRequest
 } from '../../../test/test-util/request-mocker';
 import { testEntityResourcePath } from '../../../test/test-util/test-data';
@@ -204,6 +205,30 @@ describe('CreateRequestBuilder', () => {
     ).execute(defaultDestination);
 
     await expect(createRequest).rejects.toThrowErrorMatchingSnapshot();
+  });
+
+  it('create an entity with csrf token request when the option is set to false', async () => {
+    const keyProp = uuid();
+    const stringProp = 'testStr';
+    const postBody = { KeyPropertyGuid: keyProp, StringProperty: stringProp };
+
+    nock(defaultHost)
+      .post(
+        '/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity',
+        postBody
+      )
+      .reply(200, { d: postBody }, {});
+
+    const entity = TestEntity.builder()
+      .keyPropertyGuid(keyProp)
+      .stringProperty(stringProp)
+      .build();
+
+    const actual = await new CreateRequestBuilder(TestEntity, entity)
+      .fetchCsrfToken(false)
+      .execute(defaultDestination);
+
+    testPostRequestOutcome(actual, entity.setOrInitializeRemoteState());
   });
 
   describe('executeRaw', () => {

--- a/packages/core/src/odata-v2/request-builder/create-request-builder.spec.ts
+++ b/packages/core/src/odata-v2/request-builder/create-request-builder.spec.ts
@@ -225,7 +225,7 @@ describe('CreateRequestBuilder', () => {
       .build();
 
     const actual = await new CreateRequestBuilder(TestEntity, entity)
-      .fetchCsrfToken(false)
+      .skipCsrfTokenFetching()
       .execute(defaultDestination);
 
     testPostRequestOutcome(actual, entity.setOrInitializeRemoteState());

--- a/packages/core/src/openapi/openapi-request-builder.spec.ts
+++ b/packages/core/src/openapi/openapi-request-builder.spec.ts
@@ -138,4 +138,23 @@ describe('openapi-request-builder', () => {
       { fetchCsrfToken: false }
     );
   });
+
+  it('will not fetch csrf token when the config is set to false', () => {
+    const requestBuilder = new OpenApiRequestBuilder(
+      'post',
+      '/test'
+    ).fetchCsrfToken(false);
+    requestBuilder.executeRaw(destination);
+    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(
+      destination,
+      {
+        method: 'post',
+        url: '/test',
+        headers: {},
+        params: undefined,
+        data: undefined
+      },
+      { fetchCsrfToken: false }
+    );
+  });
 });

--- a/packages/core/src/openapi/openapi-request-builder.ts
+++ b/packages/core/src/openapi/openapi-request-builder.ts
@@ -19,6 +19,7 @@ export class OpenApiRequestBuilder<ResponseT = any> {
 
   private customHeaders: Record<string, string> = {};
   private customRequestConfiguration: Record<string, string> = {};
+  private _fetchCsrfToken = true;
 
   /**
    * Create an instance of `OpenApiRequestBuilder`.
@@ -61,6 +62,16 @@ export class OpenApiRequestBuilder<ResponseT = any> {
   }
 
   /**
+   * Replace the default value of fetching csrf token configuration with a given value.
+   * @param fetchCsrfToken The new value of the configuration.
+   * @returns The request builder itself, to facilitate method chaining.
+   */
+  fetchCsrfToken(fetchCsrfToken: boolean): this {
+    this._fetchCsrfToken = fetchCsrfToken;
+    return this;
+  }
+
+  /**
    * Execute request and get a raw HttpResponse, including all information about the HTTP response.
    * This especially comes in handy, when you need to access the headers or status code of the response.
    * @param destination Destination to execute the request against.
@@ -69,9 +80,9 @@ export class OpenApiRequestBuilder<ResponseT = any> {
   async executeRaw(
     destination: Destination | DestinationNameAndJwt
   ): Promise<HttpResponse> {
-    const fetchCsrfToken = ['post', 'put', 'patch', 'delete'].includes(
-      this.method.toLowerCase()
-    );
+    const fetchCsrfToken =
+      this._fetchCsrfToken &&
+      ['post', 'put', 'patch', 'delete'].includes(this.method.toLowerCase());
     return executeHttpRequest(
       destination,
       {


### PR DESCRIPTION
Related to: https://github.com/SAP/cloud-sdk-js/issues/1185 and https://github.com/SAP/cloud-sdk-js/issues/606

- [x] Users can disable the csrf token request in all request builders, which fits some systems that do not need the token.
