### PR TITLE
escape ' for enum strings

### DIFF
--- a/packages/core/test/test-util/test-services/openapi/test-service/entity-api.ts
+++ b/packages/core/test/test-util/test-services/openapi/test-service/entity-api.ts
@@ -20,7 +20,7 @@ export const EntityApi = {
     integerParameter?: number;
     $dollarParameter?: string;
     'dot.parameter'?: string;
-    enumStringParameter?: 'value1' | 'value2';
+    enumStringParameter?: 'value1' | 'value2' | "valueWith'Quote";
     enumInt32Parameter?: 1 | 2;
     enumDoubleParameter?: 1 | 2;
     enumBooleanParameter?: true | false;

--- a/packages/openapi-generator/src/parser/schema.spec.ts
+++ b/packages/openapi-generator/src/parser/schema.spec.ts
@@ -183,6 +183,17 @@ describe('parseSchema', () => {
     });
   });
 
+  it('parses string enum schema with escaping', async () => {
+    const schema: OpenAPIV3.SchemaObject = {
+      enum: ["valueWith'Quot'es"],
+      type: 'string'
+    };
+    expect(parseSchema(schema, await createTestRefs())).toEqual({
+      type: 'string',
+      enum: ["'valueWith\\'Quot\\'es'"]
+    });
+  });
+
   it("parses enum schema with 'string' as default", async () => {
     const schema: OpenAPIV3.SchemaObject = {
       enum: ['one', 'two', 'three']

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -170,9 +170,13 @@ function parseEnumSchema(
   return {
     type,
     enum: (schema.enum || []).map(entry =>
-      type === 'string' ? `'${entry}'` : entry
+      type === 'string' ? toEnumString(entry) : entry
     )
   };
+}
+
+function toEnumString(input: string): string {
+  return `'${input.replace(/'/g, "\\'")}'`;
 }
 
 /**

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -170,12 +170,12 @@ function parseEnumSchema(
   return {
     type,
     enum: (schema.enum || []).map(entry =>
-      type === 'string' ? toEnumString(entry) : entry
+      type === 'string' ? getEnumStringValue(entry) : entry
     )
   };
 }
 
-function toEnumString(input: string): string {
+function getEnumStringValue(input: string): string {
   return `'${input.replace(/'/g, "\\'")}'`;
 }
 

--- a/test-packages/e2e-tests/test/openapi.spec.ts
+++ b/test-packages/e2e-tests/test/openapi.spec.ts
@@ -35,7 +35,7 @@ describe('openapi request builder', () => {
 
   it('executes request with quote in property', async () => {
     const response = await EntityApi.getAllEntities({
-      enumStringParameter: 'value1'
+      enumStringParameter: "valueWith'Quote"
     }).execute(restDestination);
     expect(response.length).toBeGreaterThanOrEqual(4);
   });

--- a/test-packages/e2e-tests/test/openapi.spec.ts
+++ b/test-packages/e2e-tests/test/openapi.spec.ts
@@ -32,6 +32,13 @@ describe('openapi request builder', () => {
     const postCreateCount = await countEntities();
     expect(postCreateCount).toEqual(preCreateCount + 1);
   });
+
+  it('executes request with quote in property', async () => {
+    const response = await EntityApi.getAllEntities({
+      enumStringParameter: 'value1'
+    }).execute(restDestination);
+    expect(response.length).toBeGreaterThanOrEqual(4);
+  });
 });
 
 function countEntities(): Promise<number> {

--- a/test-packages/test-services/openapi/test-service/entity-api.d.ts
+++ b/test-packages/test-services/openapi/test-service/entity-api.d.ts
@@ -17,7 +17,11 @@ export declare const EntityApi: {
           integerParameter?: number | undefined;
           $dollarParameter?: string | undefined;
           'dot.parameter'?: string | undefined;
-          enumStringParameter?: 'value1' | 'value2' | undefined;
+          enumStringParameter?:
+            | 'value1'
+            | 'value2'
+            | "valueWith'Quote"
+            | undefined;
           enumInt32Parameter?: 1 | 2 | undefined;
           enumDoubleParameter?: 1 | 2 | undefined;
           enumBooleanParameter?: boolean | undefined;

--- a/test-packages/test-services/openapi/test-service/entity-api.ts
+++ b/test-packages/test-services/openapi/test-service/entity-api.ts
@@ -20,7 +20,7 @@ export const EntityApi = {
     integerParameter?: number;
     $dollarParameter?: string;
     'dot.parameter'?: string;
-    enumStringParameter?: 'value1' | 'value2';
+    enumStringParameter?: 'value1' | 'value2' | "valueWith'Quote";
     enumInt32Parameter?: 1 | 2;
     enumDoubleParameter?: 1 | 2;
     enumBooleanParameter?: true | false;

--- a/test-resources/openapi-service-specs/test-service.json
+++ b/test-resources/openapi-service-specs/test-service.json
@@ -98,7 +98,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["value1", "value2"]
+              "enum": ["value1", "value2", "valueWith'Quote"]
             }
           },
           {


### PR DESCRIPTION
Escape `'` in enum strings. Since the outer `'` are already added in the parsing, I added the escaping also directly there.