### PR TITLE
fix: Fix OpenAPI readme

### DIFF
--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -1,5 +1,5 @@
 <!-- sap-cloud-sdk-logo -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 <a href="https://sap.com/s4sdk"><img src="https://help.sap.com/doc/2324e9c3b28748a4ae2ad08166d77675/1.0/en-US/logo-with-js.svg" alt="SAP Cloud SDK for JavaScript Logo" height="122.92" width="226.773"/></a>
 <!-- sap-cloud-sdk-logo-stop -->
 
@@ -10,7 +10,7 @@ Please note that usage analytics is disabled by default, i.e. you need to explic
 For more information on how to opt-in and which data is collected, please refer to [this document](https://github.com/SAP/cloud-sdk-js/blob/main/packages/analytics/usage-analytics.md).
 
 <!-- sap-cloud-sdk-common-readme -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 ## Support
 
 The recommended way to get in touch with us is to create an issue in our [github repository](https://github.com/SAP/cloud-sdk-js/issues).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,5 @@
 <!-- sap-cloud-sdk-logo -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 <a href="https://sap.com/s4sdk"><img src="https://help.sap.com/doc/2324e9c3b28748a4ae2ad08166d77675/1.0/en-US/logo-with-js.svg" alt="SAP Cloud SDK for JavaScript Logo" height="122.92" width="226.773"/></a>
 <!-- sap-cloud-sdk-logo-stop -->
 
@@ -299,7 +299,7 @@ _See code: [src/commands/package.ts](https://github.com/SAP/cloud-sdk-js/blob/v1
 <!-- prettier-ignore-end -->
 
 <!-- sap-cloud-sdk-common-readme -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 ## Support
 
 The recommended way to get in touch with us is to create an issue in our [github repository](https://github.com/SAP/cloud-sdk-js/issues).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,5 @@
 <!-- sap-cloud-sdk-logo -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 <a href="https://sap.com/s4sdk"><img src="https://help.sap.com/doc/2324e9c3b28748a4ae2ad08166d77675/1.0/en-US/logo-with-js.svg" alt="SAP Cloud SDK for JavaScript Logo" height="122.92" width="226.773"/></a>
 <!-- sap-cloud-sdk-logo-stop -->
 
@@ -39,7 +39,7 @@ BusinessPartner.requestBuilder()
 For more detailed overview visit our [OData client documentation](https://sap.github.io/cloud-sdk/docs/js/features/odata/use-odata-v2-type-safe-client-for-javascript-typescript).
 
 <!-- sap-cloud-sdk-common-readme -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 ## Support
 
 The recommended way to get in touch with us is to create an issue in our [github repository](https://github.com/SAP/cloud-sdk-js/issues).

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,5 +1,5 @@
 <!-- sap-cloud-sdk-logo -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 <a href="https://sap.com/s4sdk"><img src="https://help.sap.com/doc/2324e9c3b28748a4ae2ad08166d77675/1.0/en-US/logo-with-js.svg" alt="SAP Cloud SDK for JavaScript Logo" height="122.92" width="226.773"/></a>
 <!-- sap-cloud-sdk-logo-stop -->
 
@@ -33,7 +33,7 @@ ESlint merges these shareable configs with your configuration.
 Any rule configured in your `.eslintrc.js` will overwrite the setting for this rule in shareable configs.
 
 <!-- sap-cloud-sdk-common-readme -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 ## Support
 
 The recommended way to get in touch with us is to create an issue in our [github repository](https://github.com/SAP/cloud-sdk-js/issues).

--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -1,5 +1,5 @@
 <!-- sap-cloud-sdk-logo -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 <a href="https://sap.com/s4sdk"><img src="https://help.sap.com/doc/2324e9c3b28748a4ae2ad08166d77675/1.0/en-US/logo-with-js.svg" alt="SAP Cloud SDK for JavaScript Logo" height="122.92" width="226.773"/></a>
 <!-- sap-cloud-sdk-logo-stop -->
 
@@ -40,7 +40,7 @@ generate(options);
 For more detailed overview visit our [generator documentation](https://sap.github.io/cloud-sdk/docs/js/features/odata/generate-odata-client).
 
 <!-- sap-cloud-sdk-common-readme -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 ## Support
 
 The recommended way to get in touch with us is to create an issue in our [github repository](https://github.com/SAP/cloud-sdk-js/issues).

--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -20,15 +20,15 @@ $ npm install @sap-cloud-sdk/openapi-generator
 
 <!-- prettier-ignore-start -->
 <!-- commands -->
-* [`generate-openapi-client `](#generate-openapi-client-)
+* [`generate-openapi-client --inputDir <inputDirectory> --outputDir <outputDirectory>`](#generate-openapi-client---inputdir-inputdirectory---outputdir-outputdirectory)
 
-## `generate-openapi-client `
+## `generate-openapi-client --inputDir <inputDirectory> --outputDir <outputDirectory>`
 
-Generate an OpenApi client using the connectivity features of the SAP Cloud SDK for JavaScript.
+Generate OpenAPI clients, that use the connectivity features of the SAP Cloud SDK for JavaScript.
 
 ```
 USAGE
-  $ generate-openapi-client
+  $ generate-openapi-client --inputDir <inputDirectory> --outputDir <outputDirectory>
 
 OPTIONS
   -i, --input=input                            (required) Input directory or file for the OpenApi service definitions.
@@ -52,10 +52,6 @@ OPTIONS
   --versionInPackageJson=versionInPackageJson  By default, when generating package.json file, the generator will set a
                                                version by using the generator version. It can also be set to a specific
                                                version.
-
-EXAMPLES
-  $ generate-openapi-client -i directoryWithOpenApiFiles -o outputDirectory
-  $ generate-openapi-client --help
 ```
 
 _See code: [dist/cli/index.ts](https://github.com/SAP/cloud-sdk-js/blob/v1.41.0/dist/cli/index.ts)_

--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -1,5 +1,5 @@
 <!-- sap-cloud-sdk-logo -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 <a href="https://sap.com/s4sdk"><img src="https://help.sap.com/doc/2324e9c3b28748a4ae2ad08166d77675/1.0/en-US/logo-with-js.svg" alt="SAP Cloud SDK for JavaScript Logo" height="122.92" width="226.773"/></a>
 <!-- sap-cloud-sdk-logo-stop -->
 
@@ -20,48 +20,45 @@ $ npm install @sap-cloud-sdk/openapi-generator
 
 <!-- prettier-ignore-start -->
 <!-- commands -->
-* [`generate-openapi-client autocomplete [SHELL]`](#generate-openapi-client-autocomplete-shell)
-* [`generate-openapi-client help [COMMAND]`](#generate-openapi-client-help-command)
+* [`generate-openapi-client `](#generate-openapi-client-)
 
-## `generate-openapi-client autocomplete [SHELL]`
+## `generate-openapi-client `
 
-display autocomplete installation instructions
+Generate an OpenApi client using the connectivity features of the SAP Cloud SDK for JavaScript.
 
 ```
 USAGE
-  $ generate-openapi-client autocomplete [SHELL]
-
-ARGUMENTS
-  SHELL  shell type
+  $ generate-openapi-client
 
 OPTIONS
-  -r, --refresh-cache  Refresh cache (ignores displaying instructions)
+  -i, --input=input                            (required) Input directory or file for the OpenApi service definitions.
+  -o, --outputDir=outputDir                    (required) Output directory for the generated OpenApi client.
+  --clearOutputDir                             Remove all files in the output directory before generation.
+
+  --generateJs                                 By default, the generator will also generate transpiled .js, .js.map,
+                                               .d.ts and .d.ts.map files. When setting to false, the generator will only
+                                               generate .ts files.
+
+  --generatePackageJson                        By default, the generator will generate a package.json file, specifying
+                                               dependencies and scripts for compiling and generating documentation. When
+                                               set to false, the generator will skip the generation of the package.json.
+
+  --serviceMapping=serviceMapping              Configuration file to ensure consistent names between multiple generation
+                                               runs with updated / changed metadata files. By default it will be read
+                                               from the input directory as "service-mapping.json".
+
+  --tsConfig=tsConfig                          tsconfig.json file to overwrite the default "tsconfig.json".
+
+  --versionInPackageJson=versionInPackageJson  By default, when generating package.json file, the generator will set a
+                                               version by using the generator version. It can also be set to a specific
+                                               version.
 
 EXAMPLES
-  $ generate-openapi-client autocomplete
-  $ generate-openapi-client autocomplete bash
-  $ generate-openapi-client autocomplete zsh
-  $ generate-openapi-client autocomplete --refresh-cache
+  $ generate-openapi-client -i directoryWithOpenApiFiles -o outputDirectory
+  $ generate-openapi-client --help
 ```
 
-_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v0.3.0/src/commands/autocomplete/index.ts)_
-
-## `generate-openapi-client help [COMMAND]`
-
-display help for generate-openapi-client
-
-```
-USAGE
-  $ generate-openapi-client help [COMMAND]
-
-ARGUMENTS
-  COMMAND  command to show help for
-
-OPTIONS
-  --all  see all commands in CLI
-```
-
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.2/src/commands/help.ts)_
+_See code: [dist/cli/index.ts](https://github.com/SAP/cloud-sdk-js/blob/v1.41.0/dist/cli/index.ts)_
 <!-- commandsstop -->
 <!-- prettier-ignore-end -->
 
@@ -84,7 +81,7 @@ await generate(options);
 For more detailed overview visit our [generator documentation](https://sap.github.io/cloud-sdk/docs/js/features/openapi/generate-openapi-client).
 
 <!-- sap-cloud-sdk-common-readme -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 ## Support
 
 The recommended way to get in touch with us is to create an issue in our [github repository](https://github.com/SAP/cloud-sdk-js/issues).

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -41,7 +41,6 @@
     "@apidevtools/swagger-parser": "^10.0.2",
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.14.0",
-    "@oclif/parser": "^3.8.4",
     "@sap-cloud-sdk/util": "^1.41.0",
     "@types/js-yaml": "^4.0.0",
     "cli-ux": "^5.4.5",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -25,18 +25,7 @@
   ],
   "oclif": {
     "bin": "generate-openapi-client",
-    "warn-if-update-available": {
-      "timeoutInDays": 7
-    },
-    "macos": {
-      "identifier": "com.sap.generate-openapi-client"
-    },
-    "plugins": [
-      "@oclif/plugin-help",
-      "@oclif/plugin-autocomplete",
-      "@oclif/plugin-not-found",
-      "@oclif/plugin-warn-if-update-available"
-    ]
+    "commands": "./dist/cli"
   },
   "scripts": {
     "compile": "yarn tsc -b",
@@ -53,10 +42,6 @@
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.14.0",
     "@oclif/parser": "^3.8.4",
-    "@oclif/plugin-autocomplete": "^0.3.0",
-    "@oclif/plugin-help": "^3.2.2",
-    "@oclif/plugin-not-found": "^1.2.3",
-    "@oclif/plugin-warn-if-update-available": "^1.7.0",
     "@sap-cloud-sdk/util": "^1.41.0",
     "@types/js-yaml": "^4.0.0",
     "cli-ux": "^5.4.5",

--- a/packages/openapi-generator/src/cli/index.ts
+++ b/packages/openapi-generator/src/cli/index.ts
@@ -10,12 +10,9 @@ const logger = createLogger('openapi-generator');
 
 class GenerateOpenApiClient extends Command {
   static description =
-    'Generate an OpenApi client using the connectivity features of the SAP Cloud SDK for JavaScript.';
+    'Generate OpenAPI clients, that use the connectivity features of the SAP Cloud SDK for JavaScript.';
 
-  static examples = [
-    '$ generate-openapi-client -i directoryWithOpenApiFiles -o outputDirectory',
-    '$ generate-openapi-client --help'
-  ];
+  static usage = '--inputDir <inputDirectory> --outputDir <outputDirectory>';
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   static version = require('../../package.json').version;

--- a/packages/openapi-generator/src/cli/index.ts
+++ b/packages/openapi-generator/src/cli/index.ts
@@ -1,12 +1,10 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
 import { resolve } from 'path';
-import { readFileSync } from 'fs';
 import { createLogger } from '@sap-cloud-sdk/util';
-import Command from '@oclif/command';
-import { flags } from '@oclif/parser';
+import { Command, flags } from '@oclif/command';
 import cli from 'cli-ux';
-import { generate } from './generator';
+import { generate } from '../generator';
 
 const logger = createLogger('openapi-generator');
 
@@ -19,9 +17,8 @@ class GenerateOpenApiClient extends Command {
     '$ generate-openapi-client --help'
   ];
 
-  static version = JSON.parse(
-    readFileSync(resolve(__dirname, '../package.json'), { encoding: 'utf8' })
-  ).version;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  static version = require('../../package.json').version;
 
   static flags = {
     input: flags.string({

--- a/packages/test-util/README.md
+++ b/packages/test-util/README.md
@@ -1,5 +1,5 @@
 <!-- sap-cloud-sdk-logo -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 <a href="https://sap.com/s4sdk"><img src="https://help.sap.com/doc/2324e9c3b28748a4ae2ad08166d77675/1.0/en-US/logo-with-js.svg" alt="SAP Cloud SDK for JavaScript Logo" height="122.92" width="226.773"/></a>
 <!-- sap-cloud-sdk-logo-stop -->
 
@@ -52,7 +52,7 @@ and `credentials.json`:
 ```
 
 <!-- sap-cloud-sdk-common-readme -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 ## Support
 
 The recommended way to get in touch with us is to create an issue in our [github repository](https://github.com/SAP/cloud-sdk-js/issues).

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -1,5 +1,5 @@
 <!-- sap-cloud-sdk-logo -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 <a href="https://sap.com/s4sdk"><img src="https://help.sap.com/doc/2324e9c3b28748a4ae2ad08166d77675/1.0/en-US/logo-with-js.svg" alt="SAP Cloud SDK for JavaScript Logo" height="122.92" width="226.773"/></a>
 <!-- sap-cloud-sdk-logo-stop -->
 
@@ -25,7 +25,7 @@ setLogLevel('debug', 'destination-accessor');
 ```
 
 <!-- sap-cloud-sdk-common-readme -->
-<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->
+<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->
 ## Support
 
 The recommended way to get in touch with us is to create an issue in our [github repository](https://github.com/SAP/cloud-sdk-js/issues).

--- a/scripts/replace-common-readme.ts
+++ b/scripts/replace-common-readme.ts
@@ -10,7 +10,7 @@ const endTagLogo = '<!-- sap-cloud-sdk-logo-stop -->';
 
 const logoContent = `<a href="https://sap.com/s4sdk"><img src="https://help.sap.com/doc/2324e9c3b28748a4ae2ad08166d77675/1.0/en-US/logo-with-js.svg" alt="SAP Cloud SDK for JavaScript Logo" height="122.92" width="226.773"/></a>${unixEOL}`;
 const infoNoManualEdit =
-  '<!-- This block is inserted by scripts/replace-common-readme.ts and not oclif like the commands block. Do not adjust it manually. -->';
+  '<!-- This block is inserted by scripts/replace-common-readme.ts. Do not adjust it manually. -->';
 
 const logger = createLogger('check-licenses');
 


### PR DESCRIPTION
This fixes the missing usage section in the readme of the openapi generator. The issue seems to have been caused by how the version was read.