### PR TITLE
chore: disable node 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [10.x, 12.x]
+        node-version: [12.x]
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1


### PR DESCRIPTION
Today is the last day of the node 10 lifecycle.
https://nodejs.org/en/about/releases/