### PR TITLE
fix: Proxy config not considered for destination service calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- [proxy] Fix destination service calls using web proxies.
 
 
 # 1.46.0

--- a/packages/core/src/connectivity/scp-cf/destination/destination-service.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-service.ts
@@ -8,7 +8,6 @@ import CircuitBreaker from 'opossum';
 import { decodeJwt, wrapJwtInHeader } from '../jwt';
 import {
   executeHttpRequest,
-  getAxiosConfigWithDefaults,
   HttpRequestConfig,
   HttpRequestOptions,
   HttpResponse
@@ -239,9 +238,7 @@ function callDestinationService(
   options: ResilienceOptions = { enableCircuitBreaker: true }
 ): Promise<HttpResponse> {
   const config: HttpRequestConfig = {
-    ...getAxiosConfigWithDefaults(),
-    url: uri,
-    method: 'GET',
+    method: 'get',
     headers
   };
 

--- a/packages/core/src/http-client/http-client.spec.ts
+++ b/packages/core/src/http-client/http-client.spec.ts
@@ -163,7 +163,7 @@ describe('generic http client', () => {
       );
     });
 
-    it('overwrites the default axios config with detination config', async () => {
+    it('overwrites the default axios config with destination related request config', async () => {
       const destination: Destination = {
         url: 'https://destinationUrl',
         proxyConfiguration: {

--- a/packages/core/src/http-client/http-client.spec.ts
+++ b/packages/core/src/http-client/http-client.spec.ts
@@ -147,6 +147,59 @@ describe('generic http client', () => {
       expect(actual.httpsAgent).toBeDefined();
     });
 
+    it('includes the default axios config in request', async () => {
+      const destination: Destination = { url: 'https://destinationUrl' };
+      // const destination:Destination = {url:'https://destinationUrl',proxyConfiguration:{host:'dummy',port:1234,protocol:Protocol.HTTP}}
+      const requestSpy = jest.spyOn(Axios, 'request');
+      await expect(
+        executeHttpRequest(destination, { method: 'get' })
+      ).rejects.toThrowError();
+      expect(requestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          proxy: false,
+          httpsAgent: expect.anything(),
+          httpAgent: expect.anything()
+        })
+      );
+    });
+
+    it('overwrites the default axios config with detination config', async () => {
+      const destination: Destination = {
+        url: 'https://destinationUrl',
+        proxyConfiguration: {
+          host: 'dummy',
+          port: 1234,
+          protocol: Protocol.HTTP
+        }
+      };
+      const requestSpy = jest.spyOn(Axios, 'request');
+      await expect(
+        executeHttpRequest(destination, { method: 'get' })
+      ).rejects.toThrowError();
+      expect(requestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          proxy: false,
+          httpsAgent: expect.objectContaining({
+            proxy: expect.objectContaining({ port: 1234 })
+          })
+        })
+      );
+    });
+
+    it('overwrites destination related request config with the explicit one', async () => {
+      const destination: Destination = { url: 'https://destinationUrl' };
+      const requestSpy = jest.spyOn(Axios, 'request');
+      await expect(
+        executeHttpRequest(destination, { method: 'post' })
+      ).rejects.toThrowError();
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'post'
+        })
+      );
+    });
+
     it('overwrites baseURL and either httpAgent or httpsAgent', async () => {
       const expected = {
         baseURL: 'https://custom.example.com',

--- a/packages/openapi-generator/src/parser/schema-naming.ts
+++ b/packages/openapi-generator/src/parser/schema-naming.ts
@@ -4,12 +4,6 @@ import { ParserOptions } from './options';
 const illegalCharacterRegex = /[.#@/"'*%]+/g;
 const startsWithNumberRegex = /^\d+/g;
 
-function isValidSchemaName(name: string): boolean {
-  return (
-    !name.match(startsWithNumberRegex) && !name.match(illegalCharacterRegex)
-  );
-}
-
 function makeSchemaNameValid(name: string): string {
   while (name.match(illegalCharacterRegex)) {
     name = name.replace(illegalCharacterRegex, '');


### PR DESCRIPTION
closes #1384 

@johenning found an error in the proxy handling. We included the default agents in the passed request config. This config beats the one from the destination, which is intended to have a way to overwrite things.

However, if the destination had a valid internet proxy config this would would overwrite the config from the destination and leads the error @johenning observed.

Note that es always add the [axios default config](https://github.com/SAP/cloud-sdk-js/blob/40c006573602c6813d51714073f6ee6055006b4c/packages/core/src/http-client/http-client.ts#L205) with the agents which gets overwritten by everything else. So there is no need to add this in the config at all.