### PR TITLE
Test errors windows

### DIFF
--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -11,6 +11,7 @@ jest.mock('../../generator-common', () => {
 });
 
 const { readFile } = promises;
+const path = require('path');
 
 describe('generator', () => {
   afterAll(() => {
@@ -30,9 +31,9 @@ describe('generator', () => {
     });
 
     expect(await getInputFilePaths('/path/to/test/dir')).toEqual([
-      '/path/to/test/dir/sub-dir/sub-directory-service.txt',
-      '/path/to/test/dir/sub-dir/test-service.txt',
-      '/path/to/test/dir/test-service.txt'
+      path.resolve('/path/to/test/dir/sub-dir/sub-directory-service.txt'),
+      path.resolve('/path/to/test/dir/sub-dir/test-service.txt'),
+      path.resolve('/path/to/test/dir/test-service.txt')
     ]);
 
     mock.restore();
@@ -154,7 +155,7 @@ describe('generator', () => {
           })
         },
         existingConfig:
-          '{ "inputDir/spec.json": {"directoryName": "customName" } }'
+          JSON.stringify({ [path.normalize("inputDir/spec.json")]: {"directoryName": "customName" } })
       });
     });
 
@@ -171,16 +172,13 @@ describe('generator', () => {
 
       const actual = readFile('options.json', 'utf8');
       await expect(actual).resolves.toMatch(endsWithNewLine);
-      await expect(actual).resolves.toMatchInlineSnapshot(`
-              "{
-                \\"inputDir/spec.json\\": {
-                  \\"packageName\\": \\"spec\\",
-                  \\"directoryName\\": \\"spec\\",
-                  \\"serviceName\\": \\"spec\\"
-                }
-              }
-              "
-            `);
+       expect(JSON.parse(await actual)).toEqual({
+        [`${path.join('inputDir/spec.json')}`]: {
+          "packageName": "spec",
+          "directoryName": "spec",
+          "serviceName": "spec"
+        }
+      });
     });
 
     it('overwrites writes options per service', async () => {
@@ -192,16 +190,13 @@ describe('generator', () => {
 
       const actual = readFile('existingConfig', 'utf8');
       await expect(actual).resolves.toMatch(endsWithNewLine);
-      await expect(actual).resolves.toMatchInlineSnapshot(`
-              "{
-                \\"inputDir/spec.json\\": {
-                  \\"packageName\\": \\"customName\\",
-                  \\"directoryName\\": \\"customName\\",
-                  \\"serviceName\\": \\"customName\\"
-                }
-              }
-              "
-            `);
+      expect(JSON.parse(await actual)).toEqual({
+        [`${path.join('inputDir/spec.json')}`]: {
+          "packageName": "customName",
+          "directoryName": "customName",
+          "serviceName": "customName"
+        }
+      });
     });
   });
 

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'path';
 import { existsSync, promises } from 'fs';
+import path = require('path');
 import mock from 'mock-fs';
 import { readJSON } from '@sap-cloud-sdk/util';
 import { emptyDocument } from '../test/test-util';
@@ -11,7 +12,6 @@ jest.mock('../../generator-common', () => {
 });
 
 const { readFile } = promises;
-const path = require('path');
 
 describe('generator', () => {
   afterAll(() => {
@@ -154,8 +154,11 @@ describe('generator', () => {
             }
           })
         },
-        existingConfig:
-          JSON.stringify({ [path.normalize("inputDir/spec.json")]: {"directoryName": "customName" } })
+        existingConfig: JSON.stringify({
+          [path.normalize('inputDir/spec.json')]: {
+            directoryName: 'customName'
+          }
+        })
       });
     });
 
