### PR TITLE
feat: odata code snippet generation

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -48,7 +48,8 @@
     "ts-morph": "^11.0.0",
     "typescript": "~4.3.4",
     "voca": "^1.4.0",
-    "yargs": "^17.0.1"
+    "yargs": "^17.0.1",
+    "fast-levenshtein": "^3.0.0"
   },
   "devDependencies": {
     "@sap/cloud-sdk-vdm-business-partner-service": "^1.24.0",

--- a/packages/generator/src/sdk-metadata/__snapshots__/generation-and-usage.spec.ts.snap
+++ b/packages/generator/src/sdk-metadata/__snapshots__/generation-and-usage.spec.ts.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`generation-and-usage create api specific usage for action import 1`] = `
+Object {
+  "header": "Usage Example",
+  "instructions": "import { dummyActionImport, dummyParamType } from '@sap/dummy-package/action-imports';
+
+const parameter: dummyParamType = { dummyParam1: 'dummyParam1' };
+    
+const resultPromise = dummyActionImport(parameter).execute({ destinationName:'myDestinationName' });",
+  "text": "To consume the service via the pregenerated typed client library run the code snippet below. For more details about OData client libraries chose \\"OData Consumption Manual\\" from the \\"Helpful Links\\" menu.",
+}
+`;
+
+exports[`generation-and-usage create api specific usage for function import 1`] = `
+Object {
+  "header": "Usage Example",
+  "instructions": "import { dummyFunc, dummyParamType } from '@sap/dummy-package/function-imports';
+
+const parameter: dummyParamType = { dummyParam1: 'dummyParam1', dummyParam2: 'dummyParam2', ... };
+    
+const resultPromise = dummyFunc(parameter).execute({ destinationName:'myDestinationName' });",
+  "text": "To consume the service via the pregenerated typed client library run the code snippet below. For more details about OData client libraries chose \\"OData Consumption Manual\\" from the \\"Helpful Links\\" menu.",
+}
+`;
+
+exports[`generation-and-usage create api specific usage for function import with minimum parameters 1`] = `
+Object {
+  "header": "Usage Example",
+  "instructions": "import { dummyFunc, dummyParamType } from '@sap/dummy-package/function-imports';
+
+const parameter: dummyParamType = { dummyParam1: 'dummyParam1' };
+    
+const resultPromise = dummyFunc(parameter).execute({ destinationName:'myDestinationName' });",
+  "text": "To consume the service via the pregenerated typed client library run the code snippet below. For more details about OData client libraries chose \\"OData Consumption Manual\\" from the \\"Helpful Links\\" menu.",
+}
+`;
+
 exports[`generation-and-usage creates api specific usage for entity 1`] = `
 Object {
   "header": "Usage Example",

--- a/packages/generator/src/sdk-metadata/__snapshots__/sdk-metadata.spec.ts.snap
+++ b/packages/generator/src/sdk-metadata/__snapshots__/sdk-metadata.spec.ts.snap
@@ -7,9 +7,9 @@ Object {
   "generationAndUsage": Object {
     "apiSpecificUsage": Object {
       "header": "Usage Example",
-      "instructions": "import { TestEntity } from '@sap/cloud-sdk-vdm-test-service';
+      "instructions": "import { CaseTest } from '@sap/cloud-sdk-vdm-test-service';
 
-const resultPromise = TestEntity.requestBuilder().getAll().top(5).execute({ destinationName:'myDestinationName' });
+const resultPromise = CaseTest.requestBuilder().getAll().top(5).execute({ destinationName:'myDestinationName' });
 ",
       "text": "To consume the service via the pregenerated typed client library run the code snippet below. For more details about OData client libraries chose \\"OData Consumption Manual\\" from the \\"Helpful Links\\" menu.",
     },
@@ -80,9 +80,9 @@ Object {
   "generationAndUsage": Object {
     "apiSpecificUsage": Object {
       "header": "Usage Example",
-      "instructions": "import { TestEntity } from '@sap/cloud-sdk-vdm-test-service';
+      "instructions": "import { CaseTest } from '@sap/cloud-sdk-vdm-test-service';
 
-const resultPromise = TestEntity.requestBuilder().getAll().top(5).execute({ destinationName:'myDestinationName' });
+const resultPromise = CaseTest.requestBuilder().getAll().top(5).execute({ destinationName:'myDestinationName' });
 ",
       "text": "To consume the service via the pregenerated typed client library run the code snippet below. For more details about OData client libraries chose \\"OData Consumption Manual\\" from the \\"Helpful Links\\" menu.",
     },

--- a/packages/generator/src/sdk-metadata/code-sample-util.spec.ts
+++ b/packages/generator/src/sdk-metadata/code-sample-util.spec.ts
@@ -2,8 +2,7 @@ import {
   VdmActionImport,
   VdmEntity,
   VdmFunctionImport,
-  VdmParameter,
-  VdmServiceMetadata
+  VdmParameter
 } from '../vdm-types';
 import {
   getActionFunctionImport,
@@ -16,25 +15,25 @@ import {
 
 describe('code-sample-utils entity', () => {
   it('gets entity based on levenshtein algorithm', () => {
-     const entities = [
-       { className: 'DummyCollection' },
-       { className: 'DummyClass' }
-      ] as VdmEntity[];
-
-    expect(getODataEntity('DummyClass', entities)).toEqual(
+    const entities = [
+      { className: 'DummyCollection' },
       { className: 'DummyClass' }
-    );
+    ] as VdmEntity[];
+
+    expect(getODataEntity('DummyClass', entities)).toEqual({
+      className: 'DummyClass'
+    });
   });
 
   it('gets entity with shortest name when closest match is not found', () => {
     const entities = [
       { className: 'TestEntity' },
       { className: 'TestCollection' }
-     ] as VdmEntity[];
-     
-    expect(getODataEntity('DummyClass', entities)).toEqual(
-      { className: 'TestEntity' }
-    );
+    ] as VdmEntity[];
+
+    expect(getODataEntity('DummyClass', entities)).toEqual({
+      className: 'TestEntity'
+    });
   });
 });
 describe('code-sample-utils imports', () => {
@@ -52,7 +51,13 @@ describe('code-sample-utils imports', () => {
   const functionImportsZeroParams = [
     { name: 'serviceFuncA', parameters: [{ parameterName: 'dummyParam' }] },
     { name: 'serviceFuncB', parameters: [] },
-    { name: 'serviceFuncC', parameters: [{ parameterName: 'dummyParam' }, { parameterName: 'dummyParam' }] },
+    {
+      name: 'serviceFuncC',
+      parameters: [
+        { parameterName: 'dummyParam' },
+        { parameterName: 'dummyParam' }
+      ]
+    }
   ] as VdmFunctionImport[];
 
   it('gets undefined when func import based on levenshtein algorithm is not found', () => {
@@ -62,9 +67,10 @@ describe('code-sample-utils imports', () => {
   });
 
   it('gets func import without parameters when no closest match found', () => {
-    expect(getFunctionWithoutParameters(functionImportsZeroParams)).toEqual(
-      { name: 'serviceFuncB', parameters: [] }
-    );
+    expect(getFunctionWithoutParameters(functionImportsZeroParams)).toEqual({
+      name: 'serviceFuncB',
+      parameters: []
+    });
   });
 
   const functionImportsMinParams = [
@@ -81,12 +87,10 @@ describe('code-sample-utils imports', () => {
     }
   ] as VdmFunctionImport[];
   it('gets func import with min parameters when methods without params not found ', () => {
-    expect(getFunctionWithMinParameters(functionImportsMinParams)).toEqual(
-      {
-        name: 'serviceFunctionA',
-        parameters: [{ parameterName: 'dummyParam1' }]
-      }
-    );
+    expect(getFunctionWithMinParameters(functionImportsMinParams)).toEqual({
+      name: 'serviceFunctionA',
+      parameters: [{ parameterName: 'dummyParam1' }]
+    });
   });
 
   const actionsImports = [
@@ -95,15 +99,17 @@ describe('code-sample-utils imports', () => {
   ] as VdmActionImport[];
 
   it('gets action import based on levenshtein algorithm', () => {
-    expect(getActionFunctionImport('DummyClass', actionsImports!)).toEqual(
-      { name: 'dummy_Class_Actn', parameters: [{ parameterName: 'param' }] }
-    );
+    expect(getActionFunctionImport('DummyClass', actionsImports!)).toEqual({
+      name: 'dummy_Class_Actn',
+      parameters: [{ parameterName: 'param' }]
+    });
   });
 
   it('gets action import without min parameters when no closest match found', () => {
-    expect(getActionFunctionImport('API_TestAction', actionsImports!)).toEqual(
-      { name: 'service_Actn', parameters: [] }
-    );
+    expect(getActionFunctionImport('API_TestAction', actionsImports!)).toEqual({
+      name: 'service_Actn',
+      parameters: []
+    });
   });
 });
 

--- a/packages/generator/src/sdk-metadata/code-sample-util.spec.ts
+++ b/packages/generator/src/sdk-metadata/code-sample-util.spec.ts
@@ -1,5 +1,6 @@
 import {
   VdmActionImport,
+  VdmEntity,
   VdmFunctionImport,
   VdmParameter,
   VdmServiceMetadata
@@ -15,30 +16,56 @@ import {
 
 describe('code-sample-utils entity', () => {
   it('gets entity based on levenshtein algorithm', () => {
-    const service = {
-      originalFileName: 'DummyClass',
-      entities: [{ className: 'DummyCollection' }, { className: 'DummyClass' }]
-    } as VdmServiceMetadata;
-    expect(getODataEntity(service.originalFileName, service.entities)).toEqual(
-      service.entities[1]
+     const entities = [
+       { className: 'DummyCollection' },
+       { className: 'DummyClass' }
+      ] as VdmEntity[];
+
+    expect(getODataEntity('DummyClass', entities)).toEqual(
+      { className: 'DummyClass' }
     );
   });
 
   it('gets entity with shortest name when closest match is not found', () => {
-    const service = {
-      originalFileName: 'DummyClass',
-      entities: [{ className: 'TestEntity' }, { className: 'TestCollection' }]
-    } as VdmServiceMetadata;
-    expect(getODataEntity(service.originalFileName, service.entities)).toEqual(
-      service.entities[0]
+    const entities = [
+      { className: 'TestEntity' },
+      { className: 'TestCollection' }
+     ] as VdmEntity[];
+     
+    expect(getODataEntity('DummyClass', entities)).toEqual(
+      { className: 'TestEntity' }
     );
   });
 });
 describe('code-sample-utils imports', () => {
+  it('gets function import based on levenshtein algorithm', () => {
+    const functionImports = [
+      { name: 'dummy_Class_Func' },
+      { name: 'some_Other_Function' }
+    ] as VdmFunctionImport[];
+
+    expect(getLevensteinClosestFunction('DummyClass', functionImports)).toEqual(
+      { name: 'dummy_Class_Func' }
+    );
+  });
+
   const functionImportsZeroParams = [
-    { name: 'serviceFunctionA', parameters: [] },
-    { name: 'serviceFunctionB', parameters: [{ parameterName: 'dummyParam' }] }
+    { name: 'serviceFuncA', parameters: [{ parameterName: 'dummyParam' }] },
+    { name: 'serviceFuncB', parameters: [] },
+    { name: 'serviceFuncC', parameters: [{ parameterName: 'dummyParam' }, { parameterName: 'dummyParam' }] },
   ] as VdmFunctionImport[];
+
+  it('gets undefined when func import based on levenshtein algorithm is not found', () => {
+    expect(
+      getLevensteinClosestFunction('DummyClass', functionImportsZeroParams)
+    ).toBeUndefined();
+  });
+
+  it('gets func import without parameters when no closest match found', () => {
+    expect(getFunctionWithoutParameters(functionImportsZeroParams)).toEqual(
+      { name: 'serviceFuncB', parameters: [] }
+    );
+  });
 
   const functionImportsMinParams = [
     {
@@ -53,42 +80,29 @@ describe('code-sample-utils imports', () => {
       ]
     }
   ] as VdmFunctionImport[];
-
-  it('gets function import based on levenshtein algorithm', () => {
-    const functionImports = [
-      { name: 'some_Other_Function' },
-      { name: 'dummy_Class_Func' }
-    ] as VdmFunctionImport[];
-    expect(getLevensteinClosestFunction('DummyClass', functionImports)).toEqual(
-      functionImports[1]
-    );
-  });
-
-  it('gets undefined when func import based on levenshtein algorithm is not found', () => {
-    expect(
-      getLevensteinClosestFunction('DummyClass', functionImportsZeroParams)
-    ).toBeUndefined();
-  });
-
-  it('gets func import without parameters when no closest match found', () => {
-    expect(getFunctionWithoutParameters(functionImportsZeroParams)).toEqual(
-      functionImportsZeroParams[0]
-    );
-  });
-
   it('gets func import with min parameters when methods without params not found ', () => {
     expect(getFunctionWithMinParameters(functionImportsMinParams)).toEqual(
-      functionImportsMinParams[0]
+      {
+        name: 'serviceFunctionA',
+        parameters: [{ parameterName: 'dummyParam1' }]
+      }
     );
   });
 
-  it('gets action import', () => {
-    const actionsImports = [
-      { name: 'service_Actn', parameters: [] },
-      { name: 'dummy_Class_Actn', parameters: [{ parameterName: 'param' }] }
-    ] as VdmActionImport[];
+  const actionsImports = [
+    { name: 'service_Actn', parameters: [] },
+    { name: 'dummy_Class_Actn', parameters: [{ parameterName: 'param' }] }
+  ] as VdmActionImport[];
+
+  it('gets action import based on levenshtein algorithm', () => {
     expect(getActionFunctionImport('DummyClass', actionsImports!)).toEqual(
-      actionsImports![1]
+      { name: 'dummy_Class_Actn', parameters: [{ parameterName: 'param' }] }
+    );
+  });
+
+  it('gets action import without min parameters when no closest match found', () => {
+    expect(getActionFunctionImport('API_TestAction', actionsImports!)).toEqual(
+      { name: 'service_Actn', parameters: [] }
     );
   });
 });

--- a/packages/generator/src/sdk-metadata/code-sample-util.spec.ts
+++ b/packages/generator/src/sdk-metadata/code-sample-util.spec.ts
@@ -1,0 +1,117 @@
+import {
+  VdmActionImport,
+  VdmFunctionImport,
+  VdmParameter,
+  VdmServiceMetadata
+} from '../vdm-types';
+import {
+  getActionFunctionImport,
+  getActionFunctionParams,
+  getFunctionWithMinParameters,
+  getFunctionWithoutParameters,
+  getLevensteinClosestFunction,
+  getODataEntity
+} from './code-sample-util';
+
+describe('code-sample-utils entity', () => {
+  it('gets entity based on levenshtein algorithm', () => {
+    const service = {
+      originalFileName: 'DummyClass',
+      entities: [{ className: 'DummyCollection' }, { className: 'DummyClass' }]
+    } as VdmServiceMetadata;
+    expect(getODataEntity(service.originalFileName, service.entities)).toEqual(
+      service.entities[1]
+    );
+  });
+
+  it('gets entity with shortest name when closest match is not found', () => {
+    const service = {
+      originalFileName: 'DummyClass',
+      entities: [{ className: 'TestEntity' }, { className: 'TestCollection' }]
+    } as VdmServiceMetadata;
+    expect(getODataEntity(service.originalFileName, service.entities)).toEqual(
+      service.entities[0]
+    );
+  });
+});
+describe('code-sample-utils imports', () => {
+  const functionImportsZeroParams = [
+    { name: 'serviceFunctionA', parameters: [] },
+    { name: 'serviceFunctionB', parameters: [{ parameterName: 'dummyParam' }] }
+  ] as VdmFunctionImport[];
+
+  const functionImportsMinParams = [
+    {
+      name: 'serviceFunctionA',
+      parameters: [{ parameterName: 'dummyParam1' }]
+    },
+    {
+      name: 'serviceFunctionB',
+      parameters: [
+        { parameterName: 'dummyParam2' },
+        { parameterName: 'dummyParam3' }
+      ]
+    }
+  ] as VdmFunctionImport[];
+
+  it('gets function import based on levenshtein algorithm', () => {
+    const functionImports = [
+      { name: 'some_Other_Function' },
+      { name: 'dummy_Class_Func' }
+    ] as VdmFunctionImport[];
+    expect(getLevensteinClosestFunction('DummyClass', functionImports)).toEqual(
+      functionImports[1]
+    );
+  });
+
+  it('gets undefined when func import based on levenshtein algorithm is not found', () => {
+    expect(
+      getLevensteinClosestFunction('DummyClass', functionImportsZeroParams)
+    ).toBeUndefined();
+  });
+
+  it('gets func import without parameters when no closest match found', () => {
+    expect(getFunctionWithoutParameters(functionImportsZeroParams)).toEqual(
+      functionImportsZeroParams[0]
+    );
+  });
+
+  it('gets func import with min parameters when methods without params not found ', () => {
+    expect(getFunctionWithMinParameters(functionImportsMinParams)).toEqual(
+      functionImportsMinParams[0]
+    );
+  });
+
+  it('gets action import', () => {
+    const actionsImports = [
+      { name: 'service_Actn', parameters: [] },
+      { name: 'dummy_Class_Actn', parameters: [{ parameterName: 'param' }] }
+    ] as VdmActionImport[];
+    expect(getActionFunctionImport('DummyClass', actionsImports!)).toEqual(
+      actionsImports![1]
+    );
+  });
+});
+
+describe('code-sample-utils parameters', () => {
+  it('gets the parameter string for 2 parameters', () => {
+    const parameters = [
+      { parameterName: 'dummyParam1' },
+      { parameterName: 'dummyParam2' }
+    ] as VdmParameter[];
+    expect(getActionFunctionParams(parameters)).toMatchInlineSnapshot(
+      "\"{ dummyParam1: 'dummyParam1', dummyParam2: 'dummyParam2' }\""
+    );
+  });
+
+  it('gets the parameter string for 3 or more parameters', () => {
+    const parameters = [
+      { parameterName: 'dummyParam1' },
+      { parameterName: 'dummyParam2' },
+      { parameterName: 'dummyParam3' }
+    ] as VdmParameter[];
+    expect(getActionFunctionParams(parameters)).toMatchInlineSnapshot(
+      "\"{ dummyParam1: 'dummyParam1', dummyParam2: 'dummyParam2', ... }\""
+    );
+  });
+});

--- a/packages/generator/src/sdk-metadata/code-sample-util.ts
+++ b/packages/generator/src/sdk-metadata/code-sample-util.ts
@@ -22,7 +22,7 @@ export function getODataEntity(
       serviceNameFormatted,
       getWordWithoutSpecialChars(entity.className)
     );
-    if (distance < minDistance) {
+    if (distance <= minDistance) {
       minDistance = distance;
       closestEntity = entity;
     }

--- a/packages/generator/src/sdk-metadata/code-sample-util.ts
+++ b/packages/generator/src/sdk-metadata/code-sample-util.ts
@@ -1,0 +1,135 @@
+import levenstein from 'fast-levenshtein';
+import {
+  VdmActionImport,
+  VdmEntity,
+  VdmFunctionImport,
+  VdmParameter
+} from '../vdm-types';
+
+const distanceThreshold = 5;
+
+export function getODataEntity(
+  serviceName: string,
+  vdmEntities: VdmEntity[]
+): VdmEntity {
+  let closestEntity: VdmEntity | undefined;
+  let minDistance = distanceThreshold;
+
+  // remove special char from service name
+  const serviceNameFormatted = getWordWithoutSpecialChars(serviceName);
+  vdmEntities.forEach(entity => {
+    const distance = getLevensteinDistance(
+      serviceNameFormatted,
+      getWordWithoutSpecialChars(entity.className)
+    );
+    if (distance < minDistance) {
+      minDistance = distance;
+      closestEntity = entity;
+    }
+  });
+
+  if (closestEntity) {
+    return closestEntity!;
+  }
+  // If no closest entity found, return the entity with shortest name
+  return vdmEntities.sort((a, b) =>
+    a.className.length < b.className.length ? -1 : 1
+  )[0];
+}
+
+export function getActionFunctionImport(
+  serviceName: string,
+  actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
+): VdmFunctionImport | VdmActionImport {
+  if (actionFunctionImports.length === 1) {
+    return actionFunctionImports[0];
+  }
+
+  return (
+    getLevensteinClosestFunction(serviceName, actionFunctionImports) ||
+    getFunctionWithoutParameters(actionFunctionImports) ||
+    getFunctionWithMinParameters(actionFunctionImports)
+  );
+}
+
+/**
+ * Gets function having minimum Levenstein distance with the service name. Returns undefined if distance is greater than threshhold.
+ * @param serviceName - Name of service
+ * @param actionFunctionImports - function or action imports array
+ * @returns Import with least levenshtein dist or undefined if no matching import found
+ * @hidden
+ */
+export function getLevensteinClosestFunction(
+  serviceName: string,
+  actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
+): VdmFunctionImport | VdmActionImport | undefined {
+  let closestFunc: VdmFunctionImport | VdmActionImport | undefined;
+  let minDistance = distanceThreshold;
+  actionFunctionImports.forEach(func => {
+    const distance = getLevensteinDistance(
+      getWordWithoutSpecialChars(serviceName),
+      getWordWithoutSpecialChars(func.name)
+    );
+    if (distance <= minDistance) {
+      minDistance = distance;
+      closestFunc = func;
+    }
+  });
+
+  return closestFunc;
+}
+
+export function getFunctionWithoutParameters(
+  actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
+): VdmFunctionImport | VdmActionImport | undefined {
+  return actionFunctionImports.find(func => func.parameters?.length === 0);
+}
+
+/**
+ * Sorts and gets a function import having minimum input parameters.
+ * @param actionFunctionImports - function or action imports array
+ * @returns Import containing minimum input paramters
+ * @hidden
+ */
+export function getFunctionWithMinParameters(
+  actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
+): VdmFunctionImport | VdmActionImport {
+  const getFunctions = actionFunctionImports.filter(
+    func => func.httpMethod?.toLowerCase() === 'get'
+  );
+  if (getFunctions.length > 0) {
+    actionFunctionImports = getFunctions;
+  }
+  const sortedfunctions = actionFunctionImports.sort((funcA, funcB) =>
+    funcA.parameters?.length < funcB.parameters?.length ? -1 : 1
+  );
+  return sortedfunctions[0];
+}
+
+export function getActionFunctionParams(parameters: VdmParameter[]): string {
+  const paramString = Object.entries(parameters || [])
+    .slice(0, 2)
+    .reduce(
+      (cumulator, currentParam) =>
+        `${cumulator}, ${currentParam[1].parameterName}: '${currentParam[1].parameterName}'`,
+      ''
+    );
+  return `{${paramString.substring(1)}${
+    parameters.length > 2 ? ', ...' : ''
+  } }`;
+}
+
+/**
+ * Calculate levenshtein distance of the two strings.
+ * @param stringA - The first string.
+ * @param stringB - The second string.
+ * @returns The levenshtein distance (0 and above).
+ * @hidden
+ */
+function getLevensteinDistance(stringA: string, stringB: string): number {
+  return levenstein.get(stringA.toLowerCase(), stringB.toLowerCase());
+}
+
+function getWordWithoutSpecialChars(text: string): string {
+  return text.replace('_', '');
+}

--- a/packages/generator/src/sdk-metadata/code-samples.ts
+++ b/packages/generator/src/sdk-metadata/code-samples.ts
@@ -4,7 +4,8 @@ import {
   InstructionWithTextAndHeader,
   usageHeaderText
 } from '@sap-cloud-sdk/generator-common';
-import { VdmActionImport, VdmFunctionImport, VdmParameter } from '../vdm-types';
+import { VdmActionImport, VdmFunctionImport } from '../vdm-types';
+import { getActionFunctionParams } from './code-sample-util';
 
 const instructionsText =
   'To consume the service via the pregenerated typed client library run the code snippet below. For more details about OData client libraries chose "OData Consumption Manual" from the "Helpful Links" menu.';
@@ -77,17 +78,4 @@ function getParameterCodeSample(functionImport: VdmFunctionImport): string {
     `;
   }
   return '';
