### PR TITLE
fix: Fix CSRF fetch content length header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@
 
 ## Fixed Issues
 
-- [core] Re-enable the circuit breakers for the destination and xsuaa services.
+- [core] Re-enable the circuit breakers for the destination and XSUAA services.
 - [odata] Fix encoding of filter strings.
+- [core] Add or overwrite the content length header for CSRF fetch requests. As those are always `HEAD` requests, the content length is always set to 0.
 
 
 # 1.44.0

--- a/packages/core/src/http-client/csrf-token-header.spec.ts
+++ b/packages/core/src/http-client/csrf-token-header.spec.ts
@@ -8,7 +8,7 @@ import {
   createCreateRequest
 } from '../../test/test-util';
 import { Destination } from '../connectivity/scp-cf';
-import { buildCsrfHeaders } from './csrf-token-header';
+import { buildCsrfFetchHeaders, buildCsrfHeaders } from './csrf-token-header';
 
 const standardHeaders = {
   accept: 'application/json',
@@ -134,5 +134,30 @@ describe('buildCsrfHeaders', () => {
       url: request.relativeServiceUrl()
     });
     expect(headers).toEqual(expected);
+  });
+});
+
+describe('buildCsrfFetchHeaders', () => {
+  it('builds default csrf header when no headers are passed', () => {
+    expect(buildCsrfFetchHeaders({})).toEqual({
+      'x-csrf-token': 'Fetch',
+      'content-length': 0
+    });
+  });
+
+  it('builds custom csrf header when x-csrf-token is passed', () => {
+    expect(
+      buildCsrfFetchHeaders({ 'X-CSRF-TOKEN': 'TOKEN', 'content-length': 0 })
+    ).toEqual({
+      'X-CSRF-TOKEN': 'TOKEN',
+      'content-length': 0
+    });
+  });
+
+  it('overwrites existing content length header', () => {
+    expect(buildCsrfFetchHeaders({ 'Content-Length': 22 })).toEqual({
+      'x-csrf-token': 'Fetch',
+      'Content-Length': 0
+    });
   });
 });

--- a/packages/core/src/http-client/index.ts
+++ b/packages/core/src/http-client/index.ts
@@ -3,4 +3,4 @@ export * from './http-client-types';
 export * from './http-agent';
 export * from './agent-config';
 export * from './http-request-config';
-export * from './csrf-token-header';
+export { buildCsrfHeaders } from './csrf-token-header';


### PR DESCRIPTION
Always overwrite the content length header to be 0, which is the correct length of a HEAD request.

Related to #1320 