### PR TITLE
Fix schema name conflicts

### DIFF
--- a/packages/openapi-generator/src/file-serializer/api-file.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/api-file.spec.ts
@@ -1,4 +1,4 @@
-import { OpenApiApi } from '../openapi-types';
+import { OpenApiApi, OpenApiReferenceSchema } from '../openapi-types';
 import { apiDocumentation, apiFile } from './api-file';
 
 describe('apiFile', () => {
@@ -64,7 +64,7 @@ describe('apiFile', () => {
               schema: {
                 $ref: '#/components/schemas/PathParameterType',
                 schemaName: 'PathParameterType'
-              },
+              } as OpenApiReferenceSchema,
               required: true
             }
           ],
@@ -76,7 +76,7 @@ describe('apiFile', () => {
               schema: {
                 $ref: '#/components/schemas/QueryParameterType',
                 schemaName: 'QueryParameterType'
-              },
+              } as OpenApiReferenceSchema,
               required: true
             }
           ],
@@ -94,13 +94,13 @@ describe('apiFile', () => {
             schema: {
               $ref: '#/components/schemas/RefType',
               schemaName: 'RefType'
-            }
+            } as OpenApiReferenceSchema
           },
           pathPattern: 'test',
           response: {
             $ref: '#/components/schemas/ResponseType',
             schemaName: 'ResponseType'
-          }
+          } as OpenApiReferenceSchema
         }
       ]
     };

--- a/packages/openapi-generator/src/file-serializer/index-file.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/index-file.spec.ts
@@ -27,10 +27,13 @@ it('apiIndexFile serializes the api index file without referenced schemas', () =
 it('schemaIndexFile serializes the schema index file for schemas in a document', () => {
   const document = ({
     apis: [],
-    schemas: [{ name: 'MySchema1' }, { name: 'MySchema2' }]
+    schemas: [
+      { schemaName: 'MySchema1', fileName: 'my-schema-1' },
+      { schemaName: 'MySchema2', fileName: 'some-other-name' }
+    ]
   } as unknown) as OpenApiDocument;
   expect(schemaIndexFile(document)).toMatchInlineSnapshot(`
-    "    export * from './my-schema-1';
-        export * from './my-schema-2';"
+    "export * from './my-schema-1';
+    export * from './some-other-name';"
   `);
 });

--- a/packages/openapi-generator/src/file-serializer/index-file.ts
+++ b/packages/openapi-generator/src/file-serializer/index-file.ts
@@ -12,7 +12,7 @@ export function apiIndexFile(openApiDocument: OpenApiDocument): string {
     ...(openApiDocument.schemas.length ? ['schema'] : [])
   ];
   return codeBlock`
-    ${exportAllFiles(files)}
+    ${exportAllFiles(files.map(fileName => kebabCase(fileName)))}
   `;
 }
 