-}
-
-function getActionFunctionParams(parameters: VdmParameter[]): string {
-  const paramString = Object.entries(parameters || [])
-    .slice(0, 2)
-    .reduce(
-      (cumulator, currentParam) =>
-        `${cumulator}, ${currentParam[1].parameterName}: '${currentParam[1].parameterName}'`,
-      ''
-    );
-  return `{${paramString.substring(1)}${
-    parameters.length > 2 ? ', ...' : ''
-  } }`;
 }

--- a/packages/generator/src/sdk-metadata/code-samples.ts
+++ b/packages/generator/src/sdk-metadata/code-samples.ts
@@ -4,6 +4,7 @@ import {
   InstructionWithTextAndHeader,
   usageHeaderText
 } from '@sap-cloud-sdk/generator-common';
+import { VdmActionImport, VdmFunctionImport, VdmParameter } from '../vdm-types';
 
 export function codeSamples(
   entityName: string,
@@ -28,4 +29,48 @@ export function genericCodeSample(): InstructionWithTextAndHeader {
     ),
     header: usageHeaderText
   };
+}
+
+export function importsCodeSample(
+  actionFunctionImport: VdmFunctionImport | VdmActionImport,
+  packageName: string
+): InstructionWithText {
+  return {
+    text: 'To consume the service via the pregenerated typed client library run the code snippet below. For more details about OData client libraries chose "OData Consumption Manual" from the "Helpful Links" menu.',
+    instructions: codeBlock`
+import { ${actionFunctionImport.name}${
+      actionFunctionImport.parametersTypeName
+        ? `, ${actionFunctionImport.parametersTypeName}`
+        : ''
+    } } from '${packageName}';
+
+${getParameterCodeSample(actionFunctionImport)}
+const resultPromise = ${actionFunctionImport.name}(${
+      actionFunctionImport.parametersTypeName ? 'parameter' : ''
+    }).execute({ destinationName:'myDestinationName' });
+`
+  };
+}
+
+function getParameterCodeSample(functionImport: VdmFunctionImport): string {
+  if (functionImport.parameters) {
+    return `const parameter: ${
+      functionImport.parametersTypeName
+    } = ${getActionFunctionParams(functionImport.parameters)};
+    `;
+  }
+  return '';
+}
+
+function getActionFunctionParams(parameters: VdmParameter[]): string {
+  const paramString = Object.entries(parameters || [])
+    .slice(0, 2)
+    .reduce(
+      (cumulator, currentParam) =>
+        `${cumulator}, ${currentParam[1].parameterName}: '${currentParam[1].parameterName}'`,
+      ''
+    );
+  return `{${paramString.substring(1)}${
+    parameters.length > 2 ? ', ...' : ''
+  } }`;
 }

