### PR TITLE
chore: Refactor unique naming functions

### DIFF
--- a/packages/openapi-generator/src/parser/operation.spec.ts
+++ b/packages/openapi-generator/src/parser/operation.spec.ts
@@ -149,13 +149,24 @@ describe('parsePathParameters', () => {
         '/root/{path-param}/{pathParam}/path/{PathParam1}/sub-path/{path_param}',
         await createTestRefs()
       )
-    ).toEqual(
-      [pathParam3, pathParam1, pathParam2, pathParam4].map((param, i) => ({
-        ...param,
-        originalName: param.name,
-        name: 'pathParam' + (i ? i : '')
-      }))
-    );
+    ).toEqual([
+      expect.objectContaining({
+        name: 'pathParam1',
+        originalName: 'path-param'
+      }),
+      expect.objectContaining({
+        name: 'pathParam',
+        originalName: 'pathParam'
+      }),
+      expect.objectContaining({
+        name: 'pathParam2',
+        originalName: 'PathParam1'
+      }),
+      expect.objectContaining({
+        name: 'pathParam3',
+        originalName: 'path_param'
+      })
+    ]);
   });
 });
 

--- a/packages/openapi-generator/src/parser/operation.ts
+++ b/packages/openapi-generator/src/parser/operation.ts
@@ -115,7 +115,7 @@ export function parsePathParameters(
 ): OpenApiParameter[] {
   const sortedPathParameters = sortPathParameters(pathParameters, pathPattern);
   const parsedParameters = parseParameters(sortedPathParameters, refs);
-  const names = ensureUniqueNames(
+  const uniqueNames = ensureUniqueNames(
     parsedParameters.map(({ originalName }) => originalName),
     {
       reservedWords: ['body', 'queryParameters', ...reservedJsKeywords]
@@ -123,7 +123,7 @@ export function parsePathParameters(
   );
 
   return parsedParameters.map((param, i) => {
-    param.name = names[i];
+    param.name = uniqueNames[i];
     return param;
   });
 }

--- a/packages/openapi-generator/src/parser/operation.ts
+++ b/packages/openapi-generator/src/parser/operation.ts
@@ -1,10 +1,5 @@
 import { OpenAPIV3 } from 'openapi-types';
-import {
-  camelCase,
-  filterDuplicatesRight,
-  partition,
-  UniqueNameGenerator
-} from '@sap-cloud-sdk/util';
+import { filterDuplicatesRight, partition } from '@sap-cloud-sdk/util';
 import { OpenApiOperation, OpenApiParameter } from '../openapi-types';
 import { parseRequestBody } from './request-body';
 import { OpenApiDocumentRefs } from './refs';
@@ -12,6 +7,7 @@ import { parseSchema } from './schema';
 import { parseResponses } from './responses';
 import { OperationInfo } from './parsing-info';
 import { reservedJsKeywords } from './reserved-words';
+import { ensureUniqueNames } from './unique-naming';
 
 /**
  * Parse an operation info into a serialization-ready object.
@@ -118,16 +114,18 @@ export function parsePathParameters(
   refs: OpenApiDocumentRefs
 ): OpenApiParameter[] {
   const sortedPathParameters = sortPathParameters(pathParameters, pathPattern);
-  const nameGenerator = new UniqueNameGenerator('', [
-    'body',
-    'queryParameters',
-    ...reservedJsKeywords
-  ]);
+  const parsedParameters = parseParameters(sortedPathParameters, refs);
+  const names = ensureUniqueNames(
+    parsedParameters.map(({ originalName }) => originalName),
+    {
+      reservedWords: ['body', 'queryParameters', ...reservedJsKeywords]
+    }
+  );
 
-  return parseParameters(sortedPathParameters, refs).map(param => ({
-    ...param,
-    name: nameGenerator.generateAndSaveUniqueName(camelCase(param.originalName))
-  }));
+  return parsedParameters.map((param, i) => {
+    param.name = names[i];
+    return param;
+  });
 }
 
 export function parseParameters(

--- a/packages/openapi-generator/src/parser/refs.ts
+++ b/packages/openapi-generator/src/parser/refs.ts
@@ -45,33 +45,21 @@ export class OpenApiDocumentRefs {
     document: OpenAPIV3.Document
   ): SchemaRefMapping {
     const originalNames = Object.keys(document.components?.schemas || {});
-
     const schemaNames = ensureUniqueNames(originalNames, {
-      formatName: pascalCase,
-      getName: item => item,
-      transformItem: (originalName, schemaName) => ({
-        originalName,
-        schemaName
-      })
+      format: pascalCase
     });
-
-    const schemaNamesWithFileNames = ensureUniqueNames(schemaNames, {
-      transformItem: (item, name) => ({
-        originalName: item.originalName,
-        schemaNaming: {
-          schemaName: item.schemaName,
-          fileName: name
-        }
-      }),
-      getName: ({ schemaName }) => schemaName,
-      formatName: kebabCase,
+    const fileNames = ensureUniqueNames(schemaNames, {
+      format: kebabCase,
       reservedWords: ['index']
     });
 
-    return schemaNamesWithFileNames.reduce(
-      (mapping, { originalName, schemaNaming }) => ({
+    return originalNames.reduce(
+      (mapping, originalName, i) => ({
         ...mapping,
-        [`#/components/schemas/${originalName}`]: schemaNaming
+        [`#/components/schemas/${originalName}`]: {
+          schemaName: schemaNames[i],
+          fileName: fileNames[i]
+        }
       }),
       {}
     );

--- a/packages/openapi-generator/src/parser/unique-naming.spec.ts
+++ b/packages/openapi-generator/src/parser/unique-naming.spec.ts
@@ -1,31 +1,34 @@
 import { pascalCase } from '@sap-cloud-sdk/util';
 import { ensureUniqueNames } from './unique-naming';
 
-it('ensureUniqueNames replaces duplicate names using defaults', () => {
-  expect(
-    ensureUniqueNames([
-      'someDuplicateName1',
-      'someDuplicateName',
-      'someDuplicateName'
-    ])
-  ).toEqual(['someDuplicateName1', 'someDuplicateName', 'someDuplicateName2']);
-});
-
-it('ensureUniqueNames replaces duplicate names using pascal case', () => {
-  expect(
-    ensureUniqueNames(
-      ['someDuplicateName1', 'SomeDuplicateName', 'someDuplicateName'],
-      {
+describe('ensureUniqueNames', () => {
+  it('replaces duplicate names using defaults', () => {
+    expect(
+      ensureUniqueNames(['duplicate', 'duplicate'], {
         format: pascalCase
-      }
-    )
-  ).toEqual(['SomeDuplicateName1', 'SomeDuplicateName', 'SomeDuplicateName2']);
-});
-
-it('ensureUniqueNames replaces duplicate names if they occur in the reserved words', () => {
-  const uniqueItems = ensureUniqueNames(['reserved', 'reserved1'], {
-    reservedWords: ['reserved']
+      })
+    ).toEqual(['duplicate', 'duplicate1']);
   });
 
-  expect(uniqueItems).toEqual(['reserved2', 'reserved1']);
+  it('replaces duplicate names using pascal case', () => {
+    expect(
+      ensureUniqueNames(['Duplicate', 'duplicate'], {
+        format: pascalCase
+      })
+    ).toEqual(['Duplicate', 'Duplicate1']);
+  });
+
+  it('replaces duplicate names, while keeping camel case names as is', () => {
+    expect(
+      ensureUniqueNames(['duplicate1', 'duplicate', 'duplicate'])
+    ).toEqual(['duplicate1', 'duplicate', 'duplicate2']);
+  });
+
+  it('replaces duplicate names if they occur in the reserved words', () => {
+    const uniqueItems = ensureUniqueNames(['reserved', 'reserved1'], {
+      reservedWords: ['reserved']
+    });
+
+    expect(uniqueItems).toEqual(['reserved2', 'reserved1']);
+  });
 });

--- a/packages/openapi-generator/src/parser/unique-naming.spec.ts
+++ b/packages/openapi-generator/src/parser/unique-naming.spec.ts
@@ -1,69 +1,31 @@
 import { pascalCase } from '@sap-cloud-sdk/util';
 import { ensureUniqueNames } from './unique-naming';
 
-it('ensureUniqueNames replaces duplicate names using defaults (getName, setName, formatName)', () => {
-  const uniqueItems = ensureUniqueNames([
-    { name: 'someDuplicateName1', id: '1' },
-    { name: 'someDuplicateName', id: '2' },
-    { name: 'someDuplicateName', id: '3' }
-  ]);
-
-  expect(uniqueItems).toEqual([
-    { name: 'someDuplicateName1', id: '1' },
-    { name: 'someDuplicateName', id: '2' },
-    { name: 'someDuplicateName2', id: '3' }
-  ]);
+it('ensureUniqueNames replaces duplicate names using defaults', () => {
+  expect(
+    ensureUniqueNames([
+      'someDuplicateName1',
+      'someDuplicateName',
+      'someDuplicateName'
+    ])
+  ).toEqual(['someDuplicateName1', 'someDuplicateName', 'someDuplicateName2']);
 });
 
 it('ensureUniqueNames replaces duplicate names using pascal case', () => {
-  const uniqueItems = ensureUniqueNames(
-    [
-      { name: 'someDuplicateName1', id: '1' },
-      { name: 'SomeDuplicateName', id: '2' },
-      { name: 'someDuplicateName', id: '3' }
-    ],
-    {
-      formatName: pascalCase
-    }
-  );
-
-  expect(uniqueItems).toEqual([
-    { name: 'SomeDuplicateName1', id: '1' },
-    { name: 'SomeDuplicateName', id: '2' },
-    { name: 'SomeDuplicateName2', id: '3' }
-  ]);
+  expect(
+    ensureUniqueNames(
+      ['someDuplicateName1', 'SomeDuplicateName', 'someDuplicateName'],
+      {
+        format: pascalCase
+      }
+    )
+  ).toEqual(['SomeDuplicateName1', 'SomeDuplicateName', 'SomeDuplicateName2']);
 });
 
 it('ensureUniqueNames replaces duplicate names if they occur in the reserved words', () => {
-  const uniqueItems = ensureUniqueNames(
-    [{ name: 'reserved' }, { name: 'reserved1' }],
-    {
-      reservedWords: ['reserved']
-    }
-  );
+  const uniqueItems = ensureUniqueNames(['reserved', 'reserved1'], {
+    reservedWords: ['reserved']
+  });
 
-  expect(uniqueItems).toEqual([{ name: 'reserved2' }, { name: 'reserved1' }]);
-});
-
-it('ensureUniqueNames replaces duplicate names for operations', () => {
-  const uniqueOperations = ensureUniqueNames(
-    [
-      { operation: { operationId: 'getX', summary: 'operation1' } },
-      { operation: { operationId: 'getX', summary: 'operation2' } },
-      { operation: { operationId: 'getX1', summary: 'operation3' } }
-    ],
-    {
-      getName: ({ operation }) => operation.operationId!,
-      transformItem: (operationInfo, operationId) => {
-        operationInfo.operation.operationId = operationId;
-        return operationInfo;
-      }
-    }
-  );
-
-  expect(uniqueOperations.map(({ operation }) => operation)).toEqual([
-    { operationId: 'getX', summary: 'operation1' },
-    { operationId: 'getX2', summary: 'operation2' },
-    { operationId: 'getX1', summary: 'operation3' }
-  ]);
+  expect(uniqueItems).toEqual(['reserved2', 'reserved1']);
 });

--- a/packages/openapi-generator/src/parser/unique-naming.spec.ts
+++ b/packages/openapi-generator/src/parser/unique-naming.spec.ts
@@ -3,11 +3,10 @@ import { ensureUniqueNames } from './unique-naming';
 
 describe('ensureUniqueNames', () => {
   it('replaces duplicate names using defaults', () => {
-    expect(
-      ensureUniqueNames(['duplicate', 'duplicate'], {
-        format: pascalCase
-      })
-    ).toEqual(['duplicate', 'duplicate1']);
+    expect(ensureUniqueNames(['duplicate', 'duplicate'])).toEqual([
+      'duplicate',
+      'duplicate1'
+    ]);
   });
 
   it('replaces duplicate names using pascal case', () => {

--- a/packages/openapi-generator/src/parser/unique-naming.ts
+++ b/packages/openapi-generator/src/parser/unique-naming.ts
@@ -3,6 +3,7 @@ import { UniqueNameGenerator, camelCase } from '@sap-cloud-sdk/util';
 /**
  * Ensure uniqueness of names.
  * Takes a list of names and renames those that are duplicate.
+ * The renamed list has the same order as the original list.
  * @param names List of names to deduplicate.
  * @param options Object containing options to configure the transformation.
  * @param options.format Function to format the name. Defaults to camel case.
@@ -18,16 +19,20 @@ export function ensureUniqueNames(
 ): string[] {
   const { format: format = camelCase, reservedWords = [] } = options;
 
-  const correctNames = getCorrectNames(names, format, reservedWords);
+  const nonConflictingNames = getNonConflictingNames(
+    names,
+    format,
+    reservedWords
+  );
 
   const nameGenerator = new UniqueNameGenerator('', [
     ...reservedWords,
-    ...correctNames
+    ...nonConflictingNames
   ]);
 
   return names.map(name => {
-    if (correctNames.length && correctNames[0] === name) {
-      correctNames.shift();
+    if (nonConflictingNames.length && nonConflictingNames[0] === name) {
+      nonConflictingNames.shift();
       return name;
     }
     return nameGenerator.generateAndSaveUniqueName(format(name));
@@ -36,13 +41,13 @@ export function ensureUniqueNames(
 
 /**
  * Get the names within a list of names that won't have to be renamed.
- * Those are the names that are unique and have a name that does not need to be formatted.
+ * Those are the names that are unique and don't need to be formatted.
  * @param names Names to check.
  * @param format Function to format the name.
  * @param reservedWords Reserved words that should be handled as duplicates.
  * @returns A list of names that do not need to be renamed.
  */
-function getCorrectNames(
+function getNonConflictingNames(
   names: string[],
   format: (name: string) => string,
   reservedWords: string[]


### PR DESCRIPTION
Simplify unique naming functions by a lot. Left-over suggestions from @FrankEssenberger.