@@ -172,11 +175,11 @@ describe('generator', () => {
 
       const actual = readFile('options.json', 'utf8');
       await expect(actual).resolves.toMatch(endsWithNewLine);
-       expect(JSON.parse(await actual)).toEqual({
+      expect(JSON.parse(await actual)).toEqual({
         [`${path.join('inputDir/spec.json')}`]: {
-          "packageName": "spec",
-          "directoryName": "spec",
-          "serviceName": "spec"
+          packageName: 'spec',
+          directoryName: 'spec',
+          serviceName: 'spec'
         }
       });
     });
@@ -192,9 +195,9 @@ describe('generator', () => {
       await expect(actual).resolves.toMatch(endsWithNewLine);
       expect(JSON.parse(await actual)).toEqual({
         [`${path.join('inputDir/spec.json')}`]: {
-          "packageName": "customName",
-          "directoryName": "customName",
-          "serviceName": "customName"
+          packageName: 'customName',
+          directoryName: 'customName',
+          serviceName: 'customName'
         }
       });
     });

--- a/packages/openapi-generator/src/options/generator-options.spec.ts
+++ b/packages/openapi-generator/src/options/generator-options.spec.ts
@@ -1,3 +1,4 @@
+import path = require('path');
 import mock from 'mock-fs';
 import { createLogger } from '@sap-cloud-sdk/util';
 import { generateWithParsedOptions } from '../generator';
@@ -5,7 +6,6 @@ import {
   parseGeneratorOptions,
   parseOptionsFromConfig
 } from './generator-options';
-const path = require('path');
 
 describe('parseGeneratorOptions', () => {
   beforeEach(() => {
@@ -57,7 +57,10 @@ describe('parseGeneratorOptions', () => {
         optionsPerService: 'non-existent-directory/config.json'
       })
     ).toMatchObject({
-      optionsPerService: path.join(process.cwd(), 'non-existent-directory/config.json')
+      optionsPerService: path.join(
+        process.cwd(),
+        'non-existent-directory/config.json'
+      )
     });
   });
 
@@ -69,7 +72,10 @@ describe('parseGeneratorOptions', () => {
         optionsPerService: 'existent-directory/existent-file'
       })
     ).toMatchObject({
-      optionsPerService: path.join(process.cwd(), 'existent-directory/existent-file')
+      optionsPerService: path.join(
+        process.cwd(),
+        'existent-directory/existent-file'
+      )
     });
   });
 
@@ -81,7 +87,10 @@ describe('parseGeneratorOptions', () => {
         optionsPerService: 'non-existent-directory'
       })
     ).toMatchObject({
-      optionsPerService: path.join(process.cwd(), 'non-existent-directory/options-per-service.json')
+      optionsPerService: path.join(
+        process.cwd(),
+        'non-existent-directory/options-per-service.json'
+      )
     });
   });
 
@@ -93,7 +102,10 @@ describe('parseGeneratorOptions', () => {
         optionsPerService: 'existent-directory'
       })
     ).toMatchObject({
-      optionsPerService: path.join(process.cwd(), 'existent-directory/options-per-service.json')
+      optionsPerService: path.join(
+        process.cwd(),
+        'existent-directory/options-per-service.json'
+      )
     });
   });
 

--- a/packages/openapi-generator/src/options/generator-options.spec.ts
+++ b/packages/openapi-generator/src/options/generator-options.spec.ts
@@ -5,6 +5,7 @@ import {
   parseGeneratorOptions,
   parseOptionsFromConfig
 } from './generator-options';
+const path = require('path');
 
 describe('parseGeneratorOptions', () => {
   beforeEach(() => {
@@ -42,8 +43,8 @@ describe('parseGeneratorOptions', () => {
         outputDir: 'outputDir'
       })
     ).toEqual({
-      input: `${process.cwd()}/inputDir`,
-      outputDir: `${process.cwd()}/outputDir`,
+      input: path.join(process.cwd(), 'inputDir'),
+      outputDir: path.join(process.cwd(), 'outputDir'),
       ...options
     });
   });
@@ -56,7 +57,7 @@ describe('parseGeneratorOptions', () => {
         optionsPerService: 'non-existent-directory/config.json'
       })
     ).toMatchObject({
-      optionsPerService: `${process.cwd()}/non-existent-directory/config.json`
+      optionsPerService: path.join(process.cwd(), 'non-existent-directory/config.json')
     });
   });
 
@@ -68,7 +69,7 @@ describe('parseGeneratorOptions', () => {
         optionsPerService: 'existent-directory/existent-file'
       })
     ).toMatchObject({
-      optionsPerService: `${process.cwd()}/existent-directory/existent-file`
+      optionsPerService: path.join(process.cwd(), 'existent-directory/existent-file')
     });
   });
 
@@ -80,7 +81,7 @@ describe('parseGeneratorOptions', () => {
         optionsPerService: 'non-existent-directory'
       })
     ).toMatchObject({
-      optionsPerService: `${process.cwd()}/non-existent-directory/options-per-service.json`
+      optionsPerService: path.join(process.cwd(), 'non-existent-directory/options-per-service.json')
     });
   });
 
@@ -92,7 +93,7 @@ describe('parseGeneratorOptions', () => {
         optionsPerService: 'existent-directory'
       })
     ).toMatchObject({
-      optionsPerService: `${process.cwd()}/existent-directory/options-per-service.json`
+      optionsPerService: path.join(process.cwd(), 'existent-directory/options-per-service.json')
     });
   });
 
@@ -104,7 +105,7 @@ describe('parseGeneratorOptions', () => {
         tsConfig: 'someDir'
       })
     ).toMatchObject({
-      tsConfig: `${process.cwd()}/someDir`
+      tsConfig: path.join(process.cwd(), 'someDir')
     });
   });
 


### PR DESCRIPTION
Fixed unit test errors that fail when run on windows. Used path.js lib to resolve or normalize paths to handle file path delimiters. 

Closes SAP/cloud-sdk-backlog#270

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
