### PR TITLE
fix: missing export for http-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- [core] Fix the missing export for files under `http-agent` directory.
 
 
 # 1.48.1

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@
 export * from './connectivity';
 export * from './header-util';
 export * from './http-client';
+export * from './http-agent';
 export * from './odata-common';
 export * from './odata-v2';
 // The explicit exports are needed to guarantee backwards compatibility, they override the named exports of the other odata modules.

--- a/test-packages/type-tests/test/http-agent.spec.ts
+++ b/test-packages/type-tests/test/http-agent.spec.ts
@@ -1,0 +1,4 @@
+import { getAgentConfig } from '@sap-cloud-sdk/core';
+
+// $ExpectType HttpAgentConfig | HttpsAgentConfig
+getAgentConfig({ name: 'destination', url: 'url' });


### PR DESCRIPTION
related to: https://github.com/SAP/cloud-sdk-js/issues/1568

- [x] fix the missing export