### PR TITLE
chore: Fix metadata test to be sdk version independent

### DIFF
--- a/packages/generator/src/sdk-metadata/__snapshots__/sdk-metadata.spec.ts.snap
+++ b/packages/generator/src/sdk-metadata/__snapshots__/sdk-metadata.spec.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`pregenerated-lib returns description of the service 1`] = `"SAP Cloud SDK for JavaScript: Virtual Data Model (VDM) for service test-service"`;
+
 exports[`sdk-metadata generates the sdk metadata content for services with pregenerated lib 1`] = `
 Object {
   "generationAndUsage": Object {
@@ -20,7 +22,7 @@ The steps above will generate a basic TypeScript client. For additional options 
       "text": "Follow the following generation steps to generate the client.",
     },
     "generatorRepositoryLink": "https://www.npmjs.com/package/@sap-cloud-sdk/generator",
-    "generatorVersion": "1.41.0",
+    "generatorVersion": Any<String>,
     "genericUsage": Object {
       "instructions": "import { BusinessPartner } from '@sap/cloud-sdk-vdm-business-partner-service';
 
@@ -93,7 +95,7 @@ The steps above will generate a basic TypeScript client. For additional options 
       "text": "Follow the following generation steps to generate the client.",
     },
     "generatorRepositoryLink": "https://www.npmjs.com/package/@sap-cloud-sdk/generator",
-    "generatorVersion": "1.41.0",
+    "generatorVersion": Any<String>,
     "genericUsage": Object {
       "instructions": "import { BusinessPartner } from '@sap/cloud-sdk-vdm-business-partner-service';
 
@@ -133,5 +135,3 @@ const resultPromise = BusinessPartner.requestBuilder().getAll().top(5).execute({
   },
 }
 `;
-
-exports[`pregenerated-lib returns description of the service 1`] = `"SAP Cloud SDK for JavaScript: Virtual Data Model (VDM) for service test-service"`;

--- a/packages/generator/src/sdk-metadata/sdk-metadata.spec.ts
+++ b/packages/generator/src/sdk-metadata/sdk-metadata.spec.ts
@@ -14,12 +14,11 @@ describe('sdk-metadata', () => {
       service,
       createOptions({ versionInPackageJson: '1.0.0' })
     );
-    expect(metaData).toMatchSnapshot();
-    expect(metaData.pregeneratedLibrary).toBeDefined();
-    expect(metaData.serviceStatus.status).toBe('certified');
-    expect(metaData.serviceStatus.statusText).toBe(
-      'A pre-generated API client exists.'
-    );
+    expect(metaData).toMatchSnapshot({
+      generationAndUsage: {
+        generatorVersion: expect.any(String)
+      }
+    });
   });
 
   it('generates the sdk metadata content for services without pregenerated lib', async () => {
@@ -28,11 +27,10 @@ describe('sdk-metadata', () => {
       createOptions({ versionInPackageJson: '1.0.0' })
     );
 
-    expect(metaData).toMatchSnapshot();
-    expect(metaData.serviceStatus.status).toBe('verified');
-    expect(metaData.pregeneratedLibrary).toBeUndefined();
-    expect(metaData.serviceStatus.statusText).toBe(
-      'The generation process for this API works.'
-    );
+    expect(metaData).toMatchSnapshot({
+      generationAndUsage: {
+        generatorVersion: expect.any(String)
+      }
+    });
   });
 });

--- a/packages/openapi-generator/src/sdk-metadata/__snapshots__/generation-and-usage.spec.ts.snap
+++ b/packages/openapi-generator/src/sdk-metadata/__snapshots__/generation-and-usage.spec.ts.snap
@@ -18,7 +18,7 @@ The steps above will generate a basic TypeScript client. For additional options 
     "text": "Follow the following generation steps to generate the client.",
   },
   "generatorRepositoryLink": "https://www.npmjs.com/package/@sap-cloud-sdk/openapi-generator",
-  "generatorVersion": "1.41.0",
+  "generatorVersion": Any<String>,
   "genericUsage": Object {
     "instructions": "import { MyApi } from 'my-npm-package';
 

--- a/packages/openapi-generator/src/sdk-metadata/__snapshots__/sdk-metadata.spec.ts.snap
+++ b/packages/openapi-generator/src/sdk-metadata/__snapshots__/sdk-metadata.spec.ts.snap
@@ -19,7 +19,7 @@ The steps above will generate a basic TypeScript client. For additional options 
       "text": "Follow the following generation steps to generate the client.",
     },
     "generatorRepositoryLink": "https://www.npmjs.com/package/@sap-cloud-sdk/openapi-generator",
-    "generatorVersion": "1.41.0",
+    "generatorVersion": Any<String>,
     "genericUsage": Object {
       "instructions": "import { MyApi } from 'my-npm-package';
 
@@ -90,7 +90,7 @@ The steps above will generate a basic TypeScript client. For additional options 
       "text": "Follow the following generation steps to generate the client.",
     },
     "generatorRepositoryLink": "https://www.npmjs.com/package/@sap-cloud-sdk/openapi-generator",
