### PR TITLE
feat: support appending path to generated url for all request builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ## New Functionality
 
--
+- [odata] Support appending path to the generated url for all request builders, which can be used for some unsupported OData functionalities like querying navigation properties.
 
 ## Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ## New Functionality
 
-- [odata] Support appending path to the generated url for all request builders, which can be used for some unsupported OData functionalities like querying navigation properties.
+- [odata] Support appending path to the request URL built by the request builders through the `appendPath` method. It can be used for unsupported OData functionality like querying navigation properties.
 
 ## Improvements
 

--- a/packages/core/src/odata-common/request-builder/request-builder-base.ts
+++ b/packages/core/src/odata-common/request-builder/request-builder-base.ts
@@ -132,6 +132,12 @@ export abstract class MethodRequestBuilder<
     return this;
   }
 
+  /**
+   * Append additional path to the generated path. Typically, this can be used for querying navigation properties of an entity.
+   * When this function is used, the "execute" function of the request builder is disabled and use "executeRaw" instead.
+   * @param path Path to be appended.
+   * @returns The request builder itself without "execute" function, to facilitate method chaining.
+   */
   appendPath(path: string): Omit<this, 'execute'> {
     this.requestConfig.appendPath(path);
     return this;

--- a/packages/core/src/odata-common/request-builder/request-builder-base.ts
+++ b/packages/core/src/odata-common/request-builder/request-builder-base.ts
@@ -132,9 +132,9 @@ export abstract class MethodRequestBuilder<
     return this;
   }
 
-  /**
-   * Append additional path to the generated path. Typically, this can be used for querying navigation properties of an entity.
-   * When this function is used, the "execute" function of the request builder is disabled and use "executeRaw" instead.
+   * Append the given path to the URL.
+   * This can be used for querying navigation properties of an entity.
+   * To execute a request with an appended path use `executeRaw` to avoid errors during deserialization. When using this, the `execute` method is omitted from the return type.
    * @param path Path to be appended.
    * @returns The request builder itself without "execute" function, to facilitate method chaining.
    */

--- a/packages/core/src/odata-common/request-builder/request-builder-base.ts
+++ b/packages/core/src/odata-common/request-builder/request-builder-base.ts
@@ -132,6 +132,11 @@ export abstract class MethodRequestBuilder<
     return this;
   }
 
+  appendPath(path: string): Omit<this, 'execute'> {
+    this.requestConfig.appendPath(path);
+    return this;
+  }
+
   /**
    * Skip fetching csrf token for this request, which is typically useful when the csrf token is not required.
    * @returns The request builder itself, to facilitate method chaining.

--- a/packages/core/src/odata-common/request-builder/request-builder-base.ts
+++ b/packages/core/src/odata-common/request-builder/request-builder-base.ts
@@ -132,14 +132,15 @@ export abstract class MethodRequestBuilder<
     return this;
   }
 
+  /**
    * Append the given path to the URL.
    * This can be used for querying navigation properties of an entity.
    * To execute a request with an appended path use `executeRaw` to avoid errors during deserialization. When using this, the `execute` method is omitted from the return type.
    * @param path Path to be appended.
    * @returns The request builder itself without "execute" function, to facilitate method chaining.
    */
