### PR TITLE
Fix: lambda expression with or operand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - [proxy] Fix destination service calls using web proxies.
 - [core] Fix type error to allow `null` values in filters for nullable properties.
+- [core] Fix OData filter runtime error, when using lambda expression with operands like `or`.
 
 
 # 1.46.0

--- a/packages/core/src/odata-common/uri-conversion/get-filter.ts
+++ b/packages/core/src/odata-common/uri-conversion/get-filter.ts
@@ -13,7 +13,7 @@ import {
   FilterLambdaExpression,
   FilterList,
   FilterLink,
-  Filter, toFilterableList
+  Filter
 } from '../filter';
 import { EdmTypeShared } from '../edm-types';
 import { ComplexTypeField, FieldType, OneToManyLink } from '../selectable';
@@ -121,7 +121,7 @@ export function createGetFilter(uriConverter: UriConverter): GetFilter {
       );
     }
 
-    if (filter instanceof OneToManyLink){
+    if (filter instanceof OneToManyLink) {
       return getODataFilterExpressionForFilterLink(
         filter._filters,
         parentFieldNames,
@@ -131,7 +131,9 @@ export function createGetFilter(uriConverter: UriConverter): GetFilter {
     }
 
     throw new Error(
-      `Could not construct query parameters from filter. Filter is not valid: ${JSON.stringify(filter)}`
+      `Could not construct query parameters from filter. Filter is not valid: ${JSON.stringify(
+        filter
+      )}`
     );
   }
 

--- a/packages/core/src/odata-common/uri-conversion/get-filter.ts
+++ b/packages/core/src/odata-common/uri-conversion/get-filter.ts
@@ -13,10 +13,10 @@ import {
   FilterLambdaExpression,
   FilterList,
   FilterLink,
-  Filter
+  Filter, toFilterableList
 } from '../filter';
 import { EdmTypeShared } from '../edm-types';
-import { ComplexTypeField, FieldType } from '../selectable';
+import { ComplexTypeField, FieldType, OneToManyLink } from '../selectable';
 import { UriConverter } from '../uri-conversion';
 import { isFilterLambdaExpression } from '../filter/filter-lambda-expression';
 import { toStaticPropertyFormat } from '../name-converter';
@@ -121,8 +121,17 @@ export function createGetFilter(uriConverter: UriConverter): GetFilter {
       );
     }
 
+    if (filter instanceof OneToManyLink){
+      return getODataFilterExpressionForFilterLink(
+        filter._filters,
+        parentFieldNames,
+        targetEntityConstructor,
+        lambdaExpressionLevel
+      );
+    }
+
     throw new Error(
-      `Could not construct query parameters from filter. Filter is not valid: ${filter}`
+      `Could not construct query parameters from filter. Filter is not valid: ${JSON.stringify(filter)}`
     );
   }
 

--- a/packages/core/src/odata-v4/uri-conversion/odata-uri.spec.ts
+++ b/packages/core/src/odata-v4/uri-conversion/odata-uri.spec.ts
@@ -3,7 +3,7 @@ import {
   testFilterLambdaExpressionFilterFunctionOnLink,
   testFilterLambdaExpressionFilterLinkOnLink,
   testFilterLambdaExpressionFilterListOnLink,
-  testFilterLambdaExpressionOnLink,
+  testFilterLambdaExpressionOnLink, testFilterLambdaExpressionWithOr,
   testFilterString,
   testFilterStringV4,
   testNestedFilterLambdaExpressionOnLink
@@ -32,6 +32,12 @@ describe('getFilter', () => {
     expect(
       getFilter(testFilterLambdaExpressionOnLink.filter, TestEntity).filter
     ).toBe(encodeURIComponent(testFilterLambdaExpressionOnLink.odataStr));
+  });
+
+  it('for lambda expression with or operand', () => {
+    expect(
+      getFilter(testFilterLambdaExpressionWithOr.filter, TestEntity).filter
+    ).toBe(encodeURIComponent(testFilterLambdaExpressionWithOr.odataStr));
   });
 
   it('for lambda expression with FilterList on one-to-many navigation property', () => {

--- a/packages/core/src/odata-v4/uri-conversion/odata-uri.spec.ts
+++ b/packages/core/src/odata-v4/uri-conversion/odata-uri.spec.ts
@@ -3,7 +3,8 @@ import {
   testFilterLambdaExpressionFilterFunctionOnLink,
   testFilterLambdaExpressionFilterLinkOnLink,
   testFilterLambdaExpressionFilterListOnLink,
-  testFilterLambdaExpressionOnLink, testFilterLambdaExpressionWithOr,
+  testFilterLambdaExpressionOnLink,
+  testFilterLambdaExpressionWithOr,
   testFilterString,
   testFilterStringV4,
   testNestedFilterLambdaExpressionOnLink

--- a/packages/core/test/test-util/filter-factory.ts
+++ b/packages/core/test/test-util/filter-factory.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from 'uuid';
-import { or } from '../../src';
+import { and, or } from '../../src';
 import {
   all,
   any,
@@ -64,6 +64,16 @@ export const testFilterLambdaExpressionOnLink = {
   )._filters,
   odataStr:
     "(to_MultiLink/any(a0:(a0/StringProperty eq 'test1')) and to_MultiLink/all(a0:(a0/StringProperty eq 'test2')))"
+};
+
+export const testFilterLambdaExpressionWithOr = {
+  filter: or(
+    TestEntityV4.STRING_PROPERTY.equals('str1'),
+    TestEntityV4.TO_MULTI_LINK.filter(
+      any(TestEntityMultiLinkV4.STRING_PROPERTY.equals('str2'))
+    )
+  ),
+  odataStr: "(StringProperty eq 'str1' or (to_MultiLink/any(a0:(a0/StringProperty eq 'str2'))))"
 };
 
 export const testFilterLambdaExpressionFilterListOnLink = {

--- a/packages/core/test/test-util/filter-factory.ts
+++ b/packages/core/test/test-util/filter-factory.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from 'uuid';
-import { and, or } from '../../src';
+import { or } from '../../src';
 import {
   all,
   any,
@@ -73,7 +73,8 @@ export const testFilterLambdaExpressionWithOr = {
       any(TestEntityMultiLinkV4.STRING_PROPERTY.equals('str2'))
     )
   ),
-  odataStr: "(StringProperty eq 'str1' or (to_MultiLink/any(a0:(a0/StringProperty eq 'str2'))))"
+  odataStr:
+    "(StringProperty eq 'str1' or (to_MultiLink/any(a0:(a0/StringProperty eq 'str2'))))"
 };
 
 export const testFilterLambdaExpressionFilterListOnLink = {


### PR DESCRIPTION
Last time, the type error (compile time) was fixed, but the runtime error still exists: `Could not construct query parameters from filter. Filter is not valid`, as mentioned in the [issue](https://github.com/SAP/cloud-sdk-js/issues/1338).

This PR will fix the runtime error.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