--- a/packages/generator/src/sdk-metadata/code-samples.ts
+++ b/packages/generator/src/sdk-metadata/code-samples.ts
@@ -6,12 +6,15 @@ import {
 } from '@sap-cloud-sdk/generator-common';
 import { VdmActionImport, VdmFunctionImport, VdmParameter } from '../vdm-types';
 
-export function codeSamples(
+const instructionsText =
+  'To consume the service via the pregenerated typed client library run the code snippet below. For more details about OData client libraries chose "OData Consumption Manual" from the "Helpful Links" menu.';
+
+export function entityCodeSample(
   entityName: string,
   packageName: string
 ): InstructionWithText {
   return {
-    text: 'To consume the service via the pregenerated typed client library run the code snippet below. For more details about OData client libraries chose "OData Consumption Manual" from the "Helpful Links" menu.',
+    text: instructionsText,
     instructions: codeBlock`
 import { ${entityName} } from '${packageName}';
 
@@ -21,9 +24,9 @@ const resultPromise = ${entityName}.requestBuilder().getAll().top(5).execute({ d
   };
 }
 
-export function genericCodeSample(): InstructionWithTextAndHeader {
+export function genericEntityCodeSample(): InstructionWithTextAndHeader {
   return {
-    ...codeSamples(
+    ...entityCodeSample(
       'BusinessPartner',
       '@sap/cloud-sdk-vdm-business-partner-service'
     ),
@@ -31,12 +34,26 @@ export function genericCodeSample(): InstructionWithTextAndHeader {
   };
 }
 
-export function importsCodeSample(
+export function functionImportCodeSample(
+  functionImport: VdmFunctionImport,
+  packageName: string
+): InstructionWithText {
+  return importsCodeSample(functionImport, packageName);
+}
+
+export function actionImportCodeSample(
+  actionImport: VdmActionImport,
+  packageName: string
+): InstructionWithText {
+  return importsCodeSample(actionImport, packageName);
+}
+
+function importsCodeSample(
   actionFunctionImport: VdmFunctionImport | VdmActionImport,
   packageName: string
 ): InstructionWithText {
   return {
-    text: 'To consume the service via the pregenerated typed client library run the code snippet below. For more details about OData client libraries chose "OData Consumption Manual" from the "Helpful Links" menu.',
+    text: instructionsText,
     instructions: codeBlock`
 import { ${actionFunctionImport.name}${
       actionFunctionImport.parametersTypeName

--- a/packages/generator/src/sdk-metadata/generation-and-usage.spec.ts
+++ b/packages/generator/src/sdk-metadata/generation-and-usage.spec.ts
@@ -8,7 +8,58 @@ import { genericCodeSample } from './code-samples';
 describe('generation-and-usage', () => {
   const service = {
     npmPackageName: '@sap/dummy-package',
-    entities: [{ className: 'DummyClass' }]
+    originalFileName: 'DummyClass',
+    entities: [{ className: 'DummyCollection' }, { className: 'DummyClass' }]
+  } as VdmServiceMetadata;
+
+  const serviceWithFunctionImport = {
+    npmPackageName: '@sap/dummy-package',
+    originalFileName: 'Dummy',
+    functionImports: [
+      {
+        name: 'dummyFunc',
+        parametersTypeName: 'dummyParamType',
+        parameters: [
+          { parameterName: 'dummyParam1' },
+          { parameterName: 'dummyParam2' },
+          { parameterName: 'dummyParam3' }
+        ]
+      }
+    ]
+  } as VdmServiceMetadata;
+
+  const serviceWithMultipleImports = {
+    npmPackageName: '@sap/dummy-package',
+    originalFileName: 'Dummy',
+    functionImports: [
+      {
+        name: 'dummyFunc',
+        httpMethod: 'get',
+        parametersTypeName: 'dummyParamType',
+        parameters: [{ parameterName: 'dummyParam1' }]
+      },
+      {
+        name: 'dummyFunction',
+        httpMethod: 'get',
+        parameters: [
+          { parameterName: 'dummyParam2' },
+          { parameterName: 'dummyParam3' }
+        ]
+      }
+    ]
+  } as VdmServiceMetadata;
+
+  const serviceWithActionImport = {
+    npmPackageName: '@sap/dummy-package',
+    originalFileName: 'Dummy',
+    actionsImports: [
+      {
+        name: 'dummyActionImport',
+        httpMethod: 'get',
+        parametersTypeName: 'dummyParamType',
+        parameters: [{ parameterName: 'dummyParam1' }]
+      }
+    ]
   } as VdmServiceMetadata;
 
   it('creates generic usage example', () => {
@@ -17,6 +68,18 @@ describe('generation-and-usage', () => {
 
   it('creates api specific usage for entity', () => {
     expect(getApiSpecificUsage(service)).toMatchSnapshot();
+  });
+
+  it('create api specific usage for function import', () => {
+    expect(getApiSpecificUsage(serviceWithFunctionImport)).toMatchSnapshot();
+  });
+
+  it('create api specific usage for function import with minimum parameters', () => {
+    expect(getApiSpecificUsage(serviceWithMultipleImports)).toMatchSnapshot();
+  });
+
+  it('create api specific usage for action import', () => {
+    expect(getApiSpecificUsage(serviceWithActionImport)).toMatchSnapshot();
   });
 
   it('creates compiling generic usage', async () => {

--- a/packages/generator/src/sdk-metadata/generation-and-usage.spec.ts
+++ b/packages/generator/src/sdk-metadata/generation-and-usage.spec.ts
@@ -3,7 +3,7 @@ import { writeFile, readFile, removeSync } from 'fs-extra';
 import execa = require('execa');
 import { VdmServiceMetadata } from '../vdm-types';
 import { getApiSpecificUsage } from './generation-and-usage';
-import { genericCodeSample } from './code-samples';
+import { genericEntityCodeSample } from './code-samples';
 
 describe('generation-and-usage', () => {
   const service = {
@@ -63,7 +63,7 @@ describe('generation-and-usage', () => {
   } as VdmServiceMetadata;
 
   it('creates generic usage example', () => {
-    expect(genericCodeSample()).toMatchSnapshot();
+    expect(genericEntityCodeSample()).toMatchSnapshot();
   });
 
   it('creates api specific usage for entity', () => {
@@ -83,7 +83,7 @@ describe('generation-and-usage', () => {
   });
 
   it('creates compiling generic usage', async () => {
-    const codeSnippet = genericCodeSample().instructions;
+    const codeSnippet = genericEntityCodeSample().instructions;
     const tsFile = 'generic-get-all-code-sample.ts';
     const jsFile = tsFile.replace('.ts', '.js');
     await writeFile(resolve(__dirname, tsFile), codeSnippet);

--- a/packages/generator/src/sdk-metadata/generation-and-usage.ts
+++ b/packages/generator/src/sdk-metadata/generation-and-usage.ts
@@ -7,8 +7,21 @@ import {
   usageHeaderText
 } from '@sap-cloud-sdk/generator-common';
 import type { GenerationAndUsage } from '@sap-cloud-sdk/generator-common';
-import { VdmServiceMetadata } from '../vdm-types';
-import { codeSamples, genericCodeSample } from './code-samples';
+import levenstein from 'fast-levenshtein';
+import voca from 'voca';
+import {
+  VdmEntity,
+  VdmServiceMetadata,
+  VdmFunctionImport,
+  VdmActionImport
+} from '../vdm-types';
+import {
+  codeSamples,
+  importsCodeSample,
+  genericCodeSample
+} from './code-samples';
+
+const distanceThreshold = 5;
 
 export async function getGenerationAndUsage(
   service: VdmServiceMetadata
@@ -44,21 +57,37 @@ export async function getGenericGenerationAndUsage(): Promise<GenerationAndUsage
 export function getApiSpecificUsage(
   service: VdmServiceMetadata
 ): InstructionWithTextAndHeader {
-  if (service.entities.length > 0) {
-    const codeSample = codeSamples(
-      service.entities[0].className,
-      service.npmPackageName
-    );
+  if (service.entities?.length > 0) {
+    const entity = getODataEntity(service.originalFileName, service.entities);
     return {
-      ...codeSample,
+      ...codeSamples(entity.className, service.npmPackageName),
       header: usageHeaderText
     };
   }
-  // TODO handle cases if no entity is there in the follow up ticket.
-  if (service.functionImports.length > 0) {
+  // Return function/action import usage if no entity is found.
+  if (service.functionImports?.length > 0) {
+    const functionImport = getActionFunctionImport(
+      service.originalFileName,
+      service.functionImports
+    );
     return {
-      instructions: '',
-      text: '',
+      ...importsCodeSample(
+        functionImport,
+        `${service.npmPackageName}/function-imports`
+      ),
+      header: usageHeaderText
+    };
+  }
+  if (service.actionsImports) {
+    const actionImport = getActionFunctionImport(
+      service.originalFileName,
+      service.actionsImports
+    );
+    return {
+      ...importsCodeSample(
+        actionImport,
+        `${service.npmPackageName}/action-imports`
+      ),
       header: usageHeaderText
     };
   }
@@ -75,4 +104,107 @@ export function getODataLinks(): Links {
     linkGenerationDocumentation,
     'OData'
   );
+}
+
+function getODataEntity(
+  serviceName: string,
+  vdmEntities: VdmEntity[]
+): VdmEntity {
+  let closestEntity: VdmEntity | undefined;
+  let minDistance = distanceThreshold;
+
+  // remove special char from service name
+  const serviceNameFormatted = getWordWithoutSpecialChars(serviceName);
+  vdmEntities.forEach(entity => {
+    const distance = getLevensteinDistance(
+      serviceNameFormatted,
+      getWordWithoutSpecialChars(entity.className)
+    );
+    if (distance < minDistance) {
+      minDistance = distance;
+      closestEntity = entity;
+    }
+  });
+
+  if (closestEntity) {
+    return closestEntity!;
+  }
+  // If no closest entity found, return the entity with shortest name
+  return vdmEntities.sort((a, b) =>
+    a.className.length < b.className.length ? -1 : 1
+  )[0];
+}
+
+function getActionFunctionImport(
+  serviceName: string,
+  actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
+): VdmFunctionImport | VdmActionImport {
+  if (actionFunctionImports.length === 1) {
+    return actionFunctionImports[0];
+  }
+
+  return (
+    getLevensteinClosestFunction(serviceName, actionFunctionImports) ||
+    getFunctionWithoutParameters(actionFunctionImports) ||
+    getFunctionWithMinParameters(actionFunctionImports)
+  );
+}
+
+// Gets function having minimum Levenstein distance with the service name. Returns undefined if distance is greater than threshhold.
+function getLevensteinClosestFunction(
+  serviceName: string,
+  actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
+): VdmFunctionImport | VdmActionImport | undefined {
+  let closestFunc: VdmFunctionImport | VdmActionImport | undefined;
+  let minDistance = distanceThreshold;
+  actionFunctionImports.forEach(func => {
+    const distance = getLevensteinDistance(serviceName, func.name);
+    if (distance < minDistance) {
+      minDistance = distance;
+      closestFunc = func;
+    }
+  });
+
+  return closestFunc;
+}
+
+function getFunctionWithoutParameters(
+  actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
+): VdmFunctionImport | VdmActionImport | undefined {
+  const functionsWithoutParams = actionFunctionImports.filter(
+    func => func.parameters?.length === 0
+  );
+  if (functionsWithoutParams) {
+    return functionsWithoutParams[0];
+  }
+}
+
+// Sorts and gets a function import having minimum input parameters.
+function getFunctionWithMinParameters(
+  actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
+): VdmFunctionImport | VdmActionImport {
+  const getFunctions = actionFunctionImports.filter(
+    func => func.httpMethod.toLowerCase() === 'get'
+  );
+  if (getFunctions) {
+    actionFunctionImports = getFunctions;
+  }
+  const sortedfunctions = actionFunctionImports.sort((funcA, funcB) =>
+    funcA.parameters?.length < funcB.parameters?.length ? -1 : 1
+  );
+  return sortedfunctions[0];
+}
+
+/**
+ * Calculate levenshtein distance of the two strings.
+ * @param stringA - The first string.
+ * @param stringB - The second string.
+ * @returns The levenshtein distance (0 and above).
+ */
+function getLevensteinDistance(stringA: string, stringB: string): number {
+  return levenstein.get(stringA.toLowerCase(), stringB.toLowerCase());
+}
+
+function getWordWithoutSpecialChars(text: string): string {
+  return voca.words(text).join();
 }

--- a/packages/generator/src/sdk-metadata/generation-and-usage.ts
+++ b/packages/generator/src/sdk-metadata/generation-and-usage.ts
@@ -16,9 +16,10 @@ import {
   VdmActionImport
 } from '../vdm-types';
 import {
-  codeSamples,
-  importsCodeSample,
-  genericCodeSample
+  actionImportCodeSample,
+  entityCodeSample,
+  functionImportCodeSample,
+  genericEntityCodeSample
 } from './code-samples';
 
 const distanceThreshold = 5;
@@ -38,7 +39,7 @@ export const linkGenerationDocumentation =
 // will be used to generate metadata for failed and unknown case.
 export async function getGenericGenerationAndUsage(): Promise<GenerationAndUsage> {
   return {
-    genericUsage: genericCodeSample(),
+    genericUsage: genericEntityCodeSample(),
     repository: 'npm',
     apiSpecificUsage: undefined,
     links: getODataLinks(),
@@ -60,7 +61,7 @@ export function getApiSpecificUsage(
   if (service.entities?.length > 0) {
     const entity = getODataEntity(service.originalFileName, service.entities);
     return {
-      ...codeSamples(entity.className, service.npmPackageName),
+      ...entityCodeSample(entity.className, service.npmPackageName),
       header: usageHeaderText
     };
   }
@@ -71,7 +72,7 @@ export function getApiSpecificUsage(
       service.functionImports
     );
     return {
-      ...importsCodeSample(
+      ...functionImportCodeSample(
         functionImport,
         `${service.npmPackageName}/function-imports`
       ),
@@ -84,7 +85,7 @@ export function getApiSpecificUsage(
       service.actionsImports
     );
     return {
-      ...importsCodeSample(
+      ...actionImportCodeSample(
         actionImport,
         `${service.npmPackageName}/action-imports`
       ),
@@ -171,12 +172,7 @@ function getLevensteinClosestFunction(
 function getFunctionWithoutParameters(
   actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
 ): VdmFunctionImport | VdmActionImport | undefined {
-  const functionsWithoutParams = actionFunctionImports.filter(
-    func => func.parameters?.length === 0
-  );
-  if (functionsWithoutParams) {
-    return functionsWithoutParams[0];
-  }
+  return actionFunctionImports.find(func => func.parameters?.length === 0);
 }
 
 // Sorts and gets a function import having minimum input parameters.

--- a/packages/generator/src/sdk-metadata/generation-and-usage.ts
+++ b/packages/generator/src/sdk-metadata/generation-and-usage.ts
@@ -7,22 +7,14 @@ import {
   usageHeaderText
 } from '@sap-cloud-sdk/generator-common';
 import type { GenerationAndUsage } from '@sap-cloud-sdk/generator-common';
-import levenstein from 'fast-levenshtein';
-import voca from 'voca';
-import {
-  VdmEntity,
-  VdmServiceMetadata,
-  VdmFunctionImport,
-  VdmActionImport
-} from '../vdm-types';
+import { VdmServiceMetadata } from '../vdm-types';
 import {
   actionImportCodeSample,
   entityCodeSample,
   functionImportCodeSample,
   genericEntityCodeSample
 } from './code-samples';
-
-const distanceThreshold = 5;
+import { getActionFunctionImport, getODataEntity } from './code-sample-util';
 
 export async function getGenerationAndUsage(
   service: VdmServiceMetadata
@@ -105,102 +97,4 @@ export function getODataLinks(): Links {
     linkGenerationDocumentation,
     'OData'
   );
-}
-
-function getODataEntity(
-  serviceName: string,
-  vdmEntities: VdmEntity[]
-): VdmEntity {
-  let closestEntity: VdmEntity | undefined;
-  let minDistance = distanceThreshold;
-
-  // remove special char from service name
-  const serviceNameFormatted = getWordWithoutSpecialChars(serviceName);
-  vdmEntities.forEach(entity => {
-    const distance = getLevensteinDistance(
-      serviceNameFormatted,
-      getWordWithoutSpecialChars(entity.className)
-    );
-    if (distance < minDistance) {
-      minDistance = distance;
-      closestEntity = entity;
-    }
-  });
-
-  if (closestEntity) {
-    return closestEntity!;
-  }
-  // If no closest entity found, return the entity with shortest name
-  return vdmEntities.sort((a, b) =>
-    a.className.length < b.className.length ? -1 : 1
-  )[0];
-}
-
-function getActionFunctionImport(
-  serviceName: string,
-  actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
-): VdmFunctionImport | VdmActionImport {
-  if (actionFunctionImports.length === 1) {
-    return actionFunctionImports[0];
-  }
-
-  return (
-    getLevensteinClosestFunction(serviceName, actionFunctionImports) ||
-    getFunctionWithoutParameters(actionFunctionImports) ||
-    getFunctionWithMinParameters(actionFunctionImports)
-  );
-}
-
-// Gets function having minimum Levenstein distance with the service name. Returns undefined if distance is greater than threshhold.
-function getLevensteinClosestFunction(
-  serviceName: string,
-  actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
-): VdmFunctionImport | VdmActionImport | undefined {
-  let closestFunc: VdmFunctionImport | VdmActionImport | undefined;
-  let minDistance = distanceThreshold;
-  actionFunctionImports.forEach(func => {
-    const distance = getLevensteinDistance(serviceName, func.name);
-    if (distance < minDistance) {
-      minDistance = distance;
-      closestFunc = func;
-    }
-  });
-
-  return closestFunc;
-}
-
-function getFunctionWithoutParameters(
-  actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
-): VdmFunctionImport | VdmActionImport | undefined {
-  return actionFunctionImports.find(func => func.parameters?.length === 0);
-}
-
-// Sorts and gets a function import having minimum input parameters.
-function getFunctionWithMinParameters(
-  actionFunctionImports: VdmFunctionImport[] | VdmActionImport[]
-): VdmFunctionImport | VdmActionImport {
-  const getFunctions = actionFunctionImports.filter(
-    func => func.httpMethod.toLowerCase() === 'get'
-  );
-  if (getFunctions) {
-    actionFunctionImports = getFunctions;
-  }
-  const sortedfunctions = actionFunctionImports.sort((funcA, funcB) =>
-    funcA.parameters?.length < funcB.parameters?.length ? -1 : 1
-  );
-  return sortedfunctions[0];
-}
-
-/**
- * Calculate levenshtein distance of the two strings.
- * @param stringA - The first string.
- * @param stringB - The second string.
- * @returns The levenshtein distance (0 and above).
- */
-function getLevensteinDistance(stringA: string, stringB: string): number {
-  return levenstein.get(stringA.toLowerCase(), stringB.toLowerCase());
-}
-
-function getWordWithoutSpecialChars(text: string): string {
-  return voca.words(text).join();
 }

--- a/test-packages/e2e-tests/test/metadata.spec.ts
+++ b/test-packages/e2e-tests/test/metadata.spec.ts
@@ -14,6 +14,7 @@ import { OpenApiDocument } from '@sap-cloud-sdk/openapi-generator/dist/openapi-t
 
 const service = {
   npmPackageName: '@sap/dummy-package',
+  originalFileName: 'DummyClass',
   entities: [{ className: 'DummyClass' }]
 } as VdmServiceMetadata;
 


### PR DESCRIPTION
Closes SAP/cloud-sdk-backlog#70

Updated `getApiSpecificUsage` method to generate usage code snippet for entity/function/action based on the closest match found using the levenshtein algo against a threshold.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
