### PR TITLE
feat: support unary operator not when building filters and improve boolean filter functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 
 ## New Functionality
 
-- Support custom axios options for all request builders.
 - [core] Support custom axios options for all request builders.
 - [core] Support disabling csrf token request as an option for all request builders.
 - [odata] Support unary operator `not` in the `filter()` of OData request builders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ## Improvements
 
-- [odata] Filter functions with boolean return types can be used directly in the `filter()` of OData request builders without `equals(true)`.
+- [odata] Allow using filter functions with boolean return types directly in the `filter()` of OData request builders without `equals(true)`.
 
 ## Fixed Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@
 ## New Functionality
 
 - Support custom axios options for all request builders.
+- [odata] Support unary operator `not` in the `filter()` of OData request builders.
 
 ## Improvements
 
--
+- [odata] Filter functions with boolean return types can be used directly in the `filter()` of OData request builders without `equals(true)`.
 
 ## Fixed Issues
 

--- a/packages/core/src/odata-common/filter/boolean-filter-function.ts
+++ b/packages/core/src/odata-common/filter/boolean-filter-function.ts
@@ -3,6 +3,9 @@ import {
   FilterFunction,
   FilterFunctionParameterType
 } from './filter-function-base';
+import { FieldType } from '../selectable';
+import { Filterable } from './filterable';
+import { Filter } from './filter';
 
 /**
  * Representation of a filter function, that returns a value of type boolean.
@@ -21,4 +24,14 @@ export class BooleanFilterFunction<
   ) {
     super(functionName, parameters, 'Edm.Boolean');
   }
+}
+
+export function isBooleanFilterFunction<EntityT extends Entity>(
+  filterable: Filterable<EntityT>
+): filterable is BooleanFilterFunction<EntityT> {
+  return (
+    typeof filterable['functionName'] !== 'undefined' &&
+    typeof filterable['parameters'] !== 'undefined' &&
+    filterable['edmType'] === 'Edm.Boolean'
+  );
 }

--- a/packages/core/src/odata-common/filter/boolean-filter-function.ts
+++ b/packages/core/src/odata-common/filter/boolean-filter-function.ts
@@ -3,9 +3,7 @@ import {
   FilterFunction,
   FilterFunctionParameterType
 } from './filter-function-base';
-import { FieldType } from '../selectable';
 import { Filterable } from './filterable';
-import { Filter } from './filter';
 
 /**
  * Representation of a filter function, that returns a value of type boolean.

--- a/packages/core/src/odata-common/filter/filter.ts
+++ b/packages/core/src/odata-common/filter/filter.ts
@@ -35,6 +35,7 @@ export type FilterOperatorByType<
  * @typeparam EntityT - Type of the entity to be filtered on
  * @typeparam FieldT - Type of the field to be filtered by, see also: [[FieldType]]
  */
+// TODO 2.0 rename to BinaryFilter
 export class Filter<
   EntityT extends Entity,
   FieldT extends FieldType | FieldType[]

--- a/packages/core/src/odata-common/filter/filterable.ts
+++ b/packages/core/src/odata-common/filter/filterable.ts
@@ -6,6 +6,7 @@ import { FilterLink } from './filter-link';
 import { FilterList } from './filter-list';
 import { FilterLambdaExpression } from './filter-lambda-expression';
 import { BooleanFilterFunction } from './boolean-filter-function';
