### PR TITLE
Adjust onpremise_proxy_port environment variable

### DIFF
--- a/packages/core/src/connectivity/scp-cf/connectivity-service.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/connectivity-service.spec.ts
@@ -10,7 +10,10 @@ import {
 import { mockServiceToken } from '../../../test/test-util/token-accessor-mocks';
 import { mockClientCredentialsGrantCall } from '../../../test/test-util/xsuaa-service-mocks';
 import { Destination } from './destination';
-import { addProxyConfiguration, proxyHostAndPort } from './connectivity-service';
+import {
+  addProxyConfiguration,
+  proxyHostAndPort
+} from './connectivity-service';
 import { Protocol } from '.';
 
 describe('connectivity-service', () => {
@@ -106,9 +109,9 @@ describe('connectivity-service', () => {
     });
 
     const expected = {
-        host: 'proxy.example.com',
-        port: 54321,
-        protocol: Protocol.HTTP
+      host: 'proxy.example.com',
+      port: 54321,
+      protocol: Protocol.HTTP
     };
 
     const hostAndPort = proxyHostAndPort();

--- a/packages/core/src/connectivity/scp-cf/connectivity-service.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/connectivity-service.spec.ts
@@ -10,7 +10,8 @@ import {
 import { mockServiceToken } from '../../../test/test-util/token-accessor-mocks';
 import { mockClientCredentialsGrantCall } from '../../../test/test-util/xsuaa-service-mocks';
 import { Destination } from './destination';
-import { addProxyConfiguration } from './connectivity-service';
+import { addProxyConfiguration, proxyHostAndPort } from './connectivity-service';
+import { Protocol } from '.';
 
 describe('connectivity-service', () => {
   afterEach(() => {
@@ -92,6 +93,27 @@ describe('connectivity-service', () => {
       );
       done();
     });
+  });
+
+  it('returns onpremise_proxy_http_port instead of onpremise_proxy_port if both are present', () => {
+    mockConnectivityServiceBinding.credentials.onpremise_proxy_http_port = 54321;
+    process.env.VCAP_SERVICES = JSON.stringify({
+      connectivity: [
+        {
+          ...mockConnectivityServiceBinding
+        }
+      ]
+    });
+
+    const expected = {
+        host: 'proxy.example.com',
+        port: 54321,
+        protocol: Protocol.HTTP
+    };
+
+    const hostAndPort = proxyHostAndPort();
+
+    expect(hostAndPort).toEqual(expected);
   });
 
   it('throws an error if the client credentials grant fails', done => {

--- a/packages/core/src/connectivity/scp-cf/connectivity-service.ts
+++ b/packages/core/src/connectivity/scp-cf/connectivity-service.ts
@@ -49,9 +49,16 @@ interface HostAndPort {
   protocol: Protocol.HTTP;
 }
 
-function proxyHostAndPort(): HostAndPort {
+export function proxyHostAndPort(): HostAndPort {
   const service = readConnectivityServiceBinding();
 
+  if(typeof service.credentials.onpremise_proxy_http_port !== 'undefined'){
+    return {
+      host: service.credentials.onpremise_proxy_host,
+      port: service.credentials.onpremise_proxy_http_port,
+      protocol: Protocol.HTTP
+    };
+  }
   return {
     host: service.credentials.onpremise_proxy_host,
     port: service.credentials.onpremise_proxy_port,

--- a/packages/core/src/connectivity/scp-cf/connectivity-service.ts
+++ b/packages/core/src/connectivity/scp-cf/connectivity-service.ts
@@ -52,7 +52,7 @@ interface HostAndPort {
 export function proxyHostAndPort(): HostAndPort {
   const service = readConnectivityServiceBinding();
 
-  if(typeof service.credentials.onpremise_proxy_http_port !== 'undefined'){
+  if (typeof service.credentials.onpremise_proxy_http_port !== 'undefined') {
     return {
       host: service.credentials.onpremise_proxy_host,
       port: service.credentials.onpremise_proxy_http_port,

--- a/packages/core/src/connectivity/scp-cf/connectivity-service.ts
+++ b/packages/core/src/connectivity/scp-cf/connectivity-service.ts
@@ -51,17 +51,11 @@ interface HostAndPort {
 
 export function proxyHostAndPort(): HostAndPort {
   const service = readConnectivityServiceBinding();
-
-  if (typeof service.credentials.onpremise_proxy_http_port !== 'undefined') {
-    return {
-      host: service.credentials.onpremise_proxy_host,
-      port: service.credentials.onpremise_proxy_http_port,
-      protocol: Protocol.HTTP
-    };
-  }
   return {
     host: service.credentials.onpremise_proxy_host,
-    port: service.credentials.onpremise_proxy_port,
+    port:
+      service.credentials.onpremise_proxy_http_port ||
+      service.credentials.onpremise_proxy_port,
     protocol: Protocol.HTTP
   };
 }


### PR DESCRIPTION
With this PR we are now able to use `onpremise_proxy_http_port` if present in the connectivity service binding, otherwise we still use the deprecated `onpremise_proxy_port`.