-    "generatorVersion": "1.41.0",
+    "generatorVersion": Any<String>,
     "genericUsage": Object {
       "instructions": "import { MyApi } from 'my-npm-package';
 

--- a/packages/openapi-generator/src/sdk-metadata/generation-and-usage.spec.ts
+++ b/packages/openapi-generator/src/sdk-metadata/generation-and-usage.spec.ts
@@ -1,8 +1,15 @@
+import { getSdkVersion } from '@sap-cloud-sdk/generator-common';
 import { dummyOpenApiDocument } from '../../test/test-util';
 import { getGenerationAndUsage } from './generation-and-usage';
 
 describe('generation-and-usage', () => {
   it('creates GenerationAndUsage from openApiDocument', async () => {
-    expect(await getGenerationAndUsage(dummyOpenApiDocument)).toMatchSnapshot();
+    const generationAndUsage = await getGenerationAndUsage(
+      dummyOpenApiDocument
+    );
+    expect(generationAndUsage).toMatchSnapshot({
+      generatorVersion: expect.any(String)
+    });
+    expect(generationAndUsage.generatorVersion).toEqual(await getSdkVersion());
   });
 });

--- a/packages/openapi-generator/src/sdk-metadata/sdk-metadata.spec.ts
+++ b/packages/openapi-generator/src/sdk-metadata/sdk-metadata.spec.ts
@@ -1,4 +1,5 @@
 import nock = require('nock');
+import { getSdkVersion } from '@sap-cloud-sdk/generator-common';
 import { GeneratorOptions } from '../options';
 import { dummyOpenApiDocument } from '../../test/test-util';
 import { sdkMetadata } from './sdk-metadata';
@@ -8,7 +9,9 @@ describe('sdk-metadata', () => {
     const metadata = await sdkMetadata(dummyOpenApiDocument, {
       packageVersion: '1.0.0'
     } as GeneratorOptions);
-    expect(metadata).toMatchSnapshot();
+    expect(metadata).toMatchSnapshot({
+      generationAndUsage: { generatorVersion: await getSdkVersion() }
+    });
     expect(metadata.serviceStatus.status).toBe('verified');
     expect(metadata.pregeneratedLibrary).toBeUndefined();
     expect(metadata.serviceStatus.statusText).toBe(

--- a/packages/openapi-generator/src/sdk-metadata/sdk-metadata.spec.ts
+++ b/packages/openapi-generator/src/sdk-metadata/sdk-metadata.spec.ts
@@ -1,5 +1,4 @@
 import nock = require('nock');
-import { getSdkVersion } from '@sap-cloud-sdk/generator-common';
 import { GeneratorOptions } from '../options';
 import { dummyOpenApiDocument } from '../../test/test-util';
 import { sdkMetadata } from './sdk-metadata';
@@ -12,9 +11,6 @@ describe('sdk-metadata', () => {
     expect(metadata).toMatchSnapshot({
       generationAndUsage: { generatorVersion: expect.any(String) }
     });
-    expect(metadata.generationAndUsage.generatorVersion).toEqual(
-      await getSdkVersion()
-    );
   });
 
   it('generates metadata content for services with pregenerated lib', async () => {

--- a/packages/openapi-generator/src/sdk-metadata/sdk-metadata.spec.ts
+++ b/packages/openapi-generator/src/sdk-metadata/sdk-metadata.spec.ts
@@ -10,12 +10,10 @@ describe('sdk-metadata', () => {
       packageVersion: '1.0.0'
     } as GeneratorOptions);
     expect(metadata).toMatchSnapshot({
-      generationAndUsage: { generatorVersion: await getSdkVersion() }
+      generationAndUsage: { generatorVersion: expect.any(String) }
     });
-    expect(metadata.serviceStatus.status).toBe('verified');
-    expect(metadata.pregeneratedLibrary).toBeUndefined();
-    expect(metadata.serviceStatus.statusText).toBe(
-      'The generation process for this API works.'
+    expect(metadata.generationAndUsage.generatorVersion).toEqual(
+      await getSdkVersion()
     );
   });
 
@@ -26,11 +24,8 @@ describe('sdk-metadata', () => {
     const metadata = await sdkMetadata(dummyOpenApiDocument, {
       packageVersion: '1.0.0'
     } as GeneratorOptions);
-    expect(metadata).toMatchSnapshot();
-    expect(metadata.pregeneratedLibrary).toBeDefined();
-    expect(metadata.serviceStatus.status).toBe('certified');
-    expect(metadata.serviceStatus.statusText).toBe(
-      'A pre-generated API client exists.'
-    );
+    expect(metadata).toMatchSnapshot({
+      generationAndUsage: { generatorVersion: expect.any(String) }
+    });
   });
 });


### PR DESCRIPTION
This test fails with other versions than 1.41.1