### PR TITLE
chore: remove macos tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,8 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         node-version: [10.x, 12.x]
-        exclude:
-          - os: macos-latest
-            node-version: 10.x
-          - os: windows-latest
-            node-version: 10.x
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1


### PR DESCRIPTION
As discussed in retro today we remove the macos tests because they did not add much value but increased the test run time.