### PR TITLE
chore: update typedoc in the client

### DIFF
--- a/packages/generator/src/service/package-json.ts
+++ b/packages/generator/src/service/package-json.ts
@@ -44,7 +44,7 @@ export async function packageJson(
           '@sap-cloud-sdk/core': `^${await getSdkVersion()}`
         },
         devDependencies: {
-          typedoc: '^0.17.0',
+          typedoc: '^0.20.36',
           typescript: '~3.8.3'
         }
       },

--- a/packages/openapi-generator/src/file-serializer/__snapshots__/package-json.spec.ts.snap
+++ b/packages/openapi-generator/src/file-serializer/__snapshots__/package-json.spec.ts.snap
@@ -32,7 +32,7 @@ exports[`packageJson returns the package.json content 1`] = `
     \\"@sap-cloud-sdk/core\\": \\"^1.35.0\\"
   },
   \\"devDependencies\\": {
-    \\"typedoc\\": \\"^0.17.0\\",
+    \\"typedoc\\": \\"^0.20.36\\",
     \\"typescript\\": \\"~3.8.3\\"
   }
 }

--- a/packages/openapi-generator/src/file-serializer/package-json.ts
+++ b/packages/openapi-generator/src/file-serializer/package-json.ts
@@ -42,7 +42,7 @@ export function packageJson(
           '@sap-cloud-sdk/core': `^${sdkVersion}`
         },
         devDependencies: {
-          typedoc: '^0.17.0',
+          typedoc: '^0.20.36',
           typescript: '~3.8.3'
         }
       },

--- a/test-packages/test-services/openapi/no-schema-service/package.json
+++ b/test-packages/test-services/openapi/no-schema-service/package.json
@@ -29,7 +29,7 @@
     "@sap-cloud-sdk/core": "^1.41.0"
   },
   "devDependencies": {
-    "typedoc": "^0.17.0",
+    "typedoc": "^0.20.36",
     "typescript": "~3.8.3"
   }
 }

--- a/test-packages/test-services/openapi/swagger-yaml-service/package.json
+++ b/test-packages/test-services/openapi/swagger-yaml-service/package.json
@@ -29,7 +29,7 @@
     "@sap-cloud-sdk/core": "^1.41.0"
   },
   "devDependencies": {
-    "typedoc": "^0.17.0",
+    "typedoc": "^0.20.36",
     "typescript": "~3.8.3"
   }
 }

--- a/test-packages/test-services/openapi/test-service/package.json
+++ b/test-packages/test-services/openapi/test-service/package.json
@@ -29,7 +29,7 @@
     "@sap-cloud-sdk/core": "^1.41.0"
   },
   "devDependencies": {
-    "typedoc": "^0.17.0",
+    "typedoc": "^0.20.36",
     "typescript": "~3.8.3"
   }
 }


### PR DESCRIPTION
The `typedoc` version of the generated client is up-to-date.

- [ ] adjust compatibility notes? I did not do it, since updating a generated client with new version of generator is not common? Typically, the version update is in the `package.json`, I would not overwrite my `package.json` for a working project so my `scripts` and other `dependencies` are gone. Feel free to challenge here.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
