### PR TITLE
chore: Wrap catch around whole doc generation

### DIFF
--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -140,19 +140,13 @@ function validateLogs(generationLogs) {
 }
 
 async function generateDocs() {
-  let generationLogs;
-  try {
-    generationLogs = await execa.command(
-      'typedoc --tsconfig tsconfig.typedoc.json',
-      {
-        cwd: resolve(),
-        encoding: 'utf8'
-      }
-    );
-  } catch (err) {
-    console.error(err);
-    process.exit(err.exitCode);
-  }
+  const generationLogs = await execa.command(
+    'typedoc --tsconfig tsconfig.typedoc.json',
+    {
+      cwd: resolve(),
+      encoding: 'utf8'
+    }
+  );
 
   validateLogs(generationLogs);
   adjustForGitHubPages();
@@ -160,4 +154,9 @@ async function generateDocs() {
   writeVersions();
 }
 
-generateDocs();
+try {
+  generateDocs();
+} catch (err) {
+  console.error(err);
+  process.exit(err.exitCode);
+}

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -154,9 +154,7 @@ async function generateDocs() {
   writeVersions();
 }
 
-try {
-  generateDocs();
-} catch (err) {
+generateDocs().catch(err => {
   console.error(err);
   process.exit(err.exitCode);
-}
+});

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -130,7 +130,7 @@ function writeVersions() {
   );
 }
 
-function validateLogs(generationLogs) {
+function validateLogs(generationLogs: string) {
   const invalidLinksMessage =
     'Found invalid symbol reference(s) in JSDocs, they will not render as links in the generated documentation.';
   const [, invalidLinks] = generationLogs.split(invalidLinksMessage);
@@ -140,6 +140,11 @@ function validateLogs(generationLogs) {
 }
 
 async function generateDocs() {
+  process.on('unhandledRejection', reason => {
+    console.error(`Unhandled rejection at: ${reason}`);
+    process.exit(1);
+  });
+
   const generationLogs = await execa.command(
     'typedoc --tsconfig tsconfig.typedoc.json',
     {
@@ -148,13 +153,10 @@ async function generateDocs() {
     }
   );
 
-  validateLogs(generationLogs);
+  validateLogs(generationLogs.stdout);
   adjustForGitHubPages();
   insertCopyrightAndTracking();
   writeVersions();
 }
 
-generateDocs().catch(err => {
-  console.error(err);
-  process.exit(err.exitCode);
-});
+generateDocs();


### PR DESCRIPTION
Causes the documentation check to fail if any step of the generation fails.