### PR TITLE
chore: export sdk-metatdata in generator common

### DIFF
--- a/packages/generator-common/internal.js
+++ b/packages/generator-common/internal.js
@@ -1,0 +1,15 @@
+'use strict';
+function __export(m) {
+  for (const p in m) {
+    if (!exports.hasOwnProperty(p)) {
+      exports[p] = m[p];
+    }
+  }
+}
+Object.defineProperty(exports, '__esModule', { value: true });
+/**
+ * @packageDocumentation
+ * @experimental The internal module is related to sdk-metadata types which are used only internally.
+ */
+__export(require('./dist/sdk-metadata'));
+// # sourceMappingURL=internal.js.map

--- a/packages/generator-common/package.json
+++ b/packages/generator-common/package.json
@@ -19,7 +19,8 @@
     "dist/**/*.js",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
-    "dist/**/*.d.ts.map"
+    "dist/**/*.d.ts.map",
+    "internal.js"
   ],
   "repository": "github:SAP/cloud-sdk-js",
   "scripts": {


### PR DESCRIPTION
For the oData and openApi generators we were already exporting the metadata under the non root to be used by us internally. We did not do this for the generator-common part which was introduced later.