### PR TITLE
feat: Support OAuth2JWTBearer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ## New Functionality
 
--
+- [core] Support `OAuth2JWTBearer` authentication type.
 
 ## Improvements
 

--- a/packages/core/src/connectivity/scp-cf/authorization-header.ts
+++ b/packages/core/src/connectivity/scp-cf/authorization-header.ts
@@ -56,6 +56,7 @@ function needsAuthHeaders(destination: Destination): boolean {
     'OAuth2ClientCredentials',
     'OAuth2SAMLBearerAssertion',
     'OAuth2UserTokenExchange',
+    'OAuth2JWTBearer',
     'PrincipalPropagation'
   ];
   return authTypesWithAuthorizationHeader.includes(destination.authentication);
@@ -233,6 +234,7 @@ async function getAuthenticationRelatedHeaders(
       return {};
     case 'OAuth2SAMLBearerAssertion':
     case 'OAuth2UserTokenExchange':
+    case 'OAuth2JWTBearer':
     case 'OAuth2ClientCredentials':
       return headerFromTokens(
         destination.authentication,

--- a/packages/core/src/connectivity/scp-cf/client-credentials-token.ts
+++ b/packages/core/src/connectivity/scp-cf/client-credentials-token.ts
@@ -5,8 +5,8 @@ import {
   ClientCredentialsResponse
 } from './xsuaa-service-types';
 
-// TODO: This should be moved down to the token accessor
 /**
+ * @deprecated Since v1.47.0.
  * Retrieves an access token required for "OAuth2ClientCredentials" destination authentication type.
  *
  * @param destination - A destination having `OAuth2ClientCredentials` authentication type

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
@@ -114,6 +114,13 @@ class DestinationFromServiceRetriever {
     if (destination.authentication === 'OAuth2ClientCredentials') {
       destination = await da.addOAuth2ClientCredentials();
     }
+    if (destination.authentication === 'OAuth2JWTBearer'){
+      // todo add jwt info
+      destination = await da.addOAuthSamlAuth(
+        destination,
+        destinationResult.origin
+      );
+    }
     if (destination.authentication === 'ClientCertificateAuthentication') {
       destination = await da.addClientCertAuth();
     }

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
@@ -115,10 +115,7 @@ class DestinationFromServiceRetriever {
       destination = await da.addOAuth2ClientCredentials();
     }
     if (destination.authentication === 'OAuth2JWTBearer') {
-      destination = await da.addOAuthSamlAuth(
-        destination,
-        destinationResult.origin
-      );
+      destination = await da.fetchDestinationByUserJwt();
     }
     if (destination.authentication === 'ClientCertificateAuthentication') {
       destination = await da.addClientCertAuth();
@@ -331,8 +328,6 @@ class DestinationFromServiceRetriever {
     destination: Destination,
     destinationOrigin: DestinationOrigin
   ): Promise<Destination> {
-    const destinationService = getDestinationService();
-
     /* This covers the two technical user propagation cases https://help.sap.com/viewer/cca91383641e40ffbe03bdc78f00f681/Cloud/en-US/3cb7b81115c44cf594e0e3631291af94.html
    If the destination comes from the provider account the client credentials token from the xsuaa.url is used (provider token).
    If the destination comes from the subscriber account the subscriber subdomain is used fetch the client credentials token (subscriber token).
@@ -352,6 +347,13 @@ class DestinationFromServiceRetriever {
         return this.fetchDestinationByToken(token);
       }
     }
+
+    return this.fetchDestinationByUserJwt();
+  }
+
+  private async fetchDestinationByUserJwt(): Promise<Destination> {
+    const destinationService = getDestinationService();
+
     /* This covers the two business user propagation cases https://help.sap.com/viewer/cca91383641e40ffbe03bdc78f00f681/Cloud/en-US/3cb7b81115c44cf594e0e3631291af94.html
      The two cases are JWT issued from provider or JWT from subscriber - the two cases are handled automatically.
      In the provider case the subdomain replacement in the xsuaa.url with the iss value does nothing but this does not hurt. */

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
@@ -114,7 +114,7 @@ class DestinationFromServiceRetriever {
     if (destination.authentication === 'OAuth2ClientCredentials') {
       destination = await da.addOAuth2ClientCredentials();
     }
-    if (destination.authentication === 'OAuth2JWTBearer'){
+    if (destination.authentication === 'OAuth2JWTBearer') {
       destination = await da.addOAuthSamlAuth(
         destination,
         destinationResult.origin

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
@@ -115,7 +115,6 @@ class DestinationFromServiceRetriever {
       destination = await da.addOAuth2ClientCredentials();
     }
     if (destination.authentication === 'OAuth2JWTBearer'){
-      // todo add jwt info
       destination = await da.addOAuthSamlAuth(
         destination,
         destinationResult.origin

--- a/packages/core/src/connectivity/scp-cf/destination/destination-service-types.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-service-types.ts
@@ -72,17 +72,17 @@ export interface Destination {
   proxyConfiguration?: ProxyConfiguration;
 
   /**
-   * Client Id used to retrieve access token for "OAuth2ClientCredentials" authentication.
+   * Client Id used to retrieve access token for "OAuth2ClientCredentials", "OAuth2UserTokenExchange" and "OAuth2JWTBearer" authentication.
    */
   clientId?: string;
 
   /**
-   * Client Secret used to retrieve access token for "OAuth2ClientCredentials" authentication.
+   * Client Secret used to retrieve access token for "OAuth2ClientCredentials", "OAuth2UserTokenExchange" and "OAuth2JWTBearer" authentication.
    */
   clientSecret?: string;
 
   /**
-   * URL to retrieve access token for "OAuth2ClientCredentials" authentication.
+   * URL to retrieve access token for "OAuth2ClientCredentials", "OAuth2UserTokenExchange" and "OAuth2JWTBearer" authentication.
    */
   tokenServiceUrl?: string;
 
@@ -247,7 +247,8 @@ export type AuthenticationType =
   | 'OAuth2SAMLBearerAssertion'
   | 'OAuth2ClientCredentials'
   | 'OAuth2UserTokenExchange'
-  | 'ClientCertificateAuthentication';
+  | 'ClientCertificateAuthentication'
+  | 'OAuth2JWTBearer';
 
 /**
  * The destinations endpoint distinguished between destinations maintained on service level (instance) and account level (subaccount).

--- a/packages/core/test/test-util/example-destination-service-responses.ts
+++ b/packages/core/test/test-util/example-destination-service-responses.ts
@@ -83,7 +83,7 @@ export const oauthUserTokenExchangeMultipleResponse: DestinationConfiguration[] 
       tokenServicePassword: 'password'
     }
   ];
-// todo add more
+
 export const oauthClientCredentialsMultipleResponse: DestinationConfiguration[] =
   [
     {

--- a/packages/core/test/test-util/example-destination-service-responses.ts
+++ b/packages/core/test/test-util/example-destination-service-responses.ts
@@ -83,7 +83,7 @@ export const oauthUserTokenExchangeMultipleResponse: DestinationConfiguration[] 
       tokenServicePassword: 'password'
     }
   ];
-
+// todo add more
 export const oauthClientCredentialsMultipleResponse: DestinationConfiguration[] =
   [
     {

--- a/test-packages/integration-tests/test/auth-flows/auth-flow-util.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow-util.ts
@@ -45,7 +45,7 @@ export interface Systems {
   workflow: {
     providerOAuth2ClientCredentials: string;
     providerOAuth2UserTokenExchange: string;
-    providerOauth2JWTBearer: string
+    providerOauth2JWTBearer: string;
   };
   destination: {
     subscriberOAuth2UserTokenExchange: string;

--- a/test-packages/integration-tests/test/auth-flows/auth-flow-util.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow-util.ts
@@ -45,6 +45,7 @@ export interface Systems {
   workflow: {
     providerOAuth2ClientCredentials: string;
     providerOAuth2UserTokenExchange: string;
+    providerOauth2JWTBearer: string
   };
   destination: {
     subscriberOAuth2UserTokenExchange: string;

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -148,6 +148,25 @@ describe('OAuth flows', () => {
     expect(response.status).toBe(200);
   }, 60000);
 
+  xit('OAuth2JWTBearer: Provider Destination & Provider Token', async () => {
+    const token = await serviceToken('destination', {
+      userJwt: accessToken.provider
+    });
+
+    const destination = await fetchDestination(
+      destinationService!.credentials.uri,
+      token,
+      systems.workflow.providerOauth2JWTBearer
+    );
+
+    expect(destination!.authTokens![0].error).toBeNull();
+
+    destination.url = destination.url + '/v1/workflow-definitions';
+    const response = await executeHttpRequest(destination, { method: 'get' });
+
+    expect(response.status).toBe(200);
+  }, 60000);
+
   xit('ClientCertificate: Fetches the certificate and uses it', async () => {
     const destination = await getDestination('CC8-HTTP-CERT');
     expect(destination!.certificates!.length).toBe(1);


### PR DESCRIPTION
- [x] add `OAuth2JWTBearer` to the support list
- [x] test the auth type with workflow in ` auth-flow.spec.ts`

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