@@ -22,14 +22,12 @@ export function apiIndexFile(openApiDocument: OpenApiDocument): string {
  * @returns The serialized index file contents.
  */
 export function schemaIndexFile(openApiDocument: OpenApiDocument): string {
-  return codeBlock`
-    ${exportAllFiles(openApiDocument.schemas.map(schema => schema.name))}
-  `;
+  return exportAllFiles(openApiDocument.schemas.map(schema => schema.fileName));
 }
 
 function exportAllFiles(fileNames: string[]): string {
   return codeBlock`${fileNames
-    .map(fileName => exportAll(`${kebabCase(fileName)}`))
+    .map(fileName => exportAll(fileName))
     .join('\n')}`;
 }
 

--- a/packages/openapi-generator/src/file-serializer/operation.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/operation.spec.ts
@@ -1,4 +1,8 @@
-import { OpenApiOperation } from '../openapi-types';
+import {
+  OpenApiOperation,
+  OpenApiParameter,
+  OpenApiReferenceSchema
+} from '../openapi-types';
 import { operationDocumentation, serializeOperation } from './operation';
 
 describe('serializeOperation', () => {
@@ -177,7 +181,10 @@ describe('serializeOperation', () => {
       queryParameters: [],
       requestBody: {
         required: false,
-        schema: { $ref: '#/components/schemas/RefType', schemaName: 'RefType' }
+        schema: {
+          $ref: '#/components/schemas/RefType',
+          schemaName: 'RefType'
+        } as OpenApiReferenceSchema
       },
       response: { type: 'string' },
       pathPattern: 'test'
@@ -204,8 +211,8 @@ describe('serializeOperation', () => {
       response: { type: 'string' },
       method: 'GET',
       pathPattern: 'my/Api',
-      pathParameters: [] as any,
-      queryParameters: [] as any
+      pathParameters: [] as OpenApiParameter[],
+      queryParameters: [] as OpenApiParameter[]
     } as OpenApiOperation;
   }
 
@@ -232,7 +239,7 @@ describe('serializeOperation', () => {
     operation.pathParameters = [
       { name: 'pathParameter1' },
       { name: 'path-parameter-2' }
-    ] as any;
+    ] as OpenApiParameter[];
     expect(operationDocumentation(operation)).toMatchInlineSnapshot(`
       "/**
        * Create a request builder for execution of GET requests to the 'my/Api' endpoint.
@@ -250,7 +257,7 @@ describe('serializeOperation', () => {
         name: 'pathParameter1',
         description: 'This is my parameter description'
       }
-    ] as any;
+    ] as OpenApiParameter[];
     expect(operationDocumentation(operation)).toMatch(
       /This is my parameter description/
     );
@@ -261,7 +268,7 @@ describe('serializeOperation', () => {
     operation.queryParameters = [
       { name: 'queryParameter1' },
       { name: 'queryParameter2' }
-    ] as any;
+    ] as OpenApiParameter[];
     expect(operationDocumentation(operation)).toMatchInlineSnapshot(`
       "/**
        * Create a request builder for execution of GET requests to the 'my/Api' endpoint.
@@ -295,12 +302,14 @@ describe('serializeOperation', () => {
 
   it('creates the signature in order path parameter, body, queryParameter and returns last', () => {
     const operation = getOperation();
-    operation.pathParameters = [{ name: 'pathParameter1' }] as any;
+    operation.pathParameters = [
+      { name: 'pathParameter1' }
+    ] as OpenApiParameter[];
     operation.requestBody = { schema: { type: 'string' }, required: false };
     operation.queryParameters = [
       { name: 'queryParameter1' },
       { name: 'queryParameter2' }
-    ] as any;
+    ] as OpenApiParameter[];
     operation.requestBody = { schema: { type: 'string' }, required: true };
     expect(operationDocumentation(operation)).toMatch(
       /@param pathParameter1.*\s.*@param body.*\s.*@param queryParameters.*\s.*@returns/

--- a/packages/openapi-generator/src/file-serializer/schema-file.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/schema-file.spec.ts
@@ -1,10 +1,15 @@
+import {
+  OpenApiObjectSchemaProperty,
+  OpenApiPersistedSchema
+} from '../openapi-types';
 import { schemaDocumentation, schemaFile } from './schema-file';
 import { schemaPropertyDocumentation } from './schema';
 describe('schemaFile', () => {
   it('serializes schema file for schema', () => {
     expect(
       schemaFile({
-        name: 'MySchema',
+        schemaName: 'MySchema',
+        fileName: 'my-schema',
         schema: {
           properties: [
             {
@@ -31,7 +36,8 @@ describe('schemaFile', () => {
   it('serializes schema file for schema including references', () => {
     expect(
       schemaFile({
-        name: 'MySchema',
+        schemaName: 'MySchema',
+        fileName: 'my-schema',
         schema: {
           properties: [
             {
@@ -39,7 +45,8 @@ describe('schemaFile', () => {
               required: true,
               schema: {
                 $ref: '#/components/schema/OtherSchema1',
-                schemaName: 'OtherSchema1'
+                schemaName: 'OtherSchema1',
+                fileName: 'other-schema-1'
               }
             },
             {
@@ -48,7 +55,8 @@ describe('schemaFile', () => {
               required: true,
               schema: {
                 $ref: '#/components/schema/OtherSchema2',
-                schemaName: 'OtherSchema2'
+                schemaName: 'OtherSchema2',
+                fileName: 'other-schema-2'
               }
             }
           ]
@@ -73,7 +81,8 @@ describe('schemaFile', () => {
   it('serializes schema file for schema including not schema', () => {
     expect(
       schemaFile({
-        name: 'MySchema',
+        schemaName: 'MySchema',
+        fileName: 'my-schema',
         schema: {
           items: { not: { type: 'integer' } }
         }
@@ -90,7 +99,8 @@ describe('schemaFile', () => {
   it('serializes schema file without imports for schema including only self reference', () => {
     expect(
       schemaFile({
-        name: 'MySchema',
+        schemaName: 'MySchema',
+        fileName: 'my-schema',
         schema: {
           properties: [
             {
@@ -98,7 +108,8 @@ describe('schemaFile', () => {
               required: false,
               schema: {
                 $ref: '#/components/schema/MySchema',
-                schemaName: 'MySchema'
+                schemaName: 'MySchema',
+                fileName: 'my-schema'
               }
             }
           ]
@@ -118,7 +129,8 @@ describe('schemaFile', () => {
   it('serializes simple schema file for schema with description', () => {
     expect(
       schemaFile({
-        name: 'MySchema',
+        schemaName: 'MySchema',
+        fileName: 'my-schema',
         schema: {
           properties: [
             {
@@ -155,8 +167,9 @@ describe('schemaFile', () => {
   });
 
   it('creates schema documentation', () => {
-    expect(schemaDocumentation({ name: 'mySchema' } as any))
-      .toMatchInlineSnapshot(`
+    expect(
+      schemaDocumentation({ schemaName: 'mySchema' } as OpenApiPersistedSchema)
+    ).toMatchInlineSnapshot(`
       "/**
        * Representation of the 'mySchema' schema.
        */"
@@ -166,9 +179,9 @@ describe('schemaFile', () => {
   it('uses the schema description documentation if present', () => {
     expect(
       schemaDocumentation({
-        name: 'mySchema',
+        schemaName: 'mySchema',
         description: 'My schmema description.'
-      } as any)
+      } as OpenApiPersistedSchema)
     ).toMatch(/My schmema description/);
   });
 
@@ -176,7 +189,7 @@ describe('schemaFile', () => {
     expect(
       schemaPropertyDocumentation({
         description: 'My property Description.'
-      } as any)
+      } as OpenApiObjectSchemaProperty)
     ).toMatchInlineSnapshot(`
       "/**
        * My property Description.

--- a/packages/openapi-generator/src/file-serializer/schema.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/schema.spec.ts
@@ -4,7 +4,8 @@ it('serializeSchema serializes reference schema', () => {
   expect(
     serializeSchema({
       $ref: '#/components/schemas/my-schema',
-      schemaName: 'MySchema'
+      schemaName: 'MySchema',
+      fileName: 'my-schema'
     })
   ).toEqual('MySchema');
 });
@@ -124,8 +125,16 @@ describe('serializeSchema for xOf schemas', () => {
     expect(
       serializeSchema({
         oneOf: [
-          { $ref: '#/components/schemas/XOr1', schemaName: 'XOr1' },
-          { $ref: '#/components/schemas/XOr2', schemaName: 'XOr2' }
+          {
+            $ref: '#/components/schemas/XOr1',
+            schemaName: 'XOr1',
+            fileName: 'x-or-1'
+          },
+          {
+            $ref: '#/components/schemas/XOr2',
+            schemaName: 'XOr2',
+            fileName: 'x-or-2'
+          }
         ]
       })
     ).toEqual('XOr1 | XOr2');
@@ -137,11 +146,13 @@ describe('serializeSchema for xOf schemas', () => {
         anyOf: [
           {
             $ref: '#/components/schemas/InclusiveOr1',
-            schemaName: 'InclusiveOr1'
+            schemaName: 'InclusiveOr1',
+            fileName: 'inclusive-or-1'
           },
           {
             $ref: '#/components/schemas/InclusiveOr2',
-            schemaName: 'InclusiveOr2'
+            schemaName: 'InclusiveOr2',
+            fileName: 'inclusive-or-2'
           }
         ]
       })
@@ -152,8 +163,16 @@ describe('serializeSchema for xOf schemas', () => {
     expect(
       serializeSchema({
         allOf: [
-          { $ref: '#/components/schemas/And1', schemaName: 'And1' },
-          { $ref: '#/components/schemas/And2', schemaName: 'And2' }
+          {
+            $ref: '#/components/schemas/And1',
+            schemaName: 'And1',
+            fileName: 'and-1'
+          },
+          {
+            $ref: '#/components/schemas/And2',
+            schemaName: 'And2',
+            fileName: 'and-2'
+          }
         ]
       })
     ).toEqual('And1 & And2');

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -150,7 +150,7 @@ async function createSchemaFiles(
   await mkdir(dir, { recursive: true });
   await Promise.all(
     openApiDocument.schemas.map(schema =>
-      createFile(dir, `${kebabCase(schema.name)}.ts`, schemaFile(schema), true)
+      createFile(dir, `${schema.fileName}.ts`, schemaFile(schema), true)
     )
   );
 }

--- a/packages/openapi-generator/src/openapi-types.ts
+++ b/packages/openapi-generator/src/openapi-types.ts
@@ -31,7 +31,7 @@ export interface OpenApiDocument {
   /**
    * Parsed schemas of the document.
    */
-  schemas: OpenApiNamedSchema[];
+  schemas: OpenApiPersistedSchema[];
 
   /**
    * Parsed APIs of the document.
@@ -193,6 +193,21 @@ export interface OpenApiNamedSchema {
 }
 
 /**
+ * Represents a reference to a schema, that will be saved in a file.
+ */
+export interface OpenApiPersistedSchema extends SchemaNaming {
+  /**
+   * The schema.
+   */
+  schema: OpenApiSchema;
+
+  /**
+   * Description of the schema.
+   */
+  description?: string;
+}
+
+/**
  * Represents an object that can be referenced by the given path.
  */
 export interface WithRefPath {
@@ -304,9 +319,19 @@ export interface OpenApiObjectSchemaProperty extends OpenApiNamedSchema {
 /**
  * Represents a schema referencing another schema by name.
  */
-export interface OpenApiReferenceSchema extends OpenAPIV3.ReferenceObject {
+export type OpenApiReferenceSchema = OpenAPIV3.ReferenceObject & SchemaNaming;
+
+/**
+ * Represents an object containing the parsed names for a schema.
+ */
+export interface SchemaNaming {
   /**
-   * Name of the referenced schema;
+   * Name of the referenced schema.
    */
   schemaName: string;
+
+  /**
+   * File name of the referenced schema file.
+   */
+  fileName: string;
 }

--- a/packages/openapi-generator/src/parser/api.ts
+++ b/packages/openapi-generator/src/parser/api.ts
@@ -4,7 +4,7 @@ import { OpenAPIV3 } from 'openapi-types';
 import { methods, OpenApiApi } from '../openapi-types';
 import { apiNameExtension, defaultApiName } from '../extensions';
 import { parseOperation } from './operation';
-import { OperationInfo } from './parsing-info';
+import { OperationInfo, SchemaRefMapping } from './parsing-info';
 import { nameOperations } from './operation-naming';
 import { ensureUniqueNames } from './unique-naming';
 
@@ -18,7 +18,7 @@ import { ensureUniqueNames } from './unique-naming';
 export function parseApis(
   document: OpenAPIV3.Document,
   refs: $Refs,
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiApi[] {
   const operationsByApis = getOperationsByApis(document);
 
@@ -30,8 +30,9 @@ export function parseApis(
         // All operations got an operationId in the line before
         {
           getName: ({ operation }) => operation.operationId!,
-          setName: (operationInfo, operationId) => {
+          transformItem: (operationInfo, operationId) => {
             operationInfo.operation.operationId = operationId;
+            return operationInfo;
           }
         }
       ).map(operationInfo =>

--- a/packages/openapi-generator/src/parser/media-type.ts
+++ b/packages/openapi-generator/src/parser/media-type.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@sap-cloud-sdk/util';
 import { OpenAPIV3 } from 'openapi-types';
 import { OpenApiSchema } from '../openapi-types';
+import { SchemaRefMapping } from './parsing-info';
 import { parseSchema } from './schema';
 
 const logger = createLogger('openapi-generator');
@@ -15,7 +16,7 @@ export function parseApplicationJsonMediaType(
     | OpenAPIV3.RequestBodyObject
     | OpenAPIV3.ResponseObject
     | undefined,
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiSchema | undefined {
   if (bodyOrResponseObject) {
     const mediaType = getMediaTypeObject(
@@ -34,7 +35,7 @@ export function parseMediaType(
     | OpenAPIV3.RequestBodyObject
     | OpenAPIV3.ResponseObject
     | undefined,
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiSchema | undefined {
   const allMediaTypes = getMediaTypes(bodyOrResponseObject);
   if (allMediaTypes.length) {

--- a/packages/openapi-generator/src/parser/operation.ts
+++ b/packages/openapi-generator/src/parser/operation.ts
@@ -11,7 +11,7 @@ import { parseRequestBody } from './request-body';
 import { resolveObject } from './refs';
 import { parseSchema } from './schema';
 import { parseResponses } from './responses';
-import { OperationInfo } from './parsing-info';
+import { OperationInfo, SchemaRefMapping } from './parsing-info';
 import { reservedJsKeywords } from './reserved-words';
 
 /**
@@ -24,7 +24,7 @@ import { reservedJsKeywords } from './reserved-words';
 export function parseOperation(
   { operation, pathPattern, method, pathItemParameters }: OperationInfo,
   refs: $Refs,
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiOperation {
   const requestBody = parseRequestBody(
     operation.requestBody,
@@ -126,7 +126,7 @@ export function parsePathPattern(
 export function parsePathParameters(
   pathParameters: OpenAPIV3.ParameterObject[],
   pathPattern: string,
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiParameter[] {
   const sortedPathParameters = sortPathParameters(pathParameters, pathPattern);
   const nameGenerator = new UniqueNameGenerator('', [
@@ -143,7 +143,7 @@ export function parsePathParameters(
 
 export function parseParameters(
   pathParameters: OpenAPIV3.ParameterObject[],
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiParameter[] {
   return pathParameters.map(param => ({
     ...param,

--- a/packages/openapi-generator/src/parser/parsing-info.ts
+++ b/packages/openapi-generator/src/parser/parsing-info.ts
@@ -1,6 +1,6 @@
 import { OpenAPIV3 } from 'openapi-types';
 import { OperationNameExtended } from '../extensions';
-import { Method } from '../openapi-types';
+import { Method, SchemaNaming } from '../openapi-types';
 
 /**
  * Represents an object holding all relevant information for operation parsing.
@@ -33,8 +33,25 @@ export interface OperationInfo {
   pathItemParameters: (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[];
 }
 
+/**
+ * Represents an object holding all relevant information for schema parsing.
+ */
 export interface SchemaInfo {
+  /**
+   * Path, by which this schema is referenced.
+   */
   refPath: string;
+  /**
+   * Unique name for this schema.
+   */
   name: string;
+  /**
+   * The original schema as in the specification.
+   */
   schema: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject;
 }
+
+/**
+ * Type of an object representing a mapping between the reference path (key) and the unique parsed names for the schema.
+ */
+export type SchemaRefMapping = Record<string, SchemaNaming>;

--- a/packages/openapi-generator/src/parser/request-body.spec.ts
+++ b/packages/openapi-generator/src/parser/request-body.spec.ts
@@ -50,12 +50,17 @@ describe('getRequestBody', () => {
       required: true
     };
 
+    const schemaNaming = {
+      schemaName: 'TestEntity',
+      fileName: 'test-entity'
+    };
+
     expect(
       parseRequestBody(requestBody, await createRefs(), {
-        '#/components/schemas/TestEntity': 'TestEntity'
+        '#/components/schemas/TestEntity': schemaNaming
       })
     ).toEqual({
-      schema: { ...schema, schemaName: 'TestEntity' },
+      schema: { ...schema, ...schemaNaming },
       required: true
     });
   });

--- a/packages/openapi-generator/src/parser/request-body.ts
+++ b/packages/openapi-generator/src/parser/request-body.ts
@@ -3,6 +3,7 @@ import { $Refs } from '@apidevtools/swagger-parser';
 import { OpenApiRequestBody } from '../openapi-types';
 import { resolveObject } from './refs';
 import { parseMediaType } from './media-type';
+import { SchemaRefMapping } from './parsing-info';
 
 /**
  * Parse the request body.
@@ -17,7 +18,7 @@ export function parseRequestBody(
     | OpenAPIV3.RequestBodyObject
     | undefined,
   refs: $Refs,
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiRequestBody | undefined {
   const resolvedRequestBody = resolveObject(requestBody, refs);
   const schema = parseMediaType(resolvedRequestBody, schemaRefMapping);

--- a/packages/openapi-generator/src/parser/responses.spec.ts
+++ b/packages/openapi-generator/src/parser/responses.spec.ts
@@ -34,6 +34,10 @@ describe('parseResponses', () => {
   });
 
   it('parses response schema from multiple success codes', async () => {
+    const schemaNaming = {
+      schemaName: 'RefType',
+      fileName: 'ref-type'
+    };
     expect(
       parseResponses(
         {
@@ -53,12 +57,14 @@ describe('parseResponses', () => {
           }
         },
         await createRefs(),
-        { '#/components/schema/RefType': 'RefType' }
+        {
+          '#/components/schema/RefType': schemaNaming
+        }
       )
     ).toEqual({
       anyOf: [
         { type: 'string' },
-        { $ref: '#/components/schema/RefType', schemaName: 'RefType' }
+        { $ref: '#/components/schema/RefType', ...schemaNaming }
       ]
     });
   });

--- a/packages/openapi-generator/src/parser/responses.ts
+++ b/packages/openapi-generator/src/parser/responses.ts
@@ -3,6 +3,7 @@ import { $Refs } from '@apidevtools/swagger-parser';
 import { OpenApiSchema } from '../openapi-types';
 import { resolveObject } from './refs';
 import { parseMediaType } from './media-type';
+import { SchemaRefMapping } from './parsing-info';
 
 /**
  * Parse the type of the responses in an operation.
@@ -14,7 +15,7 @@ import { parseMediaType } from './media-type';
 export function parseResponses(
   responses: OpenAPIV3.ResponsesObject | undefined,
   refs: $Refs,
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiSchema {
   if (responses) {
     const responseSchemas = Object.entries(responses)

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@sap-cloud-sdk/util';
 import { OpenAPIV3 } from 'openapi-types';
-import { isReferenceObject, parseTypeNameFromRef } from '../schema-util';
+import { isReferenceObject, getSchemaNamingFromRef } from '../schema-util';
 import {
   OpenApiArraySchema,
   OpenApiEnumSchema,
@@ -10,6 +10,7 @@ import {
   OpenApiSchema
 } from '../openapi-types';
 import { getType } from './type-mapping';
+import { SchemaRefMapping } from './parsing-info';
 
 const logger = createLogger('openapi-generator');
 
@@ -21,7 +22,7 @@ const logger = createLogger('openapi-generator');
  */
 export function parseSchema(
   schema: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject | undefined,
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiSchema {
   if (!schema) {
     logger.debug("No schema provided, continuing with 'any'.");
@@ -73,11 +74,11 @@ export function parseSchema(
 
 function parseReferenceSchema(
   schema: OpenAPIV3.ReferenceObject,
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiReferenceSchema {
   return {
     ...schema,
-    schemaName: parseTypeNameFromRef(schema, schemaRefMapping)
+    ...getSchemaNamingFromRef(schema, schemaRefMapping)
   };
 }
 
@@ -89,7 +90,7 @@ function parseReferenceSchema(
  */
 function parseArraySchema(
   schema: OpenAPIV3.ArraySchemaObject,
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiArraySchema {
   return {
     uniqueItems: schema.uniqueItems,
@@ -105,7 +106,7 @@ function parseArraySchema(
  */
 function parseObjectSchema(
   schema: OpenAPIV3.NonArraySchemaObject,
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiObjectSchema {
   const properties = parseObjectSchemaProperties(schema, schemaRefMapping);
 
@@ -139,7 +140,7 @@ function parseObjectSchema(
  */
 function parseObjectSchemaProperties(
   schema: OpenAPIV3.NonArraySchemaObject,
-  schemaRefMapping: Record<string, string>
+  schemaRefMapping: SchemaRefMapping
 ): OpenApiObjectSchemaProperty[] {
   return Object.entries(schema.properties || {}).reduce(
     (props, [propName, propSchema]) => [
@@ -183,7 +184,7 @@ function parseEnumSchema(
  */
 function parseXOfSchema(
   schema: OpenAPIV3.NonArraySchemaObject,
-  schemaRefMapping: Record<string, string>,
+  schemaRefMapping: SchemaRefMapping,
   xOf: 'oneOf' | 'allOf' | 'anyOf'
 ): any {
   return {

--- a/packages/openapi-generator/src/parser/unique-naming.spec.ts
+++ b/packages/openapi-generator/src/parser/unique-naming.spec.ts
@@ -34,6 +34,17 @@ it('ensureUniqueNames replaces duplicate names using pascal case', () => {
   ]);
 });
 
+it('ensureUniqueNames replaces duplicate names if they occur in the reserved words', () => {
+  const uniqueItems = ensureUniqueNames(
+    [{ name: 'reserved' }, { name: 'reserved1' }],
+    {
+      reservedWords: ['reserved']
+    }
+  );
+
+  expect(uniqueItems).toEqual([{ name: 'reserved2' }, { name: 'reserved1' }]);
+});
+
 it('ensureUniqueNames replaces duplicate names for operations', () => {
   const uniqueOperations = ensureUniqueNames(
     [

--- a/packages/openapi-generator/src/parser/unique-naming.spec.ts
+++ b/packages/openapi-generator/src/parser/unique-naming.spec.ts
@@ -43,8 +43,9 @@ it('ensureUniqueNames replaces duplicate names for operations', () => {
     ],
     {
       getName: ({ operation }) => operation.operationId!,
-      setName: (operationInfo, operationId) => {
+      transformItem: (operationInfo, operationId) => {
         operationInfo.operation.operationId = operationId;
+        return operationInfo;
       }
     }
   );

--- a/packages/openapi-generator/src/parser/unique-naming.ts
+++ b/packages/openapi-generator/src/parser/unique-naming.ts
@@ -1,45 +1,44 @@
 import { UniqueNameGenerator, camelCase } from '@sap-cloud-sdk/util';
 
-/**
- * Ensure uniqueness of names.
- * Takes a list of items, identifies duplicate names and renames the duplicate names.
- * @param items List of items to rename.
- * @param nameHandler Object containing a name getter and/or setter and/or formatter.
- * @param nameHandler.getName Function to get the name of an item. Retrieves the `name` property by default.
- * @param nameHandler.setName Function to set the name of an item. Sets the name property by default.
- * @param nameHandler.formatName Function to transform the name when finding a unique name. Defaults to camel case.
- * @returns The given items with unique names.
- */
-export function ensureUniqueNames<ItemT>(
+export function ensureUniqueNames<ItemT, UniqueItemT>(
   items: ItemT[],
   nameHandler: {
     getName?: (item: ItemT) => string;
-    setName?: (item: ItemT, name: string) => void;
+    transformItem?: (item: ItemT, name: string) => UniqueItemT;
     formatName?: (name: string) => string;
+    reservedWords?: string[];
   } = {}
-): ItemT[] {
+): UniqueItemT[] {
   const {
     getName = getNameDefault,
-    setName = setNameDefault,
-    formatName = camelCase
+    transformItem = transformItemDefault,
+    formatName = camelCase,
+    reservedWords = []
   } = nameHandler;
 
-  const uniqueItems = getCorrectlyNamedItems(items, getName, formatName);
-
-  const nameGenerator = new UniqueNameGenerator(
-    '',
-    uniqueItems.map(item => getName(item))
+  const uniqueItems = getCorrectlyNamedItems(
+    items,
+    getName,
+    formatName,
+    reservedWords
   );
+
+  const nameGenerator = new UniqueNameGenerator('', [
+    ...reservedWords,
+    ...uniqueItems.map(item => getName(item))
+  ]);
 
   const uniqueNames = uniqueItems.map(item => getName(item));
   return items.map(item => {
     const name = getName(item);
     if (uniqueNames.length && uniqueNames[0] === name) {
       uniqueNames.shift();
-    } else {
-      setName(item, nameGenerator.generateAndSaveUniqueName(formatName(name)));
+      return transformItem(item, name);
     }
-    return item;
+    return transformItem(
+      item,
+      nameGenerator.generateAndSaveUniqueName(formatName(name))
+    );
   });
 }
 
@@ -49,24 +48,25 @@ export function ensureUniqueNames<ItemT>(
  * @param items Named items.
  * @param getName Function to get the name of an item.
  * @param formatName Function to transform the name when finding a unique name.
-
+ * @param reservedWords Reserved words that should not be handled as duplicates.
  * @returns An object containing the unique operations, denoted by `unique` and operations with (potentially) duplicate names, denoted by `duplicate`.
  */
 function getCorrectlyNamedItems<ItemT>(
   items: ItemT[],
   getName: (item: ItemT) => string,
-  formatName: (name: string) => string
+  formatName: (name: string) => string,
+  reservedWords: string[]
 ): ItemT[] {
   return items.reduce((uniqueItems, item) => {
     const name = getName(item);
+    const isReserved = reservedWords.includes(name);
     const isDuplicate = uniqueItems.some(
       uniqueItem => getName(uniqueItem) === name
     );
     const isFormatted = formatName(name) === name;
-    if (isDuplicate || !isFormatted) {
-      return uniqueItems;
-    }
-    return [...uniqueItems, item];
+    return isReserved || isDuplicate || !isFormatted
+      ? uniqueItems
+      : [...uniqueItems, item];
   }, [] as ItemT[]);
 }
 
@@ -83,7 +83,14 @@ export function getNameDefault<ItemT>(item: ItemT): string {
  * Default function to set the name of an item.
  * @param item The item to set the name on.
  * @param name The name to set.
+ * @returns The renamed item.
  */
-export function setNameDefault<ItemT>(item: ItemT, name: string): void {
-  item['name'] = name;
+export function transformItemDefault<
+  ItemT,
+  UniqueItemT = ItemT & { name: string }
+>(item: ItemT, name: string): UniqueItemT {
+  return ({
+    ...item,
+    name
+  } as unknown) as UniqueItemT;
 }

--- a/packages/openapi-generator/src/parser/unique-naming.ts
+++ b/packages/openapi-generator/src/parser/unique-naming.ts
@@ -91,8 +91,9 @@ export function getNameDefault<ItemT>(item: ItemT): string {
 }
 
 /**
- * Default function to set the name of an item.
- * @param item The item to set the name on.
+ * Default function to transform an item.
+ * It sets the `name` property of the item to the given name.
+ * @param item The item to trsansform.
  * @param name The name to set.
  * @returns The renamed item.
  */

--- a/packages/openapi-generator/src/parser/unique-naming.ts
+++ b/packages/openapi-generator/src/parser/unique-naming.ts
@@ -1,5 +1,16 @@
 import { UniqueNameGenerator, camelCase } from '@sap-cloud-sdk/util';
 
+/**
+ * Ensure uniqueness of names.
+ * Takes a list of items, identifies duplicate names and renames the duplicate names.
+ * @param items List of items to rename.
+ * @param nameHandler Object containing a name getter and/or setter and/or formatter.
+ * @param nameHandler.getName Function to get the name of an item. Retrieves the `name` property by default.
+ * @param nameHandler.transformItem Function to transform the given item with the new name. Sets the `name` property by default.
+ * @param nameHandler.formatName Function to transform the name when finding a unique name. Defaults to camel case.
+ * @param nameHandler.reservedWords Reserved words that should be handled as duplicates.
+ * @returns The given items with unique names.
+ */
 export function ensureUniqueNames<ItemT, UniqueItemT>(
   items: ItemT[],
   nameHandler: {
@@ -48,7 +59,7 @@ export function ensureUniqueNames<ItemT, UniqueItemT>(
  * @param items Named items.
  * @param getName Function to get the name of an item.
  * @param formatName Function to transform the name when finding a unique name.
- * @param reservedWords Reserved words that should not be handled as duplicates.
+ * @param reservedWords Reserved words that should be handled as duplicates.
  * @returns An object containing the unique operations, denoted by `unique` and operations with (potentially) duplicate names, denoted by `duplicate`.
  */
 function getCorrectlyNamedItems<ItemT>(

--- a/packages/openapi-generator/src/schema-util.spec.ts
+++ b/packages/openapi-generator/src/schema-util.spec.ts
@@ -1,48 +1,41 @@
-import { collectRefs, parseFileNameFromRef } from './schema-util';
+import { OpenApiReferenceSchema } from './openapi-types';
+import { collectRefs, getSchemaNamingFromRef } from './schema-util';
 
-describe('getSchemaNameFromRef', () => {
-  it('gets the type name for reference object from schema reference mapping', () => {
+describe('getSchemaNamingFromRef', () => {
+  it('gets the schema naming for reference object from schema reference mapping', () => {
+    const schemaNaming = {
+      schemaName: 'TypeName',
+      fileName: 'type-name'
+    };
     expect(
-      getSchemaNameFromRef(
+      getSchemaNamingFromRef(
         {
           $ref: '#/components/schemas/typeName'
         },
         {
-          '#/components/schemas/typeName': 'TypeName'
+          '#/components/schemas/typeName': schemaNaming
         }
       )
-    ).toEqual('TypeName');
+    ).toEqual(schemaNaming);
   });
 
-  it('gets the type name for reference path from schema reference mapping', () => {
+  it('gets the schema naming for reference path from schema reference mapping', () => {
+    const schemaNaming = {
+      schemaName: 'TypeName',
+      fileName: 'type-name'
+    };
     expect(
-      getSchemaNameFromRef('#/components/schemas/typeName', {
-        '#/components/schemas/typeName': 'TypeName'
+      getSchemaNamingFromRef('#/components/schemas/typeName', {
+        '#/components/schemas/typeName': schemaNaming
       })
-    ).toEqual('TypeName');
+    ).toEqual(schemaNaming);
   });
 
   it('throws an error for unknown type reference', () => {
     expect(() =>
-      getSchemaNameFromRef('#/components/schemas/typeName', {})
+      getSchemaNamingFromRef('#/components/schemas/typeName', {})
     ).toThrowErrorMatchingInlineSnapshot(
-      '"Could not find schema name for reference path \'#/components/schemas/typeName\'. Schema does not exist."'
-    );
-  });
-});
-
-describe('parseFileNameFromRef', () => {
-  it('gets the last part of a reference as type name', () => {
-    expect(
-      parseFileNameFromRef({
-        $ref: '#/components/schemas/typeName'
-      })
-    ).toEqual('type-name');
-  });
-
-  it('gets the last part of a string as type name', () => {
-    expect(parseFileNameFromRef('#/components/schemas/typeName')).toEqual(
-      'type-name'
+      '"Could not find schema naming for reference path \'#/components/schemas/typeName\'. Schema does not exist."'
     );
   });
 });
@@ -62,22 +55,27 @@ describe('collectRefs', () => {
               {
                 name: 'refProperty',
                 required: false,
-                schema: { $ref: 'ref1', schemaName: 'Ref1' }
+                schema: {
+                  $ref: 'ref1',
+                  schemaName: 'Ref1'
+                } as OpenApiReferenceSchema
               }
             ]
           },
-          { $ref: 'ref2', schemaName: 'Ref2' },
+          { $ref: 'ref2', schemaName: 'Ref2' } as OpenApiReferenceSchema,
           {
-            anyOf: [{ $ref: 'ref3', schemaName: 'Ref3' }]
+            anyOf: [
+              { $ref: 'ref3', schemaName: 'Ref3' } as OpenApiReferenceSchema
+            ]
           },
-          { $ref: 'ref3', schemaName: 'Ref3' }
+          { $ref: 'ref3', schemaName: 'Ref3' } as OpenApiReferenceSchema
         ]
       }).map(ref => ref.$ref)
     ).toStrictEqual(['ref1', 'ref2', 'ref3']);
   });
 
   it('collects one reference if the schema is a reference', () => {
-    const ref = { $ref: 'test', schemaName: 'Test' };
+    const ref = { $ref: 'test', schemaName: 'Test' } as OpenApiReferenceSchema;
     expect(collectRefs(ref)).toEqual([ref]);
   });
 });

--- a/packages/openapi-generator/src/schema-util.spec.ts
+++ b/packages/openapi-generator/src/schema-util.spec.ts
@@ -1,13 +1,9 @@
-import {
-  collectRefs,
-  parseFileNameFromRef,
-  parseTypeNameFromRef
-} from './schema-util';
+import { collectRefs, parseFileNameFromRef } from './schema-util';
 
-describe('parseTypeNameFromRef', () => {
+describe('getSchemaNameFromRef', () => {
   it('gets the type name for reference object from schema reference mapping', () => {
     expect(
-      parseTypeNameFromRef(
+      getSchemaNameFromRef(
         {
           $ref: '#/components/schemas/typeName'
         },
@@ -20,7 +16,7 @@ describe('parseTypeNameFromRef', () => {
 
   it('gets the type name for reference path from schema reference mapping', () => {
     expect(
-      parseTypeNameFromRef('#/components/schemas/typeName', {
+      getSchemaNameFromRef('#/components/schemas/typeName', {
         '#/components/schemas/typeName': 'TypeName'
       })
     ).toEqual('TypeName');
@@ -28,7 +24,7 @@ describe('parseTypeNameFromRef', () => {
 
   it('throws an error for unknown type reference', () => {
     expect(() =>
-      parseTypeNameFromRef('#/components/schemas/typeName', {})
+      getSchemaNameFromRef('#/components/schemas/typeName', {})
     ).toThrowErrorMatchingInlineSnapshot(
       '"Could not find schema name for reference path \'#/components/schemas/typeName\'. Schema does not exist."'
     );

--- a/packages/openapi-generator/src/schema-util.ts
+++ b/packages/openapi-generator/src/schema-util.ts
@@ -147,7 +147,7 @@ export function getSchemaNamingFromRef(
   const schemaNaming = schemaRefMapping[ref];
   if (!schemaNaming) {
     throw new Error(
-      `Could not find schema name for reference path '${ref}'. Schema does not exist.`
+      `Could not find schema naming for reference path '${ref}'. Schema does not exist.`
     );
   }
   return schemaNaming;

--- a/packages/openapi-generator/src/schema-util.ts
+++ b/packages/openapi-generator/src/schema-util.ts
@@ -1,4 +1,4 @@
-import { flat, kebabCase, last } from '@sap-cloud-sdk/util';
+import { flat } from '@sap-cloud-sdk/util';
 import { OpenAPIV3 } from 'openapi-types';
 import {
   OpenApiAllOfSchema,
@@ -9,8 +9,10 @@ import {
   OpenApiObjectSchema,
   OpenApiOneOfSchema,
   OpenApiReferenceSchema,
-  OpenApiSchema
+  OpenApiSchema,
+  SchemaNaming
 } from './openapi-types';
+import { SchemaRefMapping } from './parser/parsing-info';
 
 /**
  * Collect all unique reference schemas within the given schemas.
@@ -137,32 +139,16 @@ export function isNotSchema(obj: any): obj is OpenApiNotSchema {
  * @param schemaRefMapping Mapping between reference paths and schema names.
  * @returns Parsed type name.
  */
-export function parseTypeNameFromRef(
+export function getSchemaNamingFromRef(
   obj: OpenAPIV3.ReferenceObject | string,
-  schemaRefMapping: Record<string, string>
-): string {
+  schemaRefMapping: SchemaRefMapping
+): SchemaNaming {
   const ref = isReferenceObject(obj) ? obj.$ref : obj;
-  const schemaName = schemaRefMapping[ref];
-  if (!schemaName) {
+  const schemaNaming = schemaRefMapping[ref];
+  if (!schemaNaming) {
     throw new Error(
       `Could not find schema name for reference path '${ref}'. Schema does not exist.`
     );
   }
-  return schemaName;
-}
-
-/**
- * Parse the file name for a serialized reference object.
- * @param obj Reference object to get the type name from.
- * @returns Parsed file name.
- */
-export function parseFileNameFromRef(
-  obj: OpenAPIV3.ReferenceObject | string
-): string {
-  return kebabCase(parseType(obj));
-}
-
-function parseType(obj: OpenAPIV3.ReferenceObject | string): string {
-  const ref = isReferenceObject(obj) ? obj.$ref : obj;
-  return last(ref.split('/'))!;
+  return schemaNaming;
 }

--- a/test-packages/test-services/openapi/swagger-yaml-service/schema/index.d.ts.map
+++ b/test-packages/test-services/openapi/swagger-yaml-service/schema/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAKI,cAAc,eAAe,CAAC"}
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAKA,cAAc,eAAe,CAAC"}

--- a/test-packages/test-services/openapi/swagger-yaml-service/schema/index.js.map
+++ b/test-packages/test-services/openapi/swagger-yaml-service/schema/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":";;;;;;;;;;;;AAAA;;;;GAIG;AACC,gDAA8B"}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":";;;;;;;;;;;;AAAA;;;;GAIG;AACH,gDAA8B"}

--- a/test-packages/test-services/openapi/test-service/schema/index.d.ts.map
+++ b/test-packages/test-services/openapi/test-service/schema/index.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAKI,cAAc,eAAe,CAAC;AAC9B,cAAc,sBAAsB,CAAC;AACrC,cAAc,4BAA4B,CAAC;AAC3C,cAAc,mCAAmC,CAAC;AAClD,cAAc,qCAAqC,CAAC;AACpD,cAAc,uBAAuB,CAAC;AACtC,cAAc,iBAAiB,CAAC;AAChC,cAAc,gBAAgB,CAAC"}
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAKA,cAAc,eAAe,CAAC;AAC9B,cAAc,sBAAsB,CAAC;AACrC,cAAc,4BAA4B,CAAC;AAC3C,cAAc,mCAAmC,CAAC;AAClD,cAAc,qCAAqC,CAAC;AACpD,cAAc,uBAAuB,CAAC;AACtC,cAAc,iBAAiB,CAAC;AAChC,cAAc,gBAAgB,CAAC"}

--- a/test-packages/test-services/openapi/test-service/schema/index.js.map
+++ b/test-packages/test-services/openapi/test-service/schema/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":";;;;;;;;;;;;AAAA;;;;GAIG;AACC,gDAA8B;AAC9B,uDAAqC;AACrC,6DAA2C;AAC3C,oEAAkD;AAClD,sEAAoD;AACpD,wDAAsC;AACtC,kDAAgC;AAChC,iDAA+B"}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":";;;;;;;;;;;;AAAA;;;;GAIG;AACH,gDAA8B;AAC9B,uDAAqC;AACrC,6DAA2C;AAC3C,oEAAkD;AAClD,sEAAoD;AACpD,wDAAsC;AACtC,kDAAgC;AAChC,iDAA+B"}


### PR DESCRIPTION
This fixes naming and import conflicts in schemas, e.g. for the `index` file.
There is a single source of truth for filenames now and they are not derived from the schema name anymore.