### PR TITLE
chore: use minor as default release parameter instead of patch

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -6,7 +6,7 @@ on:
       bump:
         description: Version bump to be used. Can either be 'patch' or 'minor'.
         required: false
-        default: 'patch'
+        default: 'minor'
 
 jobs:
   bump:


### PR DESCRIPTION
For the last 10 releases, we have 8 minor releases + 2 patch releases. So minor matches to the most of the cases.