+import { UnaryFilter } from './unary-filter';
 
 /**
  * A union of all types that can be used for filtering.
@@ -17,6 +18,7 @@ export type Filterable<EntityT extends Entity> =
   | FilterLink<EntityT>
   | FilterList<EntityT>
   | FilterLambdaExpression<EntityT>
+  | UnaryFilter<EntityT>
   | BooleanFilterFunction<EntityT>;
 
 /**
@@ -92,7 +94,8 @@ export function toFilterableList<
   return filters.map(f => (f instanceof OneToManyLink ? f._filters : f));
 }
 
-// TODO:
-// Export function not<EntityT extends Entity>(expression: Filterable<EntityT>): Filterable<EntityT> {
-//   Return new FilterList([], expressions);
-// }
+export function not<EntityT extends Entity>(
+  filter: Filterable<EntityT>
+): UnaryFilter<EntityT> {
+  return new UnaryFilter(filter, 'not');
+}

--- a/packages/core/src/odata-common/filter/filterable.ts
+++ b/packages/core/src/odata-common/filter/filterable.ts
@@ -5,6 +5,7 @@ import { Filter } from './filter';
 import { FilterLink } from './filter-link';
 import { FilterList } from './filter-list';
 import { FilterLambdaExpression } from './filter-lambda-expression';
+import { BooleanFilterFunction } from './boolean-filter-function';
 
 /**
  * A union of all types that can be used for filtering.
@@ -15,7 +16,8 @@ export type Filterable<EntityT extends Entity> =
   | Filter<EntityT, FieldType | FieldType[]>
   | FilterLink<EntityT>
   | FilterList<EntityT>
-  | FilterLambdaExpression<EntityT>;
+  | FilterLambdaExpression<EntityT>
+  | BooleanFilterFunction<EntityT>;
 
 /**
  * Create a [[FilterList]] by combining [[Filterable]]s with logical `and`.

--- a/packages/core/src/odata-common/filter/filterable.ts
+++ b/packages/core/src/odata-common/filter/filterable.ts
@@ -1,12 +1,14 @@
 import { variadicArgumentToArray } from '@sap-cloud-sdk/util';
 import { Entity } from '../entity';
 import { FieldType, OneToManyLink } from '../selectable';
-import { Filter } from './filter';
-import { FilterLink } from './filter-link';
-import { FilterList } from './filter-list';
-import { FilterLambdaExpression } from './filter-lambda-expression';
-import { BooleanFilterFunction } from './boolean-filter-function';
-import { UnaryFilter } from './unary-filter';
+import {
+  FilterLambdaExpression,
+  BooleanFilterFunction,
+  Filter,
+  FilterLink,
+  FilterList,
+  UnaryFilter
+} from '../filter';
 
 /**
  * A union of all types that can be used for filtering.

--- a/packages/core/src/odata-common/filter/index.ts
+++ b/packages/core/src/odata-common/filter/index.ts
@@ -10,3 +10,4 @@ export * from './number-filter-function';
 export * from './string-filter-function';
 export * from './filter-lambda-expression';
 export * from './orderable-filter-function';
+export * from './unary-filter';

--- a/packages/core/src/odata-common/filter/unary-filter.ts
+++ b/packages/core/src/odata-common/filter/unary-filter.ts
@@ -1,0 +1,20 @@
+import { Entity } from '../entity';
+import { Filterable } from './filterable';
+
+type UnaryFilterOperator = 'not';
+
+export class UnaryFilter<EntityT extends Entity> {
+  constructor(
+    public singleOperand: Filterable<EntityT>,
+    public operator: UnaryFilterOperator
+  ) {}
+}
+
+export function isUnaryFilter<T extends Entity>(
+  filterable: Filterable<T>
+): filterable is UnaryFilter<T> {
+  return (
+    typeof filterable['singleOperand'] !== 'undefined' &&
+    typeof filterable['operator'] !== 'undefined'
+  );
+}

--- a/packages/core/src/odata-common/filter/unary-filter.ts
+++ b/packages/core/src/odata-common/filter/unary-filter.ts
@@ -1,5 +1,5 @@
 import { Entity } from '../entity';
-import { Filterable } from './filterable';
+import { Filterable } from '../filter';
 
 type UnaryFilterOperator = 'not';
 

--- a/packages/core/src/odata-common/uri-conversion/get-filter.ts
+++ b/packages/core/src/odata-common/uri-conversion/get-filter.ts
@@ -8,7 +8,12 @@ import {
   FilterFunction,
   FilterFunctionParameterType,
   isBooleanFilterFunction,
-  isUnaryFilter
+  isUnaryFilter,
+  UnaryFilter,
+  FilterLambdaExpression,
+  FilterList,
+  FilterLink,
+  Filter
 } from '../filter';
 import { EdmTypeShared } from '../edm-types';
 import { ComplexTypeField, FieldType } from '../selectable';
@@ -70,78 +75,29 @@ export function createGetFilter(uriConverter: UriConverter): GetFilter {
     lambdaExpressionLevel = 0
   ): string {
     if (isFilterList(filter)) {
-      let andExp = filter.andFilters
-        .map(subFilter =>
-          getODataFilterExpression(
-            subFilter,
-            parentFieldNames,
-            targetEntityConstructor,
-            lambdaExpressionLevel
-          )
-        )
-        .filter(f => !!f)
-        .join(' and ');
-      andExp = andExp ? `(${andExp})` : andExp;
-
-      let orExp = filter.orFilters
-        .map(subFilter =>
-          getODataFilterExpression(
-            subFilter,
-            parentFieldNames,
-            targetEntityConstructor,
-            lambdaExpressionLevel
-          )
-        )
-        .filter(f => !!f)
-        .join(' or ');
-      orExp = orExp ? `(${orExp})` : orExp;
-
-      const exp: string[] = [];
-      if (andExp) {
-        exp.push(andExp);
-      }
-
-      if (orExp) {
-        exp.push(orExp);
-      }
-
-      return exp.join(' and ');
+      return getODataFilterExpressionForFilterList(
+        filter,
+        parentFieldNames,
+        targetEntityConstructor,
+        lambdaExpressionLevel
+      );
     }
 
     if (isFilterLink(filter)) {
-      let linkExp = filter.filters
-        .map(subFilter =>
-          getODataFilterExpression(
-            subFilter,
-            [...parentFieldNames, filter.link._fieldName],
-            filter.link._linkedEntity,
-            lambdaExpressionLevel
-          )
-        )
-        .filter(f => !!f)
-        .join(' and ');
-      linkExp = linkExp ? `(${linkExp})` : linkExp;
-      return linkExp;
+      return getODataFilterExpressionForFilterLink(
+        filter,
+        parentFieldNames,
+        targetEntityConstructor,
+        lambdaExpressionLevel
+      );
     }
 
     if (isFilter(filter)) {
-      if (typeof filter.field === 'string') {
-        const field = retrieveField(
-          filter.field,
-          targetEntityConstructor,
-          filter.edmType
-        );
-        return [
-          [...parentFieldNames, filter.field].join('/'),
-          filter.operator,
-          convertFilterValue(filter.value, field.edmType)
-        ].join(' ');
-      }
-      return [
-        filterFunctionToString(filter.field, parentFieldNames),
-        filter.operator,
-        convertFilterValue(filter.value, filter.edmType!)
-      ].join(' ');
+      return getODataFilterExpressionForFilter(
+        filter,
+        parentFieldNames,
+        targetEntityConstructor
+      );
     }
 
     if (isBooleanFilterFunction(filter)) {
@@ -149,24 +105,20 @@ export function createGetFilter(uriConverter: UriConverter): GetFilter {
     }
 
     if (isUnaryFilter(filter)) {
-      return `${filter.operator} (${getODataFilterExpression(
-        filter.singleOperand,
+      return getODataFilterExpressionForUnaryFilter(
+        filter,
         parentFieldNames,
         targetEntityConstructor
-      )})`;
+      );
     }
 
     if (isFilterLambdaExpression(filter)) {
-      const alias = `a${lambdaExpressionLevel}`;
-      const filterExp = getODataFilterExpression(
-        filter.filters,
-        [alias],
+      return getODataFilterExpressionForFilterLambdaExpression(
+        filter,
+        parentFieldNames,
         targetEntityConstructor,
-        lambdaExpressionLevel + 1
+        lambdaExpressionLevel
       );
-      return `${parentFieldNames.join('/')}/${
-        filter.lambdaOperator
-      }(${alias}:${filterExp})`;
     }
 
     throw new Error(
@@ -238,6 +190,127 @@ export function createGetFilter(uriConverter: UriConverter): GetFilter {
           .map(v => uriConverter.convertToUriFormat(v, edmType))
           .join(',')}]`
       : uriConverter.convertToUriFormat(value, edmType);
+  }
+
+  function getODataFilterExpressionForUnaryFilter<FilterEntityT extends Entity>(
+    filter: UnaryFilter<FilterEntityT>,
+    parentFieldNames: string[],
+    targetEntityConstructor: Constructable<any>
+  ): string {
+    return `${filter.operator} (${getODataFilterExpression(
+      filter.singleOperand,
+      parentFieldNames,
+      targetEntityConstructor
+    )})`;
+  }
+
+  function getODataFilterExpressionForFilterLambdaExpression<
+    FilterEntityT extends Entity
+  >(
+    filter: FilterLambdaExpression<FilterEntityT>,
+    parentFieldNames: string[],
+    targetEntityConstructor: Constructable<any>,
+    lambdaExpressionLevel: number
+  ): string {
+    const alias = `a${lambdaExpressionLevel}`;
+    const filterExp = getODataFilterExpression(
+      filter.filters,
+      [alias],
+      targetEntityConstructor,
+      lambdaExpressionLevel + 1
+    );
+    return `${parentFieldNames.join('/')}/${
+      filter.lambdaOperator
+    }(${alias}:${filterExp})`;
+  }
+
+  function getODataFilterExpressionForFilterList<FilterEntityT extends Entity>(
+    filter: FilterList<FilterEntityT>,
+    parentFieldNames: string[],
+    targetEntityConstructor: Constructable<any>,
+    lambdaExpressionLevel: number
+  ): string {
+    let andExp = filter.andFilters
+      .map(subFilter =>
+        getODataFilterExpression(
+          subFilter,
+          parentFieldNames,
+          targetEntityConstructor,
+          lambdaExpressionLevel
+        )
+      )
+      .filter(f => !!f)
+      .join(' and ');
+    andExp = andExp ? `(${andExp})` : andExp;
+
+    let orExp = filter.orFilters
+      .map(subFilter =>
+        getODataFilterExpression(
+          subFilter,
+          parentFieldNames,
+          targetEntityConstructor,
+          lambdaExpressionLevel
+        )
+      )
+      .filter(f => !!f)
+      .join(' or ');
+    orExp = orExp ? `(${orExp})` : orExp;
+
+    const exp: string[] = [];
+    if (andExp) {
+      exp.push(andExp);
+    }
+
+    if (orExp) {
+      exp.push(orExp);
+    }
+
+    return exp.join(' and ');
+  }
+
+  function getODataFilterExpressionForFilterLink<FilterEntityT extends Entity>(
+    filter: FilterLink<FilterEntityT>,
+    parentFieldNames: string[],
+    targetEntityConstructor: Constructable<any>,
+    lambdaExpressionLevel: number
+  ): string {
+    let linkExp = filter.filters
+      .map(subFilter =>
+        getODataFilterExpression(
+          subFilter,
+          [...parentFieldNames, filter.link._fieldName],
+          filter.link._linkedEntity,
+          lambdaExpressionLevel
+        )
+      )
+      .filter(f => !!f)
+      .join(' and ');
+    linkExp = linkExp ? `(${linkExp})` : linkExp;
+    return linkExp;
+  }
+
+  function getODataFilterExpressionForFilter<FilterEntityT extends Entity>(
+    filter: Filter<FilterEntityT, FieldType | FieldType[]>,
+    parentFieldNames: string[],
+    targetEntityConstructor: Constructable<any>
+  ): string {
+    if (typeof filter.field === 'string') {
+      const field = retrieveField(
+        filter.field,
+        targetEntityConstructor,
+        filter.edmType
+      );
+      return [
+        [...parentFieldNames, filter.field].join('/'),
+        filter.operator,
+        convertFilterValue(filter.value, field.edmType)
+      ].join(' ');
+    }
+    return [
+      filterFunctionToString(filter.field, parentFieldNames),
+      filter.operator,
+      convertFilterValue(filter.value, filter.edmType!)
+    ].join(' ');
   }
 
   return {

--- a/packages/core/src/odata-common/uri-conversion/get-filter.ts
+++ b/packages/core/src/odata-common/uri-conversion/get-filter.ts
@@ -6,7 +6,7 @@ import {
   isFilterLink,
   isFilter,
   FilterFunction,
-  FilterFunctionParameterType
+  FilterFunctionParameterType, isBooleanFilterFunction
 } from '../filter';
 import { EdmTypeShared } from '../edm-types';
 import { ComplexTypeField, FieldType } from '../selectable';
@@ -140,6 +140,10 @@ export function createGetFilter(uriConverter: UriConverter): GetFilter {
         filter.operator,
         convertFilterValue(filter.value, filter.edmType!)
       ].join(' ');
+    }
+
+    if (isBooleanFilterFunction(filter)){
+      return filterFunctionToString(filter, parentFieldNames);
     }
 
     if (isFilterLambdaExpression(filter)) {

--- a/packages/core/src/odata-common/uri-conversion/get-filter.ts
+++ b/packages/core/src/odata-common/uri-conversion/get-filter.ts
@@ -6,7 +6,9 @@ import {
   isFilterLink,
   isFilter,
   FilterFunction,
-  FilterFunctionParameterType, isBooleanFilterFunction
+  FilterFunctionParameterType,
+  isBooleanFilterFunction,
+  isUnaryFilter
 } from '../filter';
 import { EdmTypeShared } from '../edm-types';
 import { ComplexTypeField, FieldType } from '../selectable';
@@ -142,8 +144,16 @@ export function createGetFilter(uriConverter: UriConverter): GetFilter {
       ].join(' ');
     }
 
-    if (isBooleanFilterFunction(filter)){
+    if (isBooleanFilterFunction(filter)) {
       return filterFunctionToString(filter, parentFieldNames);
+    }
+
+    if (isUnaryFilter(filter)) {
+      return `${filter.operator} (${getODataFilterExpression(
+        filter.singleOperand,
+        parentFieldNames,
+        targetEntityConstructor
+      )})`;
     }
 
     if (isFilterLambdaExpression(filter)) {

--- a/packages/core/src/odata-v2/uri-conversion/odata-uri.spec.ts
+++ b/packages/core/src/odata-v2/uri-conversion/odata-uri.spec.ts
@@ -155,11 +155,30 @@ describe('getFilter for filter functions', () => {
     );
   });
 
+  it('for custom filter function with boolean filter function without eq/ne', () => {
+    const fn = filterFunction(
+      'fn',
+      'boolean',
+      'str'
+    );
+    expect(oDataUri.getFilter(fn, TestEntity).filter).toBe(
+      "fn('str')"
+    );
+  });
+
   it('for custom nested filter function', () => {
     const fnNested = filterFunction('fnNested', 'boolean');
     const fn = filterFunction('fn', 'string', fnNested);
     expect(oDataUri.getFilter(fn.equals('test'), TestEntity).filter).toBe(
       "fn(fnNested()) eq 'test'"
+    );
+  });
+
+  it('for custom filter function with date', () => {
+    const date = moment.utc().year(2000).month(0).date(1).startOf('date');
+    const dateFn = filterFunction('fn', 'int', date).equals(1);
+    expect(oDataUri.getFilter(dateFn, TestEntity).filter).toEqual(
+      "fn(datetimeoffset'2000-01-01T00:00:00.000Z') eq 1"
     );
   });
 
@@ -188,12 +207,22 @@ describe('getFilter for filter functions', () => {
     ).toBe('round(10.1) eq 3M');
   });
 
-  it('for custom filter function with date', () => {
-    const date = moment.utc().year(2000).month(0).date(1).startOf('date');
-    const dateFn = filterFunction('fn', 'int', date).equals(1);
-    expect(oDataUri.getFilter(dateFn, TestEntity).filter).toEqual(
-      "fn(datetimeoffset'2000-01-01T00:00:00.000Z') eq 1"
-    );
+  it('for startsWith filter function with eq/ne', () => {
+    expect(
+      oDataUri.getFilter(
+        filterFunctions.startsWith('string', 'str').equals(false),
+        TestEntity
+      ).filter
+    ).toBe("startswith('string', 'str') eq false");
+  });
+
+  it('for startsWith filter function without eq/ne', () => {
+    expect(
+      oDataUri.getFilter(
+        filterFunctions.startsWith('string', 'str'),
+        TestEntity
+      ).filter
+    ).toBe("startswith('string', 'str')");
   });
 });
 


### PR DESCRIPTION
- [x] Support unary operator `not` in the `filter()` of OData request builders.
- [x] Filter functions with boolean return types can be used directly in the `filter()` of OData request builders without `equals(true)`.