### PR TITLE
Fix: opossum compilation error

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,6 @@
     "@sap-cloud-sdk/analytics": "^1.44.0",
     "@sap-cloud-sdk/util": "^1.44.0",
     "@sap/xsenv": "^3.0.0",
-    "@types/opossum": "^4.1.1",
     "axios": "^0.21.1",
     "bignumber.js": "^9.0.0",
     "http-proxy-agent": "^4.0.1",
@@ -51,6 +50,7 @@
   },
   "devDependencies": {
     "@sap-cloud-sdk/test-util": "^1.44.0",
+    "@types/opossum": "^4.1.1",
     "nock": "^13.0.11"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "@sap-cloud-sdk/analytics": "^1.44.0",
     "@sap-cloud-sdk/util": "^1.44.0",
     "@sap/xsenv": "^3.0.0",
+    "@types/opossum": "^4.1.1",
     "axios": "^0.21.1",
     "bignumber.js": "^9.0.0",
     "http-proxy-agent": "^4.0.1",
@@ -50,7 +51,6 @@
   },
   "devDependencies": {
     "@sap-cloud-sdk/test-util": "^1.44.0",
-    "@types/opossum": "^4.1.1",
     "nock": "^13.0.11"
   }
 }

--- a/packages/core/src/connectivity/scp-cf/resilience-options.ts
+++ b/packages/core/src/connectivity/scp-cf/resilience-options.ts
@@ -1,5 +1,3 @@
-import CircuitBreaker from 'opossum';
-
 export interface ResilienceOptions {
   /**
    * A boolean value that indicates whether to execute request to SCP-CF services using circuit breaker.
@@ -7,7 +5,7 @@ export interface ResilienceOptions {
   enableCircuitBreaker?: boolean;
 }
 
-export const circuitBreakerDefaultOptions: CircuitBreaker.Options = {
+export const circuitBreakerDefaultOptions = {
   timeout: 10000,
   errorThresholdPercentage: 50,
   volumeThreshold: 10,


### PR DESCRIPTION
The generator tests failed with error:
```
05:46:55      [2021-05-26T03:46:07.784Z] [31mERROR[39m    (generator-cli): ErrorWithCause: Generation of services failed.
05:46:55  
05:46:55        at new ErrorWithCause (node_modules/@sap-cloud-sdk/util/dist/error-with-cause.js:32:16)
05:46:55        at node_modules/@sap-cloud-sdk/generator/dist/generator-cli.js:33:18
05:46:55        Caused by:
05:46:55        Error: Compilation Errors:
05:46:55        /home/jenkins/agent/workspace/js-sdk-e2e-test-generator/e2e-test-generator/node_modules/@sap-cloud-sdk/core/dist/connectivity/scp-cf/resilience-options.d.ts:1:27 - error TS7016: [object Object]
05:46:55        at Object.<anonymous> (node_modules/@sap-cloud-sdk/generator-common/dist/compiler.js:69:31)
05:46:55        at step (node_modules/@sap-cloud-sdk/generator-common/dist/compiler.js:33:23)
05:46:55        at Object.next (node_modules/@sap-cloud-sdk/generator-common/dist/compiler.js:14:53)
05:46:55        at fulfilled (node_modules/@sap-cloud-sdk/generator-common/dist/compiler.js:5:58)
05:46:55        at makeError (node_modules/execa/lib/error.js:59:11)
05:46:55        at handlePromise (node_modules/execa/index.js:114:26)
```

As we export a const like `export const circuitBreakerDefaultOptions: CircuitBreaker.Options`, the dependency is needed.

@marikaner , I tested the old import statement `const CircuitBreaker = require('opossum');`, which works. However, by using this version, you cannot provide the type like `export const circuitBreakerDefaultOptions: CircuitBreaker.Options`.