### PR TITLE
fix: Fix uniqueness check on directory names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Compatibility Notes
 
 - [eslint-config] Remove `brace-style` rule for compatibility with Prettier 2.3.
+- [openapi-generator] Change the basis for directory, package, and service names, when generating clients. If not specified otherwise, the default is based on the directory name instead of the service name.
 
 ## New Functionality
 
@@ -27,6 +28,7 @@
 ## Fixed Issues
 
 - [core] Fix type error to allow filtering on one-to-many navigation properties in lambda expressions.
+- [openapi-generator] Base uniqueness check for directory names on directory names in `optionsPerService` instead of the human readable service name.
 
 
 # 1.45.0

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -174,9 +174,9 @@ describe('generator', () => {
         .toMatchInlineSnapshot(`
               "{
                 \\"inputDir/spec.json\\": {
-                  \\"packageName\\": \\"spec\\",
+                  \\"packageName\\": \\"customName\\",
                   \\"directoryName\\": \\"customName\\",
-                  \\"serviceName\\": \\"spec\\"
+                  \\"serviceName\\": \\"customName\\"
                 }
               }"
             `);

--- a/packages/openapi-generator/src/options/options-per-service.spec.ts
+++ b/packages/openapi-generator/src/options/options-per-service.spec.ts
@@ -79,12 +79,9 @@ describe('getServiceOptions', () => {
 
   it('adds defaults if a config exists partially', () => {
     expect(
-      getServiceOptions(
-        {
-          packageName: 'customPackageName'
-        },
-        'serviceName'
-      )
+      getServiceOptions('serviceName', {
+        packageName: 'customPackageName'
+      })
     ).toEqual({
       packageName: 'customPackageName',
       directoryName: 'serviceName',

--- a/packages/openapi-generator/src/options/options-per-service.spec.ts
+++ b/packages/openapi-generator/src/options/options-per-service.spec.ts
@@ -63,32 +63,28 @@ describe('getServiceOptions', () => {
       directoryName: 'serviceName',
       serviceName: 'serviceName'
     };
-    const optionsPerService = { 'some/input.json': expectedConfig };
-    expect(
-      getServiceOptions(optionsPerService, 'some/input.json', 'serviceName')
-    ).toEqual(expectedConfig);
+    expect(getServiceOptions(expectedConfig, 'serviceName')).toEqual(
+      expectedConfig
+    );
   });
 
   it('gets the default config if it does not exist', () => {
-    const optionsPerService = {};
     const expectedConfig = {
       packageName: 'serviceName',
       directoryName: 'serviceName',
       serviceName: 'serviceName'
     };
-    expect(
-      getServiceOptions(optionsPerService, 'some/input.json', 'serviceName')
-    ).toEqual(expectedConfig);
+    expect(getServiceOptions(undefined, 'serviceName')).toEqual(expectedConfig);
   });
 
   it('adds defaults if a config exists partially', () => {
-    const optionsPerService = {
-      'some/input.json': {
-        packageName: 'customPackageName'
-      }
-    };
     expect(
-      getServiceOptions(optionsPerService, 'some/input.json', 'serviceName')
+      getServiceOptions(
+        {
+          packageName: 'customPackageName'
+        },
+        'serviceName'
+      )
     ).toEqual({
       packageName: 'customPackageName',
       directoryName: 'serviceName',
@@ -142,10 +138,10 @@ describe('getOptionsPerService', () => {
     });
   });
 
-  it('builds PerService config with partial options  per service.', async () => {
+  it('builds options per service with partial options per service.', async () => {
     const partialConfig = {
       'path/service': {
-        directoryName: 'dirName',
+        serviceName: 'Readable Name',
         packageName: '@scope/package-name'
       }
     };
@@ -162,9 +158,9 @@ describe('getOptionsPerService', () => {
       } as ParsedGeneratorOptions)
     ).resolves.toEqual({
       'path/service': {
-        directoryName: 'dirName',
+        directoryName: 'service',
         packageName: '@scope/package-name',
-        serviceName: 'service'
+        serviceName: 'Readable Name'
       }
     });
   });
@@ -174,10 +170,13 @@ describe('getOptionsPerService', () => {
       getOptionsPerService(['/user/path1/service', '/user/path2/service'], {
         skipValidation: false
       } as ParsedGeneratorOptions)
-    ).rejects.toMatchInlineSnapshot(`
-            [Error: The following service specs lead to non unique service names:
-            path2/service.
-            You can either introduce a optionsPerSerivice file or enable the skipValidation flag.]
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+            "Duplicate service directory names found. Customize directory names with \`optionsPerService\` or enable automatic name adjustment with \`skipValidation\`.
+            	Duplicates:
+            		Directory name: 'service', specifications: [
+            			/user/path1/service,
+            			/user/path2/service
+            		]"
           `);
   });
 

--- a/packages/openapi-generator/src/options/options-per-service.spec.ts
+++ b/packages/openapi-generator/src/options/options-per-service.spec.ts
@@ -63,7 +63,7 @@ describe('getServiceOptions', () => {
       directoryName: 'serviceName',
       serviceName: 'serviceName'
     };
-    expect(getServiceOptions(expectedConfig, 'serviceName')).toEqual(
+    expect(getServiceOptions('serviceName', expectedConfig)).toEqual(
       expectedConfig
     );
   });
@@ -74,7 +74,7 @@ describe('getServiceOptions', () => {
       directoryName: 'serviceName',
       serviceName: 'serviceName'
     };
-    expect(getServiceOptions(undefined, 'serviceName')).toEqual(expectedConfig);
+    expect(getServiceOptions('serviceName')).toEqual(expectedConfig);
   });
 
   it('adds defaults if a config exists partially', () => {

--- a/packages/openapi-generator/src/options/options-per-service.ts
+++ b/packages/openapi-generator/src/options/options-per-service.ts
@@ -1,7 +1,6 @@
 import { existsSync, promises } from 'fs';
 import { parse } from 'path';
-import { EOL } from 'os';
-import { UniqueNameGenerator } from '@sap-cloud-sdk/util';
+import { unique, UniqueNameGenerator } from '@sap-cloud-sdk/util';
 import { getRelativePath } from '../generator';
 import { ParsedGeneratorOptions } from './generator-options';
 
@@ -31,7 +30,7 @@ export interface ServiceOptions {
    */
   packageName: string;
   /**
-   * Name of the service
+   * Human readable name of the service. Used in API documentation and readme.
    */
   serviceName: string;
 }
@@ -50,12 +49,12 @@ export async function getOriginalOptionsPerService(
 }
 
 /**
- * Get the options per service for the list of services.
+ * Get the options per service for given service specifications.
  * If optionsPerServicePath is not given default values are used for the services.
  * If optionsPerServicePath is given existing values for the services are.
- * @param inputPaths Paths for the service spec files
- * @param options Options of the generator
- * @returns The parsed configuration for all services in relativeServicePaths.
+ * @param inputPaths Service spec file paths.
+ * @param options Generator options.
+ * @returns The parsed options per service.
  */
 export async function getOptionsPerService(
   inputPaths: string[],
@@ -66,50 +65,96 @@ export async function getOptionsPerService(
   );
 
   const uniqueNameGenerator = new UniqueNameGenerator('-');
-  const duplicateServicePaths: string[] = [];
+
+  const directoryNamesByPaths = getDirectoryNamesByPaths(
+    inputPaths,
+    originalOptionsPerService
+  );
+  if (!options.skipValidation) {
+    validateDirectoryNames(directoryNamesByPaths);
+  }
 
   const optionsPerService: OptionsPerService = inputPaths.reduce(
-    (previousOptions, path) => {
-      const relativePath = getRelativePath(path);
+    (previousOptions, inputPath) => {
+      const relativePath = getRelativePath(inputPath);
 
-      const originalServiceName =
-        originalOptionsPerService[relativePath]?.serviceName ||
-        parseServiceName(relativePath);
-      const uniqueServiceName =
-        uniqueNameGenerator.generateAndSaveUniqueName(originalServiceName);
-      if (originalServiceName !== uniqueServiceName) {
-        duplicateServicePaths.push(relativePath);
-      }
+      const uniqueDirName = uniqueNameGenerator.generateAndSaveUniqueName(
+        directoryNamesByPaths[inputPath]
+      );
 
       previousOptions[relativePath] = getServiceOptions(
-        originalOptionsPerService,
-        relativePath,
-        uniqueServiceName
+        originalOptionsPerService[relativePath],
+        uniqueDirName
       );
       return previousOptions;
     },
     {}
   );
 
-  if (duplicateServicePaths.length > 0 && !options.skipValidation) {
-    throw new Error(
-      `The following service specs lead to non unique service names:${EOL}${duplicateServicePaths.join(
-        EOL
-      )}.${EOL}You can either ${
-        options.optionsPerService ? 'adjust your' : 'introduce a'
-      } optionsPerSerivice file or enable the skipValidation flag.`
-    );
-  }
-
   return optionsPerService;
 }
 
+function getDirectoryNamesByPaths(
+  inputPaths: string[],
+  originalOptionsPerService: PartialOptionsPerService
+): Record<string, string> {
+  return inputPaths.reduce((directoryNamesByPaths, inputPath) => {
+    const relativePath = getRelativePath(inputPath);
+    const directoryName =
+      originalOptionsPerService[relativePath]?.directoryName ||
+      parseDirectoryName(relativePath);
+
+    directoryNamesByPaths[inputPath] = directoryName;
+    return directoryNamesByPaths;
+  }, {});
+}
+
+function getPathsByDirName(
+  dirNamesByPaths: Record<string, string>
+): Record<string, string[]> {
+  return Object.entries(dirNamesByPaths).reduce(
+    (pathsByDirName, [inputPath, dirName]) => {
+      if (!pathsByDirName[dirName]) {
+        pathsByDirName[dirName] = [];
+      }
+      pathsByDirName[dirName].push(inputPath);
+      return pathsByDirName;
+    },
+    {}
+  );
+}
+
+function validateDirectoryNames(dirNamesByPaths: Record<string, string>): void {
+  const originalDirNames = Object.values(dirNamesByPaths);
+  const uniqueDirNames = unique(originalDirNames);
+  const hasDuplicates = originalDirNames.length !== uniqueDirNames.length;
+
+  if (hasDuplicates) {
+    const pathsByDirName = getPathsByDirName(dirNamesByPaths);
+    const duplicates = Object.entries(pathsByDirName).filter(
+      ([, paths]) => paths.length > 1
+    );
+
+    const duplicatesList = duplicates
+      .map(
+        ([dirName, paths]) =>
+          `\t\tDirectory name: '${dirName}', specifications: [\n${paths
+            .map(path => `\t\t\t${path}`)
+            .join(',\n')}\n\t\t]`
+      )
+      .join('\n');
+
+    const errorMessage = `Duplicate service directory names found. Customize directory names with \`optionsPerService\` or enable automatic name adjustment with \`skipValidation\`.\n\tDuplicates:\n${duplicatesList}`;
+    throw new Error(errorMessage);
+  }
+}
+
 /**
- * Parse the name of the service based on the file path.
+ * Parse the name of the service directory based on the file path.
  * @param filePath Path of the service specification.
  * @returns The parsed name.
  */
-function parseServiceName(filePath: string): string {
+function parseDirectoryName(filePath: string): string {
   return parse(filePath).name.replace(/-openapi$/, '');
 }
 
@@ -117,25 +162,23 @@ function parseServiceName(filePath: string): string {
  * Get the options for one service based on the options per service and the input file path.
  * If the file path does not exist in the options a default config is created.
  * If the service options for a file path are given only partially, default values are added for the missing values.
- * @param optionsPerService The original options per service to get the service options from.
- * @param relativeInputFilePath The input file path for which to find service options.
- * @param serviceName The default name of the according service.
+ * @param serviceOptions The original options for this service as specified in the per service options.
+ * @param directoryName The directory name of the according service.
  * @returns Service options.
  */
 export function getServiceOptions(
-  optionsPerService: PartialOptionsPerService,
-  relativeInputFilePath: string,
-  serviceName: string
+  serviceOptions: Partial<ServiceOptions> | undefined,
+  directoryName: string
 ): ServiceOptions {
   const defaultConfig = {
-    packageName: serviceName,
-    directoryName: serviceName,
-    serviceName
+    packageName: directoryName,
+    directoryName,
+    serviceName: directoryName
   };
 
-  const configFromOptionsPerService = optionsPerService[relativeInputFilePath];
   return {
     ...defaultConfig,
-    ...configFromOptionsPerService
+    ...serviceOptions,
+    directoryName
   };
 }

--- a/packages/openapi-generator/src/options/options-per-service.ts
+++ b/packages/openapi-generator/src/options/options-per-service.ts
@@ -83,8 +83,8 @@ export async function getOptionsPerService(
       );
 
       previousOptions[relativePath] = getServiceOptions(
-        originalOptionsPerService[relativePath],
-        uniqueDirName
+        uniqueDirName,
+        originalOptionsPerService[relativePath]
       );
       return previousOptions;
     },
@@ -162,13 +162,13 @@ function parseDirectoryName(filePath: string): string {
  * Get the options for one service based on the options per service and the input file path.
  * If the file path does not exist in the options a default config is created.
  * If the service options for a file path are given only partially, default values are added for the missing values.
- * @param serviceOptions The original options for this service as specified in the per service options.
  * @param directoryName The directory name of the according service.
+ * @param serviceOptions The original options for this service as specified in the per service options.
  * @returns Service options.
  */
 export function getServiceOptions(
-  serviceOptions: Partial<ServiceOptions> | undefined,
-  directoryName: string
+  directoryName: string,
+  serviceOptions?: Partial<ServiceOptions>
 ): ServiceOptions {
   const defaultConfig = {
     packageName: directoryName,

--- a/packages/openapi-generator/src/parser/refs.spec.ts
+++ b/packages/openapi-generator/src/parser/refs.spec.ts
@@ -13,6 +13,7 @@ describe('OpenApiDocumentRefs', () => {
       { strictNaming: true }
     );
   });
+
   describe('resolveObject', () => {
     it('resolves reference', async () => {
       expect(
@@ -121,7 +122,7 @@ describe('OpenApiDocumentRefs', () => {
           { strictNaming: true }
         )
       ).rejects.toThrowError(
-        'Your OpenApi definition contains the invalid schema names.'
+        'The service specification contains invalid schema names.'
       );
     });
 

--- a/packages/openapi-generator/src/parser/refs.ts
+++ b/packages/openapi-generator/src/parser/refs.ts
@@ -6,7 +6,7 @@ import { SchemaNaming } from '../openapi-types';
 import { SchemaRefMapping } from './parsing-info';
 import { ensureUniqueNames } from './unique-naming';
 import { ParserOptions } from './options';
-import { ensureUValidSchemaNames } from './schema-naming';
+import { ensureValidSchemaNames } from './schema-naming';
 
 /**
  * Convenience function to invoke the creation of the OpenApiDocumentRefs builder.
@@ -53,7 +53,7 @@ export class OpenApiDocumentRefs {
     options: ParserOptions
   ): SchemaRefMapping {
     const originalNames = Object.keys(document.components?.schemas || {});
-    const validSchemaNames = ensureUValidSchemaNames(originalNames, options);
+    const validSchemaNames = ensureValidSchemaNames(originalNames, options);
 
     const schemaNames = ensureUniqueNames(validSchemaNames, options, {
       format: pascalCase,

--- a/packages/openapi-generator/src/parser/schema-naming.spec.ts
+++ b/packages/openapi-generator/src/parser/schema-naming.spec.ts
@@ -1,27 +1,27 @@
-import { ensureUValidSchemaNames } from './schema-naming';
+import { ensureValidSchemaNames } from './schema-naming';
 
 describe('schema-naming', () => {
   it('adds prefix if schema starts with integer', () => {
     expect(
-      ensureUValidSchemaNames(['1234ABC'], { strictNaming: false })
+      ensureValidSchemaNames(['1234ABC'], { strictNaming: false })
     ).toEqual(['schema1234ABC']);
   });
 
   it('removes special character', () => {
     expect(
-      ensureUValidSchemaNames(['#som%eth.ing'], { strictNaming: false })
+      ensureValidSchemaNames(['#som%eth.ing'], { strictNaming: false })
     ).toEqual(['something']);
   });
 
   it('throws if the strict naming is on', () => {
     expect(() =>
-      ensureUValidSchemaNames(['1234ABC', '#som%eth.ing'], {
+      ensureValidSchemaNames(['1234ABC', '#som%eth.ing'], {
         strictNaming: true
       })
     ).toThrowErrorMatchingInlineSnapshot(`
-      "Your OpenApi definition contains the invalid schema names. The SDK generator can adjust such names automatically if you disable 'strictNaming' or you adjust the schema. The errors are:
-      The schema 1234ABC starts with an integer.
-      The schema #som%eth.ing contains an illegal character."
+      "The service specification contains invalid schema names. Adjust the definition file or enable automatic name adjustment with \`skipValidation\`.
+      	Invalid names starting with a number: '1234ABC'
+      	Invalid names containing illegal characters: '#som%eth.ing'"
     `);
   });
 });

--- a/packages/openapi-generator/src/parser/unique-naming.ts
+++ b/packages/openapi-generator/src/parser/unique-naming.ts
@@ -31,12 +31,8 @@ export function ensureUniqueNames(
 
   if (options.strictNaming) {
     const formattedNames = names.map(originalName => format(originalName));
-    if (validateUniqueness(formattedNames, reservedWords)) {
-      return formattedNames;
-    }
-    throw new Error(
-      getDuplicateErrorMessage(names, formattedNames, reservedWords)
-    );
+    validateUniqueness(names, formattedNames, reservedWords);
+    return formattedNames;
   }
   return deduplicateNames(names, { format, reservedWords, separator });
 }
@@ -44,18 +40,23 @@ export function ensureUniqueNames(
 /**
  * Validate uniqueness of names.
  * Takes a list of names and throws an error if there are duplicates after formatting.
+ * @param names List of names to ensure uniqueness for.
  * @param formattedNames Original transformed names.
  * @param reservedWords Reserved words that should be handled as duplicates.
- * @returns True if the names are not conflicting after transformation, otherwise false.
  */
 export function validateUniqueness(
+  names: string[],
   formattedNames: string[],
   reservedWords: string[] = []
-): boolean {
-  return (
-    !hasDuplicates(formattedNames) &&
-    !hasReservedWords(formattedNames, reservedWords)
-  );
+): void {
+  if (
+    hasDuplicates(formattedNames) ||
+    hasReservedWords(formattedNames, reservedWords)
+  ) {
+    throw new Error(
+      getDuplicateErrorMessage(names, formattedNames, reservedWords)
+    );
+  }
 }
 
 /**

--- a/test-packages/type-tests/test/v2/filter.spec.ts
+++ b/test-packages/type-tests/test/v2/filter.spec.ts
@@ -42,3 +42,9 @@ TestEntity.COMPLEX_TYPE_PROPERTY.stringProperty.equals('test');
 
 // $ExpectError
 TestEntity.COMPLEX_TYPE_PROPERTY.equals('test');
+
+// $ExpectError
+TestEntity.KEY_PROPERTY_STRING.equals(null);
+
+// $ExpectType Filter<TestEntity, string>
+TestEntity.STRING_PROPERTY.equals(null);

--- a/test-packages/type-tests/test/v2/filter.spec.ts
+++ b/test-packages/type-tests/test/v2/filter.spec.ts
@@ -42,9 +42,3 @@ TestEntity.COMPLEX_TYPE_PROPERTY.stringProperty.equals('test');
 
 // $ExpectError
 TestEntity.COMPLEX_TYPE_PROPERTY.equals('test');
-
-// $ExpectError
-TestEntity.KEY_PROPERTY_STRING.equals(null);
-
-// $ExpectType Filter<TestEntity, string>
-TestEntity.STRING_PROPERTY.equals(null);


### PR DESCRIPTION
This PR includes some minor refactoring of descriptions and error messages.
The main purpose is to fix the uniqueness check for directory names. Before, we checked the `serviceName` in `optionsPerService` for uniqueness. The purpose of this field is solely to have a human readable text in the readme and API docs. It is ok if this is duplicate. It is not for directory names, though.