### PR TITLE
fix: error messages of invalid path patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## Improvements
 
--
+- [openapi-generator] Improve the error message for invalid or unsupported path patterns.
 
 ## Fixed Issues
 

--- a/packages/openapi-generator/src/parser/operation.spec.ts
+++ b/packages/openapi-generator/src/parser/operation.spec.ts
@@ -115,6 +115,24 @@ describe('parsePathParameters', () => {
     ).toEqual([]);
   });
 
+  it('throws an error if multiple parameters defined in the same part of the path', async () => {
+    const refs = await createTestRefs();
+    expect(() =>
+      parsePathParameters([], '/test/{param1}:{param2}', refs, { strictNaming: false })
+    ).toThrowErrorMatchingInlineSnapshot(
+      '"Path pattern \'/test/{param1}:{param2}\' is invalid or not supported."'
+    );
+  });
+
+  it('throws an error if path pattern contains invalid characters', async () => {
+    const refs = await createTestRefs();
+    expect(() =>
+      parsePathParameters([], '/test/value?param={param}', refs, { strictNaming: false })
+    ).toThrowErrorMatchingInlineSnapshot(
+      '"Path pattern \'/test/value?param={param}\' is invalid or not supported."'
+    );
+  });
+
   it('throws an error if the parameters do not match the path pattern', async () => {
     const refs = await createTestRefs();
     expect(() =>

--- a/packages/openapi-generator/src/parser/operation.spec.ts
+++ b/packages/openapi-generator/src/parser/operation.spec.ts
@@ -118,7 +118,9 @@ describe('parsePathParameters', () => {
   it('throws an error if multiple parameters defined in the same part of the path', async () => {
     const refs = await createTestRefs();
     expect(() =>
-      parsePathParameters([], '/test/{param1}:{param2}', refs, { strictNaming: false })
+      parsePathParameters([], '/test/{param1}:{param2}', refs, {
+        strictNaming: false
+      })
     ).toThrowErrorMatchingInlineSnapshot(
       '"Path pattern \'/test/{param1}:{param2}\' is invalid or not supported."'
     );
@@ -127,7 +129,9 @@ describe('parsePathParameters', () => {
   it('throws an error if path pattern contains invalid characters', async () => {
     const refs = await createTestRefs();
     expect(() =>
-      parsePathParameters([], '/test/value?param={param}', refs, { strictNaming: false })
+      parsePathParameters([], '/test/value?param={param}', refs, {
+        strictNaming: false
+      })
     ).toThrowErrorMatchingInlineSnapshot(
       '"Path pattern \'/test/value?param={param}\' is invalid or not supported."'
     );

--- a/packages/openapi-generator/src/parser/operation.ts
+++ b/packages/openapi-generator/src/parser/operation.ts
@@ -76,8 +76,14 @@ function validatePlaceholder(pathPart: string): boolean {
   return /^\{[^{}]+\}$/.test(pathPart);
 }
 
-function validatePathPattern(pathPattern: string, placeholders: string[]): boolean{
-  return pathPattern.includes('?') || placeholders.some(placeholder => !validatePlaceholder(placeholder))
+function validatePathPattern(
+  pathPattern: string,
+  placeholders: string[]
+): boolean {
+  return (
+    pathPattern.includes('?') ||
+    placeholders.some(placeholder => !validatePlaceholder(placeholder))
+  );
 }
 
 function sortPathParameters(
@@ -87,7 +93,7 @@ function sortPathParameters(
   const pathParts = pathPattern.split('/');
   const placeholders = pathParts.filter(part => isPlaceholder(part));
 
-  if(validatePathPattern(pathPattern, placeholders)){
+  if (validatePathPattern(pathPattern, placeholders)) {
     throw new Error(
       `Path pattern '${pathPattern}' is invalid or not supported.`
     );
@@ -136,7 +142,7 @@ export function parsePathParameters(
   refs: OpenApiDocumentRefs,
   options: ParserOptions
 ): OpenApiParameter[] {
-  //todo validate
+  // todo validate
   const sortedPathParameters = sortPathParameters(pathParameters, pathPattern);
   const parsedParameters = parseParameters(sortedPathParameters, refs);
   const uniqueNames = ensureUniqueNames(

--- a/packages/openapi-generator/src/parser/operation.ts
+++ b/packages/openapi-generator/src/parser/operation.ts
@@ -72,17 +72,24 @@ function isPlaceholder(pathPart: string): boolean {
   return /^\{.+\}$/.test(pathPart);
 }
 
-function validatePlaceholder(pathPart: string): boolean {
-  return /^\{[^{}]+\}$/.test(pathPart);
+function isValidPlaceholder(placeholder: string): boolean {
+  // This regex matches the cases:
+  // 1. it starts with `{`
+  // 2. it ends with `}`
+  // 3. it does not contain any other `{` or `}` in the middle
+  return /^\{[^{}]+\}$/.test(placeholder);
 }
 
-function validatePathPattern(
+// This function checks whether the given path pattern is valid. Typically, it detects the invalid pattern like below
+// 1. `/path/{p1}:{p2}`
+// 2. `/path?{param}`
+function isValidPathPattern(
   pathPattern: string,
   placeholders: string[]
 ): boolean {
   return (
     pathPattern.includes('?') ||
-    placeholders.some(placeholder => !validatePlaceholder(placeholder))
+    placeholders.some(placeholder => !isValidPlaceholder(placeholder))
   );
 }
 
@@ -93,7 +100,7 @@ function sortPathParameters(
   const pathParts = pathPattern.split('/');
   const placeholders = pathParts.filter(part => isPlaceholder(part));
 
-  if (validatePathPattern(pathPattern, placeholders)) {
+  if (isValidPathPattern(pathPattern, placeholders)) {
     throw new Error(
       `Path pattern '${pathPattern}' is invalid or not supported.`
     );


### PR DESCRIPTION
There are two failing generation due to the special paths:
- /somePath/{param1}:{param2}, where `:` is used as delimiter between multiple parameters
- /somePath/value?param={date}-{time}, where `?` and query parameters are shown in the path

I added a validation step and improved the error message.