-  appendPath(path: string): Omit<this, 'execute'> {
-    this.requestConfig.appendPath(path);
+  appendPath(...path: string[]): Omit<this, 'execute'> {
+    this.requestConfig.appendPath(...path);
     return this;
   }
 

--- a/packages/core/src/odata-common/request/odata-request-config.ts
+++ b/packages/core/src/odata-common/request/odata-request-config.ts
@@ -25,7 +25,7 @@ export abstract class ODataRequestConfig {
   private _customHeaders: Record<string, string> = {};
   private _customQueryParameters: Record<string, string> = {};
   private _customRequestConfiguration: Record<string, string> = {};
-  private _appendPaths: string[] = [];
+  private _appendedPaths: string[] = [];
   private _fetchCsrfToken = true;
 
   /**
@@ -100,8 +100,8 @@ export abstract class ODataRequestConfig {
     return this._customRequestConfiguration;
   }
 
-  get appendPaths(): string[] {
-    return this._appendPaths;
+  get appendedPaths(): string[] {
+    return this._appendedPaths;
   }
 
   set fetchCsrfToken(fetchCsrfToken: boolean) {
@@ -148,8 +148,8 @@ export abstract class ODataRequestConfig {
     });
   }
 
-  appendPath(path: string): void {
-    this.appendPaths.push(path);
+  appendPath(...path: string[]): void {
+    this.appendedPaths.push(...path);
   }
 
   protected prependDollarToQueryParameters(

--- a/packages/core/src/odata-common/request/odata-request-config.ts
+++ b/packages/core/src/odata-common/request/odata-request-config.ts
@@ -25,6 +25,7 @@ export abstract class ODataRequestConfig {
   private _customHeaders: Record<string, string> = {};
   private _customQueryParameters: Record<string, string> = {};
   private _customRequestConfiguration: Record<string, string> = {};
+  private _appendPaths: string[] = [];
   private _fetchCsrfToken = true;
 
   /**
@@ -99,6 +100,10 @@ export abstract class ODataRequestConfig {
     return this._customRequestConfiguration;
   }
 
+  get appendPaths(): string[] {
+    return this._appendPaths;
+  }
+
   set fetchCsrfToken(fetchCsrfToken: boolean) {
     this._fetchCsrfToken = fetchCsrfToken;
   }
@@ -141,6 +146,10 @@ export abstract class ODataRequestConfig {
     Object.entries(requestConfiguration).forEach(([key, value]) => {
       this.customRequestConfiguration[key] = value;
     });
+  }
+
+  appendPath(path: string): void {
+    this.appendPaths.push(path);
   }
 
   protected prependDollarToQueryParameters(

--- a/packages/core/src/odata-common/request/odata-request.spec.ts
+++ b/packages/core/src/odata-common/request/odata-request.spec.ts
@@ -121,6 +121,26 @@ describe('OData Request', () => {
     });
   });
 
+  describe('relativeUrl', () => {
+    it('should contain appended path', () => {
+      const request = createRequest(ODataGetAllRequestConfig);
+      const requestConfig = request.config as ODataGetAllRequestConfig<TestEntity>;
+      requestConfig.appendPath('/$value');
+      expect(request.relativeUrl()).toBe(
+        'sap/opu/odata/sap/API_TEST_SRV/A_TestEntity/$value?$format=json'
+      );
+    });
+
+    it('should not remove the trailing slash', () => {
+      const request = createRequest(ODataGetAllRequestConfig);
+      const requestConfig = request.config as ODataGetAllRequestConfig<TestEntity>;
+      requestConfig.appendPath('/');
+      expect(request.relativeUrl()).toBe(
+        'sap/opu/odata/sap/API_TEST_SRV/A_TestEntity/?$format=json'
+      );
+    });
+  });
+
   describe('execute', () => {
     beforeEach(() => {
       requestSpy = jest.spyOn(axios, 'request').mockResolvedValue('test');

--- a/packages/core/src/odata-common/request/odata-request.ts
+++ b/packages/core/src/odata-common/request/odata-request.ts
@@ -55,9 +55,9 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
    * @returns The absolute URL for the request
    */
   url(): string {
-    return `${removeTrailingSlashes(this.resourceUrl())}${removeTrailingSlashes(
-      this.config.appendedPaths.join('')
-    )}${this.query()}`;
+    return `${removeTrailingSlashes(
+      this.resourceUrl()
+    )}${this.config.appendedPaths.join('')}${this.query()}`;
   }
 
   /**
@@ -68,9 +68,7 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
   relativeUrl(includeServicePath = true): string {
     return `${removeTrailingSlashes(
       this.relativeResourceUrl(includeServicePath)
-    )}${removeTrailingSlashes(
-      this.config.appendedPaths.join('')
-    )}${this.query()}`;
+    )}${this.config.appendedPaths.join('')}${this.query()}`;
   }
 
   /**

--- a/packages/core/src/odata-common/request/odata-request.ts
+++ b/packages/core/src/odata-common/request/odata-request.ts
@@ -55,7 +55,9 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
    * @returns The absolute URL for the request
    */
   url(): string {
-    return `${removeTrailingSlashes(this.resourceUrl())}${this.query()}`;
+    return `${removeTrailingSlashes(this.resourceUrl())}${removeTrailingSlashes(
+      this.config.appendPaths.join('/')
+    )}${this.query()}`;
   }
 
   /**
@@ -66,6 +68,8 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
   relativeUrl(includeServicePath = true): string {
     return `${removeTrailingSlashes(
       this.relativeResourceUrl(includeServicePath)
+    )}${removeTrailingSlashes(
+      this.config.appendPaths.join('/')
     )}${this.query()}`;
   }
 

--- a/packages/core/src/odata-common/request/odata-request.ts
+++ b/packages/core/src/odata-common/request/odata-request.ts
@@ -56,7 +56,7 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
    */
   url(): string {
     return `${removeTrailingSlashes(this.resourceUrl())}${removeTrailingSlashes(
-      this.config.appendPaths.join('/')
+      this.config.appendedPaths.join('')
     )}${this.query()}`;
   }
 
@@ -69,7 +69,7 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
     return `${removeTrailingSlashes(
       this.relativeResourceUrl(includeServicePath)
     )}${removeTrailingSlashes(
-      this.config.appendPaths.join('/')
+      this.config.appendedPaths.join('')
     )}${this.query()}`;
   }
 

--- a/packages/core/src/odata-v2/request-builder/get-all-request-builder.spec.ts
+++ b/packages/core/src/odata-v2/request-builder/get-all-request-builder.spec.ts
@@ -10,11 +10,10 @@ import {
   createTestEntity
 } from '../../../test/test-util/test-data';
 import {
-  TestEntity, TestEntityMultiLink,
+  TestEntity,
   TestEntitySingleLink
 } from '../../../test/test-util/test-services/v2/test-service';
 import { GetAllRequestBuilder } from './get-all-request-builder';
-import { deserializeEntity } from '../entity-deserializer';
 
 describe('GetAllRequestBuilder', () => {
   let requestBuilder: GetAllRequestBuilder<TestEntity>;
@@ -83,11 +82,7 @@ describe('GetAllRequestBuilder', () => {
         responseBody: { d: { results: [entityData1, entityData2] } }
       });
 
-      const results = (await requestBuilder.executeRaw(defaultDestination)).data.d.results;
-
-      const actual = results.map(result =>
-        deserializeEntity(result, TestEntity) as TestEntity
-      );
+      const actual = await requestBuilder.execute(defaultDestination);
       expect(actual).toEqual([
         createTestEntity(entityData1),
         createTestEntity(entityData2)

--- a/packages/core/src/odata-v2/request-builder/get-all-request-builder.spec.ts
+++ b/packages/core/src/odata-v2/request-builder/get-all-request-builder.spec.ts
@@ -10,10 +10,11 @@ import {
   createTestEntity
 } from '../../../test/test-util/test-data';
 import {
-  TestEntity,
+  TestEntity, TestEntityMultiLink,
   TestEntitySingleLink
 } from '../../../test/test-util/test-services/v2/test-service';
 import { GetAllRequestBuilder } from './get-all-request-builder';
+import { deserializeEntity } from '../entity-deserializer';
 
 describe('GetAllRequestBuilder', () => {
   let requestBuilder: GetAllRequestBuilder<TestEntity>;
@@ -82,7 +83,11 @@ describe('GetAllRequestBuilder', () => {
         responseBody: { d: { results: [entityData1, entityData2] } }
       });
 
-      const actual = await requestBuilder.execute(defaultDestination);
+      const results = (await requestBuilder.executeRaw(defaultDestination)).data.d.results;
+
+      const actual = results.map(result =>
+        deserializeEntity(result, TestEntity) as TestEntity
+      );
       expect(actual).toEqual([
         createTestEntity(entityData1),
         createTestEntity(entityData2)

--- a/packages/core/src/odata-v2/request-builder/get-by-key-request-builder.spec.ts
+++ b/packages/core/src/odata-v2/request-builder/get-by-key-request-builder.spec.ts
@@ -18,13 +18,13 @@ describe('GetByKeyRequestBuilder', () => {
     it('returns correct url with appendPath', async () => {
       const entityData = createOriginalTestEntityData1();
       const entity = createTestEntity(entityData);
-      const expected = /^\/testination\/sap\/opu\/odata\/sap\/API_TEST_SRV\/A_TestEntity\(KeyPropertyGuid=guid'\w{8}-\w{4}-\w{4}-\w{4}-\w{12}',KeyPropertyString='ABCDE'\)\/to_SingleLink\/to_MultiLink\?\$format=json$/;
+      const expected = /^\/testination\/sap\/opu\/odata\/sap\/API_TEST_SRV\/A_TestEntity\(KeyPropertyGuid=guid'\w{8}-\w{4}-\w{4}-\w{4}-\w{12}',KeyPropertyString='ABCDE'\)\/to_SingleLink\/to_MultiLink\/\?\$format=json$/;
 
       const actual = await new GetByKeyRequestBuilder(TestEntity, {
         KeyPropertyGuid: entity.keyPropertyGuid,
         KeyPropertyString: entity.keyPropertyString
       })
-        .appendPath('/to_SingleLink', '/to_MultiLink')
+        .appendPath('/to_SingleLink', '/to_MultiLink/')
         .url(defaultDestination);
       expect(actual).toMatch(expected);
     });
@@ -137,7 +137,7 @@ describe('GetByKeyRequestBuilder', () => {
       expect(actual.request.method).toBe('GET');
     });
 
-    it('returns navigation properties', async () => {
+    it('builds a URL with appended paths', async () => {
       const entityData = createOriginalTestEntityDataWithLinks();
       const entity = createTestEntity(entityData);
 
@@ -145,8 +145,7 @@ describe('GetByKeyRequestBuilder', () => {
         path: `${testEntityResourcePath(
           entity.keyPropertyGuid,
           entity.keyPropertyString
-        )}/to_SingleLink/to_MultiLink`,
-        responseBody: { d: { results: entityData.to_MultiLink } }
+        )}/to_SingleLink/to_MultiLink`
       });
 
       const response = await new GetByKeyRequestBuilder(TestEntity, {

--- a/packages/core/src/odata-v2/request-builder/get-by-key-request-builder.spec.ts
+++ b/packages/core/src/odata-v2/request-builder/get-by-key-request-builder.spec.ts
@@ -14,8 +14,8 @@ import {
   TestEntity,
   TestEntityMultiLink
 } from '../../../test/test-util/test-services/v2/test-service';
-import { GetByKeyRequestBuilder } from './get-by-key-request-builder';
 import { deserializeEntity } from '../entity-deserializer';
+import { GetByKeyRequestBuilder } from './get-by-key-request-builder';
 
 describe('GetByKeyRequestBuilder', () => {
   describe('url', () => {
@@ -33,7 +33,7 @@ describe('GetByKeyRequestBuilder', () => {
       expect(actual).toMatch(expected);
     });
   });
-  //todo
+
   describe('execute', () => {
     it('returns entity by key', async () => {
       const entityData = createOriginalTestEntityData1();
@@ -47,14 +47,12 @@ describe('GetByKeyRequestBuilder', () => {
         responseBody: { d: entityData }
       });
 
-      const actual = (await new GetByKeyRequestBuilder(TestEntity, {
+      const actual = await new GetByKeyRequestBuilder(TestEntity, {
         KeyPropertyGuid: expected.keyPropertyGuid,
         KeyPropertyString: expected.keyPropertyString
-      }).executeRaw(defaultDestination)).data.d;
-      const d = deserializeEntity(actual, TestEntity) as TestEntity;
-      expect(d).toEqual(expected);
-      // expect(actual).toEqual(expected);
-      // expect(actual.versionIdentifier).toBeUndefined();
+      }).execute(defaultDestination);
+      expect(actual).toEqual(expected);
+      expect(actual.versionIdentifier).toBeUndefined();
     });
 
     it('etag should be pulled from __metadata', async () => {
@@ -164,8 +162,9 @@ describe('GetByKeyRequestBuilder', () => {
           .appendPath('/to_MultiLink')
           .executeRaw(defaultDestination)
       ).data.d.results as any[];
-      const actual = results.map(result =>
-        deserializeEntity(result, TestEntityMultiLink) as TestEntityMultiLink
+      const actual = results.map(
+        result =>
+          deserializeEntity(result, TestEntityMultiLink) as TestEntityMultiLink
       );
       expect(actual).toEqual(expected);
     });

--- a/packages/core/test/test-util/test-data.ts
+++ b/packages/core/test/test-util/test-data.ts
@@ -1,10 +1,14 @@
 import { v4 as uuid } from 'uuid';
 import { uriConverter } from '../../src/odata-v2';
-import { TestEntity } from './test-services/v2/test-service';
+import {
+  TestEntity,
+  TestEntitySingleLink,
+  TestEntityMultiLink
+} from './test-services/v2/test-service';
 import {
   TestEntity as TestEntityV4,
-  TestEntityMultiLink,
-  TestEntitySingleLink
+  TestEntityMultiLink as TestEntityMultiLinkV4,
+  TestEntitySingleLink as TestEntitySingleLinkV4
 } from './test-services/v4/test-service';
 
 const { convertToUriFormat } = uriConverter;
@@ -46,7 +50,7 @@ export function createOriginalTestEntityDataWithLinks() {
 }
 
 export function createTestEntity(originalData): TestEntity {
-  return TestEntity.builder()
+  const entity = TestEntity.builder()
     .keyPropertyGuid(originalData.KeyPropertyGuid)
     .keyPropertyString(originalData.KeyPropertyString)
     .stringProperty(originalData.StringProperty)
@@ -54,6 +58,17 @@ export function createTestEntity(originalData): TestEntity {
     .int16Property(originalData.Int16Property)
     .build()
     .setOrInitializeRemoteState();
+  if (originalData.to_SingleLink) {
+    entity.toSingleLink = TestEntitySingleLink.builder()
+      .keyProperty(originalData.to_SingleLink.KeyProperty)
+      .build();
+  }
+  if (originalData.to_MultiLink) {
+    entity.toMultiLink = originalData.to_MultiLink.map(ml =>
+      TestEntityMultiLink.builder().keyProperty(ml.KeyProperty).build()
+    );
+  }
+  return entity;
 }
 
 export function createTestEntityV4(originalData): TestEntityV4 {
@@ -67,13 +82,13 @@ export function createTestEntityV4(originalData): TestEntityV4 {
     .build()
     .setOrInitializeRemoteState();
   if (originalData.to_SingleLink) {
-    entity.toSingleLink = TestEntitySingleLink.builder()
+    entity.toSingleLink = TestEntitySingleLinkV4.builder()
       .keyProperty(originalData.to_SingleLink.KeyProperty)
       .build();
   }
   if (originalData.to_MultiLink) {
     entity.toMultiLink = originalData.to_MultiLink.map(ml =>
-      TestEntityMultiLink.builder().keyProperty(ml.KeyProperty).build()
+      TestEntityMultiLinkV4.builder().keyProperty(ml.KeyProperty).build()
     );
   }
   return entity;

--- a/test-packages/e2e-tests/test/TripPin/request-builder.spec.ts
+++ b/test-packages/e2e-tests/test/TripPin/request-builder.spec.ts
@@ -41,12 +41,14 @@ xdescribe('Request builder', () => {
   });
 
   it('should return a collection all friends of a person', async () => {
-    const people = (await People.requestBuilder()
-      .getByKey('russellwhyte')
-      .appendPath('/Friends')
-      .executeRaw(destination)).data.value as any[];
-    const actual = people.map(person =>
-      deserializeEntityV4(person, People) as People
+    const people = (
+      await People.requestBuilder()
+        .getByKey('russellwhyte')
+        .appendPath('/Friends')
+        .executeRaw(destination)
+    ).data.value as any[];
+    const actual = people.map(
+      person => deserializeEntityV4(person, People) as People
     );
     expect(actual.length).toEqual(4);
     expect(actual).toEqual(

--- a/test-packages/e2e-tests/test/TripPin/request-builder.spec.ts
+++ b/test-packages/e2e-tests/test/TripPin/request-builder.spec.ts
@@ -1,4 +1,4 @@
-import { any } from '@sap-cloud-sdk/core';
+import { any, deserializeEntityV4 } from '@sap-cloud-sdk/core';
 import { resetDataSource } from '@sap-cloud-sdk/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/action-imports';
 import { PersonGender } from '@sap-cloud-sdk/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/PersonGender';
 import { People } from '@sap-cloud-sdk/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service';
@@ -35,6 +35,24 @@ xdescribe('Request builder', () => {
       expect.arrayContaining([
         expect.objectContaining({
           friends: expect.arrayContaining([expect.anything()])
+        })
+      ])
+    );
+  });
+
+  it('should return a collection all friends of a person', async () => {
+    const people = (await People.requestBuilder()
+      .getByKey('russellwhyte')
+      .appendPath('/Friends')
+      .executeRaw(destination)).data.value as any[];
+    const actual = people.map(person =>
+      deserializeEntityV4(person, People) as People
+    );
+    expect(actual.length).toEqual(4);
+    expect(actual).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          userName: expect.anything()
         })
       ])
     );

--- a/test-packages/e2e-tests/test/request-builder.spec.ts
+++ b/test-packages/e2e-tests/test/request-builder.spec.ts
@@ -71,9 +71,8 @@ describe('Request builder', () => {
         .appendPath('/ToMultiLink')
         .executeRaw(destination)
     ).data.value as any[];
-    const actual = multiLinks.map(
-      multiLink =>
-        deserializeEntityV4(multiLink, TestEntityLink) as TestEntityLink
+    const actual = multiLinks.map(multiLink =>
+      deserializeEntityV4(multiLink, TestEntityLink)
     );
 
     expect(actual).toEqual(

--- a/test-packages/e2e-tests/test/request-builder.spec.ts
+++ b/test-packages/e2e-tests/test/request-builder.spec.ts
@@ -71,8 +71,9 @@ describe('Request builder', () => {
         .appendPath('/ToMultiLink')
         .executeRaw(destination)
     ).data.value as any[];
-    const actual = multiLinks.map(multiLink =>
-      deserializeEntityV4(multiLink, TestEntityLink) as TestEntityLink
+    const actual = multiLinks.map(
+      multiLink =>
+        deserializeEntityV4(multiLink, TestEntityLink) as TestEntityLink
     );
 
     expect(actual).toEqual(

--- a/test-packages/e2e-tests/test/request-builder.spec.ts
+++ b/test-packages/e2e-tests/test/request-builder.spec.ts
@@ -3,7 +3,7 @@ import {
   TestEntityLink
 } from '@sap-cloud-sdk/test-services-e2e/v4/test-service';
 import moment from 'moment';
-import { and } from '@sap-cloud-sdk/core';
+import { and, deserializeEntityV4 } from '@sap-cloud-sdk/core';
 import { deleteEntity, queryEntity } from './test-utils/test-entity-operations';
 import { destination } from './test-util';
 
@@ -62,6 +62,24 @@ describe('Request builder', () => {
       .getByKey(101)
       .execute(destination);
     expect(testEntity).toEqual(expect.objectContaining({ keyTestEntity: 101 }));
+  });
+
+  it('should return one to many navigation property of an entity', async () => {
+    const multiLinks = (
+      await TestEntity.requestBuilder()
+        .getByKey(101)
+        .appendPath('/ToMultiLink')
+        .executeRaw(destination)
+    ).data.value as any[];
+    const actual = multiLinks.map(multiLink =>
+      deserializeEntityV4(multiLink, TestEntityLink) as TestEntityLink
+    );
+
+    expect(actual).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ keyToTestEntity: 101 })
+      ])
+    );
   });
 
   it('should create an entity and a link as child of the entity', async () => {


### PR DESCRIPTION
The `appendPath` is implemented as a workaround for almost all unsupported odata functionalities.
Typically, it can help queryi navigation properties (`GET` `/TestEntity(key)/to_MultiLink`).
Unfortunately, however, this function is too powerful, so the deserialisation cannot work as the return type is not clear.
I disabled the `execute` function when `appendPath` is called, and the users should use `executeRaw` instead.