### PR TITLE
feat: open-api code snippet changes

### DIFF
--- a/packages/generator-common/package.json
+++ b/packages/generator-common/package.json
@@ -35,7 +35,8 @@
     "axios": "^0.21.1",
     "fs-extra": "^10.0.0",
     "glob": "^7.1.6",
-    "typescript": "~4.3.4"
+    "typescript": "~4.3.4",
+    "fast-levenshtein": "~3.0.0"
   },
   "devDependencies": {
     "jest-extended": "^0.11.5",

--- a/packages/generator-common/src/sdk-metadata/sdk-metadata.ts
+++ b/packages/generator-common/src/sdk-metadata/sdk-metadata.ts
@@ -1,4 +1,5 @@
 import { removeFileExtension } from '@sap-cloud-sdk/util';
+import levenstein from 'fast-levenshtein';
 import { getSdkVersion } from './util';
 import {
   Client,
@@ -8,6 +9,7 @@ import {
   ServiceStatus
 } from './sdk-metadata-types';
 
+const distanceThreshold = 5;
 export function getSdkMetadataFileNames(originalFileName: string): {
   clientFileName: string;
   headerFileName: string;
@@ -51,6 +53,30 @@ export function getSdkMetadataClient(
     pregeneratedLibrary,
     generationAndUsage
   };
+}
+
+export function getLevenshteinClosest<T>(name: string, objectsToCheck: T[], extractorFn: (x: T) => string): T|undefined {
+  const distBelowThreshold = objectsToCheck.reduce((prev, obj) => {
+    const levenshteinDist = getLevenshteinDistance(name, extractorFn(obj));
+    if(levenshteinDist < distanceThreshold) {
+     return [ ...prev, { dist: levenshteinDist, obj } ];
+    }
+    return prev;
+  },[]);
+  if(distBelowThreshold.length > 0) {
+    return distBelowThreshold.sort((a,b) => a.dist < b.dist ? -1 : 1)[0].obj;
+  }
+}
+
+ function getLevenshteinDistance(stringA: string, stringB: string): number {
+  return levenstein.get(
+    getSanitizedString(stringA),
+    getSanitizedString(stringB)
+  );
+}
+
+function getSanitizedString(text: string): string {
+  return text.replace(/[^A-Za-z]/g, '').toLowerCase(); // new RegExp('[^A-Za-z]/g')
 }
 
 export const sdkMetadataHeaderIntroText =

--- a/packages/generator-common/src/sdk-metadata/sdk-metadata.ts
+++ b/packages/generator-common/src/sdk-metadata/sdk-metadata.ts
@@ -54,7 +54,13 @@ export function getSdkMetadataClient(
     generationAndUsage
   };
 }
-
+/**
+ * Gets the closest matching object using Levenshtein distance algorithm.
+ * @param name - Name of the service or api class.
+ * @param objectsToCheck - List of objects, e.g. VdmEntity, FunctionImports, etc.
+ * @param extractorFn - Function to get the object's property to match against name.
+ * @returns - closest matched object or undefined if not found.
+ */
 export function getLevenshteinClosest<T>(
   name: string,
   objectsToCheck: T[],
@@ -80,7 +86,7 @@ function getLevenshteinDistance(stringA: string, stringB: string): number {
 }
 
 function getSanitizedString(text: string): string {
-  return text.replace(/[^A-Za-z]/g, '').toLowerCase(); // new RegExp('[^A-Za-z]/g')
+  return text.replace(/[^A-Za-z]/g, '').toLowerCase();
 }
 
 export const sdkMetadataHeaderIntroText =

--- a/packages/generator-common/src/sdk-metadata/sdk-metadata.ts
+++ b/packages/generator-common/src/sdk-metadata/sdk-metadata.ts
@@ -55,20 +55,24 @@ export function getSdkMetadataClient(
   };
 }
 
-export function getLevenshteinClosest<T>(name: string, objectsToCheck: T[], extractorFn: (x: T) => string): T|undefined {
+export function getLevenshteinClosest<T>(
+  name: string,
+  objectsToCheck: T[],
+  extractorFn: (x: T) => string
+): T | undefined {
   const distBelowThreshold = objectsToCheck.reduce((prev, obj) => {
     const levenshteinDist = getLevenshteinDistance(name, extractorFn(obj));
-    if(levenshteinDist < distanceThreshold) {
-     return [ ...prev, { dist: levenshteinDist, obj } ];
+    if (levenshteinDist < distanceThreshold) {
+      return [...prev, { dist: levenshteinDist, obj }];
     }
     return prev;
-  },[]);
-  if(distBelowThreshold.length > 0) {
-    return distBelowThreshold.sort((a,b) => a.dist < b.dist ? -1 : 1)[0].obj;
+  }, []);
+  if (distBelowThreshold.length > 0) {
+    return distBelowThreshold.sort((a, b) => (a.dist < b.dist ? -1 : 1))[0].obj;
   }
 }
 
- function getLevenshteinDistance(stringA: string, stringB: string): number {
+function getLevenshteinDistance(stringA: string, stringB: string): number {
   return levenstein.get(
     getSanitizedString(stringA),
     getSanitizedString(stringB)

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -48,8 +48,7 @@
     "ts-morph": "^12.0.0",
     "typescript": "~4.3.4",
     "voca": "^1.4.0",
-    "yargs": "^17.0.1",
-    "fast-levenshtein": "^3.0.0"
+    "yargs": "^17.0.1"
   },
   "devDependencies": {
     "@sap/cloud-sdk-vdm-business-partner-service": "^1.24.0",

--- a/packages/generator/src/sdk-metadata/code-sample-util.spec.ts
+++ b/packages/generator/src/sdk-metadata/code-sample-util.spec.ts
@@ -1,3 +1,4 @@
+import { getLevenshteinClosest } from '@sap-cloud-sdk/generator-common';
 import {
   VdmActionImport,
   VdmEntity,
@@ -9,7 +10,6 @@ import {
   getActionFunctionParams,
   getFunctionWithMinParameters,
   getFunctionWithoutParameters,
-  getLevensteinClosestFunction,
   getODataEntity
 } from './code-sample-util';
 
@@ -37,13 +37,14 @@ describe('code-sample-utils entity', () => {
   });
 });
 describe('code-sample-utils imports', () => {
+  const extractorFn = (x: VdmFunctionImport) => x.name;
   it('gets function import based on levenshtein algorithm', () => {
     const functionImports = [
       { name: 'dummy_Class_Func' },
       { name: 'some_Other_Function' }
     ] as VdmFunctionImport[];
 
-    expect(getLevensteinClosestFunction('DummyClass', functionImports)).toEqual(
+    expect(getLevenshteinClosest('DummyClass', functionImports, extractorFn)).toEqual(
       { name: 'dummy_Class_Func' }
     );
   });
@@ -62,7 +63,7 @@ describe('code-sample-utils imports', () => {
 
   it('gets undefined when func import based on levenshtein algorithm is not found', () => {
     expect(
-      getLevensteinClosestFunction('DummyClass', functionImportsZeroParams)
+      getLevenshteinClosest('DummyClass', functionImportsZeroParams, extractorFn)
     ).toBeUndefined();
   });
 

--- a/packages/generator/src/sdk-metadata/code-sample-util.spec.ts
+++ b/packages/generator/src/sdk-metadata/code-sample-util.spec.ts
@@ -44,9 +44,9 @@ describe('code-sample-utils imports', () => {
       { name: 'some_Other_Function' }
     ] as VdmFunctionImport[];
 
-    expect(getLevenshteinClosest('DummyClass', functionImports, extractorFn)).toEqual(
-      { name: 'dummy_Class_Func' }
-    );
+    expect(
+      getLevenshteinClosest('DummyClass', functionImports, extractorFn)
+    ).toEqual({ name: 'dummy_Class_Func' });
   });
 
   const functionImportsZeroParams = [
@@ -63,7 +63,11 @@ describe('code-sample-utils imports', () => {
 
   it('gets undefined when func import based on levenshtein algorithm is not found', () => {
     expect(
-      getLevenshteinClosest('DummyClass', functionImportsZeroParams, extractorFn)
+      getLevenshteinClosest(
+        'DummyClass',
+        functionImportsZeroParams,
+        extractorFn
+      )
     ).toBeUndefined();
   });
 

--- a/packages/generator/src/sdk-metadata/code-sample-util.ts
+++ b/packages/generator/src/sdk-metadata/code-sample-util.ts
@@ -107,11 +107,11 @@ export function getFunctionWithMinParameters(
 }
 
 export function getActionFunctionParams(parameters: VdmParameter[]): string {
-  const paramString = Object.entries(parameters || [])
+  const paramString = parameters
     .slice(0, 2)
     .reduce(
       (cumulator, currentParam) =>
-        `${cumulator}, ${currentParam[1].parameterName}: '${currentParam[1].parameterName}'`,
+        `${cumulator}, ${currentParam.parameterName}: '${currentParam.parameterName}'`,
       ''
     );
   return `{${paramString.substring(1)}${

--- a/packages/generator/src/sdk-metadata/code-sample-util.ts
+++ b/packages/generator/src/sdk-metadata/code-sample-util.ts
@@ -10,15 +10,17 @@ export function getODataEntity(
   serviceName: string,
   vdmEntities: VdmEntity[]
 ): VdmEntity {
-  return getLevenshteinClosest(serviceName, vdmEntities, (x) => x.className) ||
-  getShortestNameEntity(vdmEntities);
+  return (
+    getLevenshteinClosest(serviceName, vdmEntities, x => x.className) ||
+    getShortestNameEntity(vdmEntities)
+  );
 }
 
 export function getShortestNameEntity(vdmEntities: VdmEntity[]): VdmEntity {
-   // If no closest entity found, return the entity with shortest name
-   return vdmEntities.sort((a, b) =>
-   a.className.length < b.className.length ? -1 : 1
- )[0];
+  // If no closest entity found, return the entity with shortest name
+  return vdmEntities.sort((a, b) =>
+    a.className.length < b.className.length ? -1 : 1
+  )[0];
 }
 
 export function getActionFunctionImport(
@@ -30,7 +32,7 @@ export function getActionFunctionImport(
   }
 
   return (
-    getLevenshteinClosest(serviceName, actionFunctionImports, (x) => x.name) ||
+    getLevenshteinClosest(serviceName, actionFunctionImports, x => x.name) ||
     getFunctionWithoutParameters(actionFunctionImports) ||
     getFunctionWithMinParameters(actionFunctionImports)
   );

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -49,8 +49,7 @@
     "glob": "^7.1.6",
     "js-yaml": "^4.0.0",
     "openapi-types": "^8.0.0",
-    "swagger2openapi": "^7.0.4",
-    "fast-levenshtein": "^3.0.0"
+    "swagger2openapi": "^7.0.4"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -49,7 +49,8 @@
     "glob": "^7.1.6",
     "js-yaml": "^4.0.0",
     "openapi-types": "^8.0.0",
-    "swagger2openapi": "^7.0.4"
+    "swagger2openapi": "^7.0.4",
+    "fast-levenshtein": "^3.0.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",

--- a/packages/openapi-generator/src/sdk-metadata/__snapshots__/generation-and-usage.spec.ts.snap
+++ b/packages/openapi-generator/src/sdk-metadata/__snapshots__/generation-and-usage.spec.ts.snap
@@ -6,7 +6,7 @@ Object {
     "header": "Usage Example",
     "instructions": "import { DummyApi } from '@sap/dummy-package';
 
-const responseData = await DummyApi.DummyFunction().execute({ destinationName:'myDestinationName' });",
+const responseData = await DummyApi.DummyFunction(dummyId, undefined, { query_1: 'myQuery1' }).execute({ destinationName:'myDestinationName' });",
     "text": "To consume the service via the pregenerated typed client library run the code snippet below. For more details about OpenAPI client libraries chose \\"OpenAPI Consumption Manual\\" from the \\"Helpful Links\\" menu.",
   },
   "generationSteps": Object {

--- a/packages/openapi-generator/src/sdk-metadata/__snapshots__/sdk-metadata.spec.ts.snap
+++ b/packages/openapi-generator/src/sdk-metadata/__snapshots__/sdk-metadata.spec.ts.snap
@@ -7,7 +7,7 @@ Object {
       "header": "Usage Example",
       "instructions": "import { DummyApi } from '@sap/dummy-package';
 
-const responseData = await DummyApi.DummyFunction().execute({ destinationName:'myDestinationName' });",
+const responseData = await DummyApi.DummyFunction(dummyId, undefined, { query_1: 'myQuery1' }).execute({ destinationName:'myDestinationName' });",
       "text": "To consume the service via the pregenerated typed client library run the code snippet below. For more details about OpenAPI client libraries chose \\"OpenAPI Consumption Manual\\" from the \\"Helpful Links\\" menu.",
     },
     "generationSteps": Object {
@@ -78,7 +78,7 @@ Object {
       "header": "Usage Example",
       "instructions": "import { DummyApi } from '@sap/dummy-package';
 
-const responseData = await DummyApi.DummyFunction().execute({ destinationName:'myDestinationName' });",
+const responseData = await DummyApi.DummyFunction(dummyId, undefined, { query_1: 'myQuery1' }).execute({ destinationName:'myDestinationName' });",
       "text": "To consume the service via the pregenerated typed client library run the code snippet below. For more details about OpenAPI client libraries chose \\"OpenAPI Consumption Manual\\" from the \\"Helpful Links\\" menu.",
     },
     "generationSteps": Object {

--- a/packages/openapi-generator/src/sdk-metadata/code-sample-util.spec.ts
+++ b/packages/openapi-generator/src/sdk-metadata/code-sample-util.spec.ts
@@ -62,8 +62,9 @@ describe('code-sample-util api', () => {
   it('gets main api based on levenshtein algo', () => {
     expect(getMainApi('dummy', [api_1, api_2])).toEqual(
       expect.objectContaining({
-      name: 'DummyApi'
-    }));
+        name: 'DummyApi'
+      })
+    );
   });
 
   it('gets main api with getAll operation', () => {

--- a/packages/openapi-generator/src/sdk-metadata/code-sample-util.spec.ts
+++ b/packages/openapi-generator/src/sdk-metadata/code-sample-util.spec.ts
@@ -1,3 +1,4 @@
+import { getLevenshteinClosest } from '@sap-cloud-sdk/generator-common';
 import {
   OpenApiApi,
   OpenApiOperation,
@@ -6,8 +7,8 @@ import {
 import {
   getGetAllOperation,
   getGetOperation,
-  getLevensteinClosestOperation,
   getMainApi,
+  getMainOperation,
   getOperationParamCode
 } from './code-sample-util';
 
@@ -19,45 +20,50 @@ describe('code-sample-util api', () => {
   const queryParam2 = { name: 'query-Param2', required: false };
   const queryParam3 = { name: 'query-Param3', required: true };
 
-  const api_1 = {
+  const api_1: OpenApiApi = {
     name: 'DummyApi',
     operations: [
       {
         operationId: 'DummyFunction',
         method: 'get',
-        pathParameters: [] as OpenApiParameter[],
-        queryParameters: [] as OpenApiParameter[]
+        tags: [],
+        pathParameters: [],
+        queryParameters: [],
+        response: { type: 'any' },
+        pathPattern: ''
       }
     ]
-  } as OpenApiApi;
+  };
 
-  const api_2 = {
+  const api_2: OpenApiApi = {
     name: 'TestApi',
     operations: [
       {
         operationId: 'getAll',
-        pathParameters: [] as OpenApiParameter[],
-        queryParameters: [] as OpenApiParameter[]
+        method: 'get',
+        tags: [],
+        pathParameters: [],
+        queryParameters: [],
+        response: { type: 'any' },
+        pathPattern: ''
       },
       {
-        operationId: 'TestFunc',
-        pathParameters: [] as OpenApiParameter[],
-        queryParameters: [] as OpenApiParameter[]
+        operationId: 'Test',
+        method: 'get',
+        tags: [],
+        pathParameters: [],
+        queryParameters: [],
+        response: { type: 'any' },
+        pathPattern: ''
       }
     ]
-  } as OpenApiApi;
+  };
+
   it('gets main api based on levenshtein algo', () => {
-    expect(getMainApi('dummy', [api_1, api_2])).toEqual({
-      name: 'DummyApi',
-      operations: [
-        {
-          operationId: 'DummyFunction',
-          method: 'get',
-          pathParameters: [],
-          queryParameters: []
-        }
-      ]
-    });
+    expect(getMainApi('dummy', [api_1, api_2])).toEqual(
+      expect.objectContaining({
+      name: 'DummyApi'
+    }));
   });
 
   it('gets main api with getAll operation', () => {
@@ -66,30 +72,38 @@ describe('code-sample-util api', () => {
         operations: [
           {
             operationId: 'getAll',
-            pathParameters: [] as OpenApiParameter[],
-            queryParameters: [] as OpenApiParameter[]
+            method: 'get',
+            tags: [],
+            pathParameters: [],
+            queryParameters: [],
+            response: { type: 'any' },
+            pathPattern: ''
           },
           {
-            operationId: 'TestFunc',
-            pathParameters: [] as OpenApiParameter[],
-            queryParameters: [] as OpenApiParameter[]
+            operationId: 'Test',
+            method: 'get',
+            tags: [],
+            pathParameters: [],
+            queryParameters: [],
+            response: { type: 'any' },
+            pathPattern: ''
           }
         ]
       })
     );
   });
-
   it('gets main operationId based on levenshtein algo', () => {
-    expect(getLevensteinClosestOperation(api_2.name, api_2.operations)).toEqual(
+    expect(getMainOperation(api_2)).toEqual(
       expect.objectContaining({
-        operationId: 'TestFunc'
+        operationId: 'Test'
       })
     );
   });
 
   it('gets undefined main operationId if no closest match found using levenshtein algo', () => {
+    const extractorFn = (x: OpenApiOperation) => x.operationId;
     expect(
-      getLevensteinClosestOperation('ResourceApi', api_2.operations)
+      getLevenshteinClosest('ResourceApi', api_2.operations, extractorFn)
     ).toBeUndefined();
   });
 
@@ -116,14 +130,17 @@ describe('code-sample-util api', () => {
 
   it('returns empty params string if there are no parameters', () => {
     const operation = {
-      operationId: 'getAll'
+      operationId: 'getAll',
+      pathParameters: [] as OpenApiParameter[],
+      queryParameters: [] as OpenApiParameter[]
     } as OpenApiOperation;
     expect(getOperationParamCode(operation)).toEqual('');
   });
 
   it('generates param string with path params', () => {
     const operation = {
-      pathParameters: [pathParam1, pathParam2]
+      pathParameters: [pathParam1, pathParam2],
+      queryParameters: [] as OpenApiParameter[]
     } as OpenApiOperation;
 
     expect(getOperationParamCode(operation)).toMatchInlineSnapshot(
@@ -145,6 +162,7 @@ describe('code-sample-util api', () => {
   it('generates param string with path params and mandatory request body', () => {
     const operation = {
       pathParameters: [pathParam1],
+      queryParameters: [] as OpenApiParameter[],
       requestBody: { required: true }
     } as OpenApiOperation;
 

--- a/packages/openapi-generator/src/sdk-metadata/code-sample-util.spec.ts
+++ b/packages/openapi-generator/src/sdk-metadata/code-sample-util.spec.ts
@@ -1,0 +1,167 @@
+import {
+  OpenApiApi,
+  OpenApiOperation,
+  OpenApiParameter
+} from '../openapi-types';
+import {
+  getGetAllOperation,
+  getGetOperation,
+  getLevensteinClosestOperation,
+  getMainApi,
+  getOperationParamCode
+} from './code-sample-util';
+
+describe('code-sample-util api', () => {
+  const pathParam1 = { name: 'path-Param1' };
+  const pathParam2 = { name: 'Path-Param2' };
+
+  const queryParam1 = { name: 'query-Param1', required: true };
+  const queryParam2 = { name: 'query-Param2', required: false };
+  const queryParam3 = { name: 'query-Param3', required: true };
+
+  const api_1 = {
+    name: 'DummyApi',
+    operations: [
+      {
+        operationId: 'DummyFunction',
+        method: 'get',
+        pathParameters: [] as OpenApiParameter[],
+        queryParameters: [] as OpenApiParameter[]
+      }
+    ]
+  } as OpenApiApi;
+
+  const api_2 = {
+    name: 'TestApi',
+    operations: [
+      {
+        operationId: 'getAll',
+        pathParameters: [] as OpenApiParameter[],
+        queryParameters: [] as OpenApiParameter[]
+      },
+      {
+        operationId: 'TestFunc',
+        pathParameters: [] as OpenApiParameter[],
+        queryParameters: [] as OpenApiParameter[]
+      }
+    ]
+  } as OpenApiApi;
+  it('gets main api based on levenshtein algo', () => {
+    expect(getMainApi('dummy', [api_1, api_2])).toEqual({
+      name: 'DummyApi',
+      operations: [
+        {
+          operationId: 'DummyFunction',
+          method: 'get',
+          pathParameters: [],
+          queryParameters: []
+        }
+      ]
+    });
+  });
+
+  it('gets main api with getAll operation', () => {
+    expect(getMainApi('resource', [api_1, api_2])).toEqual(
+      expect.objectContaining({
+        operations: [
+          {
+            operationId: 'getAll',
+            pathParameters: [] as OpenApiParameter[],
+            queryParameters: [] as OpenApiParameter[]
+          },
+          {
+            operationId: 'TestFunc',
+            pathParameters: [] as OpenApiParameter[],
+            queryParameters: [] as OpenApiParameter[]
+          }
+        ]
+      })
+    );
+  });
+
+  it('gets main operationId based on levenshtein algo', () => {
+    expect(getLevensteinClosestOperation(api_2.name, api_2.operations)).toEqual(
+      expect.objectContaining({
+        operationId: 'TestFunc'
+      })
+    );
+  });
+
+  it('gets undefined main operationId if no closest match found using levenshtein algo', () => {
+    expect(
+      getLevensteinClosestOperation('ResourceApi', api_2.operations)
+    ).toBeUndefined();
+  });
+
+  it('gets getAll operation if no closest match found', () => {
+    expect(getGetAllOperation(api_2.operations)).toEqual(
+      expect.objectContaining({
+        operationId: 'getAll'
+      })
+    );
+  });
+
+  it('gets undefined if no getAll operation found', () => {
+    expect(getGetAllOperation(api_1.operations)).toBeUndefined();
+  });
+
+  it('gets any get operation if no getAll operation found', () => {
+    expect(getGetOperation(api_1.operations)).toEqual(
+      expect.objectContaining({
+        operationId: 'DummyFunction',
+        method: 'get'
+      })
+    );
+  });
+
+  it('returns empty params string if there are no parameters', () => {
+    const operation = {
+      operationId: 'getAll'
+    } as OpenApiOperation;
+    expect(getOperationParamCode(operation)).toEqual('');
+  });
+
+  it('generates param string with path params', () => {
+    const operation = {
+      pathParameters: [pathParam1, pathParam2]
+    } as OpenApiOperation;
+
+    expect(getOperationParamCode(operation)).toMatchInlineSnapshot(
+      '"path-Param1, Path-Param2"'
+    );
+  });
+
+  it('generates param string with path, mandatory query params and skips optional query params', () => {
+    const operation = {
+      pathParameters: [pathParam1],
+      queryParameters: [queryParam1, queryParam2, queryParam3]
+    } as OpenApiOperation;
+
+    expect(getOperationParamCode(operation)).toMatchInlineSnapshot(
+      "\"path-Param1, { query-Param1: 'myQueryParam1', query-Param3: 'myQueryParam3' }\""
+    );
+  });
+
+  it('generates param string with path params and mandatory request body', () => {
+    const operation = {
+      pathParameters: [pathParam1],
+      requestBody: { required: true }
+    } as OpenApiOperation;
+
+    expect(getOperationParamCode(operation)).toMatchInlineSnapshot(
+      '"path-Param1, myRequestBody"'
+    );
+  });
+
+  it('generates param string with path, mandatory query params and optional request body', () => {
+    const operation = {
+      pathParameters: [pathParam1],
+      queryParameters: [queryParam1, queryParam2, queryParam3],
+      requestBody: { required: false }
+    } as OpenApiOperation;
+
+    expect(getOperationParamCode(operation)).toMatchInlineSnapshot(
+      "\"path-Param1, undefined, { query-Param1: 'myQueryParam1', query-Param3: 'myQueryParam3' }\""
+    );
+  });
+});

--- a/packages/openapi-generator/src/sdk-metadata/code-sample-util.ts
+++ b/packages/openapi-generator/src/sdk-metadata/code-sample-util.ts
@@ -6,24 +6,26 @@ export function getMainApi(
   serviceName: string,
   apis: OpenApiApi[]
 ): OpenApiApi {
-return getLevenshteinClosest(serviceName, apis, (x) => x.name) ||
-getApiWithMaxOperations(apis);
+  return (
+    getLevenshteinClosest(serviceName, apis, x => x.name) ||
+    getApiWithMaxOperations(apis)
+  );
 }
 
 export function getApiWithMaxOperations(apis: OpenApiApi[]): OpenApiApi {
   const sortedByOperationsLength = apis.sort((a, b) =>
-  a.operations.length > b.operations.length ? -1 : 1
-);
-const withGetAll = sortedByOperationsLength.find(api =>
-  api.operations.find(operation =>
-    operation.operationId.toLocaleLowerCase('getall')
-  )
-);
-if (withGetAll) {
-  return withGetAll;
-}
-// return the one with most methods
-return sortedByOperationsLength[0];
+    a.operations.length > b.operations.length ? -1 : 1
+  );
+  const withGetAll = sortedByOperationsLength.find(api =>
+    api.operations.find(operation =>
+      operation.operationId.toLocaleLowerCase('getall')
+    )
+  );
+  if (withGetAll) {
+    return withGetAll;
+  }
+  // return the one with most methods
+  return sortedByOperationsLength[0];
 }
 
 export function getMainOperation(api: OpenApiApi): OpenApiOperation {
@@ -31,7 +33,7 @@ export function getMainOperation(api: OpenApiApi): OpenApiOperation {
     return api.operations[0];
   }
   return (
-    getLevenshteinClosest(api.name, api.operations, (op) => op.operationId) ||
+    getLevenshteinClosest(api.name, api.operations, op => op.operationId) ||
     getGetAllOperation(api.operations) ||
     getGetOperation(api.operations) ||
     getAnyOperationWithoutParams(api.operations) ||
@@ -43,8 +45,7 @@ export function getGetAllOperation(
   operations: OpenApiOperation[]
 ): OpenApiOperation | undefined {
   return operations.find(
-    operation =>
-      operation.operationId.toLowerCase() === 'getall'
+    operation => operation.operationId.toLowerCase() === 'getall'
   );
 }
 
@@ -82,7 +83,6 @@ export function getAnyOperationWithoutParams(
 }
 
 export function getOperationParamCode(operation: OpenApiOperation): string {
-
   const paramSignature: string[] = [];
   if (operation.pathParameters) {
     paramSignature.push(

--- a/packages/openapi-generator/src/sdk-metadata/code-sample-util.ts
+++ b/packages/openapi-generator/src/sdk-metadata/code-sample-util.ts
@@ -1,0 +1,167 @@
+import levenstein from 'fast-levenshtein';
+import { codeBlock, pascalCase } from '@sap-cloud-sdk/util';
+import { OpenApiApi, OpenApiOperation } from '../openapi-types';
+
+const distanceThreshold = 5;
+export function getMainApi(
+  serviceName: string,
+  apis: OpenApiApi[]
+): OpenApiApi {
+  let closestApi: OpenApiApi | undefined;
+  let minDistance = distanceThreshold;
+
+  apis.forEach(api => {
+    const distance = getLevensteinDistance(serviceName, api.name);
+    if (distance <= minDistance) {
+      minDistance = distance;
+      closestApi = api;
+    }
+  });
+  if (closestApi) {
+    return closestApi;
+  }
+  // If no closest api found, return the api with most operations
+  const sortedByOperationsLength = apis.sort((a, b) =>
+    a.operations.length > b.operations.length ? -1 : 1
+  );
+  const withGetAll = sortedByOperationsLength.filter(api =>
+    api.operations.find(operation =>
+      operation.operationId.toLocaleLowerCase('getall')
+    )
+  );
+  if (withGetAll) {
+    return withGetAll[0];
+  }
+  // return the one with most methods
+  return sortedByOperationsLength[0];
+}
+
+export function getMainOperation(api: OpenApiApi): OpenApiOperation {
+  if (api.operations.length === 1) {
+    return api.operations[0];
+  }
+  return (
+    getLevensteinClosestOperation(api.name, api.operations) ||
+    getGetAllOperation(api.operations) ||
+    getGetOperation(api.operations) ||
+    getAnyOperationWithoutParams(api.operations) ||
+    api.operations[0]
+  );
+}
+
+export function getLevensteinClosestOperation(
+  apiName: string,
+  operations: OpenApiOperation[]
+): OpenApiOperation | undefined {
+  let closestOperation: OpenApiOperation | undefined;
+  let minDistance = distanceThreshold;
+
+  operations.forEach(operation => {
+    const distance = getLevensteinDistance(apiName, operation.operationId);
+    if (distance <= minDistance) {
+      minDistance = distance;
+      closestOperation = operation;
+    }
+  });
+  return closestOperation;
+}
+
+export function getGetAllOperation(
+  operations: OpenApiOperation[]
+): OpenApiOperation | undefined {
+  return operations.find(
+    operation =>
+      operation.operationId.toLowerCase() === 'getall' &&
+      operation.pathParameters.length === 0
+  );
+}
+
+export function getGetOperation(
+  operations: OpenApiOperation[]
+): OpenApiOperation | undefined {
+  const getOperations = operations.filter(
+    operation => operation.method === 'get'
+  );
+
+  // check if get operation without parameters exists
+  // else return operation with min parameters
+  if (getOperations.length > 0) {
+    const getOperationsWithoutParams = getOperations.filter(
+      getOperation =>
+        getOperation.pathParameters.length === 0 &&
+        getOperation.queryParameters.length === 0
+    );
+    if (getOperationsWithoutParams.length > 0) {
+      return getOperationsWithoutParams[0];
+    }
+    return getOperations[0];
+  }
+  return undefined;
+}
+
+export function getAnyOperationWithoutParams(
+  operations: OpenApiOperation[]
+): OpenApiOperation | undefined {
+  return operations.find(
+    operation =>
+      operation.pathParameters.length === 0 &&
+      operation.queryParameters.length === 0
+  );
+}
+
+export function getOperationParamCode(operation: OpenApiOperation): string {
+  if (
+    operation.pathParameters?.length === 0 &&
+    operation.queryParameters?.filter(param => param.required).length === 0 &&
+    operation.requestBody === undefined
+  ) {
+    return '';
+  }
+
+  const paramSignature: string[] = [];
+  if (operation.pathParameters?.length > 0) {
+    paramSignature.push(
+      operation.pathParameters.map(pathParam => pathParam.name).join(', ')
+    );
+  }
+
+  if (operation.requestBody) {
+    let reqBody = 'undefined';
+    if (operation.requestBody.required) {
+      reqBody = 'myRequestBody';
+    }
+    paramSignature.push(reqBody);
+  }
+
+  if (operation.queryParameters?.length > 0) {
+    const queryParams = operation.queryParameters
+      .filter(queryParam => queryParam.required)
+      .map(
+        queryParam => `${queryParam.name}: 'my${pascalCase(queryParam.name)}'`
+      );
+
+    if (queryParams) {
+      paramSignature.push(`{ ${queryParams.join(', ')} }`);
+    }
+  }
+
+  return codeBlock`${paramSignature.join(', ')}`;
+}
+
+/**
+ * Calculate levenshtein distance of the two strings.
+ * @param stringA - The first string.
+ * @param stringB - The second string.
+ * @returns The levenshtein distance (0 and above).
+ * @hidden
+ */
+function getLevensteinDistance(stringA: string, stringB: string): number {
+  return levenstein.get(
+    getWordWithoutSpecialChars(stringA).toLowerCase(),
+    getWordWithoutSpecialChars(stringB).toLowerCase()
+  );
+}
+
+function getWordWithoutSpecialChars(text: string): string {
+  return text.replace('_', '');
+}

--- a/packages/openapi-generator/src/sdk-metadata/code-sample.ts
+++ b/packages/openapi-generator/src/sdk-metadata/code-sample.ts
@@ -1,21 +1,30 @@
 import { codeBlock } from '@sap-cloud-sdk/util';
 import { InstructionWithText } from '@sap-cloud-sdk/generator-common';
+import { OpenApiOperation } from '../openapi-types';
+import { getOperationParamCode } from './code-sample-util';
 
+const instructionsText =
+  'To consume the service via the pregenerated typed client library run the code snippet below. For more details about OpenAPI client libraries chose "OpenAPI Consumption Manual" from the "Helpful Links" menu.';
 export function genericCodeSample(): InstructionWithText {
-  return apiSpecificCodeSample('MyApi', 'myFunction', 'my-npm-package');
+  const operation = { operationId: 'myFunction' } as OpenApiOperation;
+  return apiSpecificCodeSample('MyApi', operation, 'my-npm-package');
 }
 
 export function apiSpecificCodeSample(
   apiName: string,
-  functionName: string,
+  operation: OpenApiOperation,
   packageName: string
 ): InstructionWithText {
   return {
-    text: 'To consume the service via the pregenerated typed client library run the code snippet below. For more details about OpenAPI client libraries chose "OpenAPI Consumption Manual" from the "Helpful Links" menu.',
+    text: instructionsText,
     instructions: codeBlock`
 import { ${apiName} } from '${packageName}';
 
-const responseData = await ${apiName}.${functionName}().execute({ destinationName:'myDestinationName' });
+const responseData = await ${apiName}.${
+      operation.operationId
+    }(${getOperationParamCode(
+      operation
+    )}).execute({ destinationName:'myDestinationName' });
 `
   };
 }

--- a/packages/openapi-generator/src/sdk-metadata/generation-and-usage.ts
+++ b/packages/openapi-generator/src/sdk-metadata/generation-and-usage.ts
@@ -56,7 +56,7 @@ function getApiSpecificUsage(
     api => api.operations?.length > 0
   );
 
-  if (apisWithOperations) {
+  if (apisWithOperations.length > 0) {
     const mainApi = getMainApi(openApiDocument.serviceName, apisWithOperations);
     const operation = getMainOperation(mainApi);
 

--- a/packages/openapi-generator/src/sdk-metadata/generation-and-usage.ts
+++ b/packages/openapi-generator/src/sdk-metadata/generation-and-usage.ts
@@ -1,4 +1,3 @@
-import { first } from '@sap-cloud-sdk/util';
 import {
   GenerationAndUsage,
   getLinks,
@@ -10,6 +9,7 @@ import {
 } from '@sap-cloud-sdk/generator-common';
 import { OpenApiDocument } from '../openapi-types';
 import { apiSpecificCodeSample, genericCodeSample } from './code-sample';
+import { getMainApi, getMainOperation } from './code-sample-util';
 
 export async function getGenerationAndUsage(
   openApiDocument: OpenApiDocument
@@ -52,15 +52,17 @@ function getGenericUsage(): InstructionWithTextAndHeader {
 function getApiSpecificUsage(
   openApiDocument: OpenApiDocument
 ): InstructionWithTextAndHeader {
-  const apiWithOperations = first(
-    openApiDocument.apis.filter(api => api.operations.length > 0)
+  const apisWithOperations = openApiDocument.apis.filter(
+    api => api.operations.length > 0
   );
 
-  if (apiWithOperations) {
-    const operation = first(apiWithOperations.operations)!;
+  if (apisWithOperations) {
+    const mainApi = getMainApi(openApiDocument.serviceName, apisWithOperations);
+    const operation = getMainOperation(mainApi);
+
     const instructions = apiSpecificCodeSample(
-      apiWithOperations.name,
-      operation.operationId,
+      mainApi.name,
+      operation,
       openApiDocument.serviceOptions.packageName
     );
     return {

--- a/packages/openapi-generator/src/sdk-metadata/generation-and-usage.ts
+++ b/packages/openapi-generator/src/sdk-metadata/generation-and-usage.ts
@@ -53,7 +53,7 @@ function getApiSpecificUsage(
   openApiDocument: OpenApiDocument
 ): InstructionWithTextAndHeader {
   const apisWithOperations = openApiDocument.apis.filter(
-    api => api.operations.length > 0
+    api => api.operations?.length > 0
   );
 
   if (apisWithOperations) {

--- a/packages/openapi-generator/test/test-util.ts
+++ b/packages/openapi-generator/test/test-util.ts
@@ -20,6 +20,7 @@ export const emptyObjectSchema = {
 };
 
 export const dummyOpenApiDocument: OpenApiDocument = {
+  serviceName: 'dummy',
   serviceOptions: {
     packageName: '@sap/dummy-package',
     directoryName: 'dummy-package'
@@ -29,7 +30,51 @@ export const dummyOpenApiDocument: OpenApiDocument = {
       name: 'DummyApi',
       operations: [
         {
-          operationId: 'DummyFunction'
+          operationId: 'DummyFunction',
+          pathParameters: [
+            {
+              name: 'dummyId'
+            }
+          ],
+          requestBody: {
+            required: false
+          },
+          queryParameters: [
+            {
+              name: 'query_1',
+              required: true
+            },
+            {
+              name: 'query_2',
+              required: false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      name: 'ResourceApi',
+      operations: [
+        {
+          operationId: 'ResourceFunction',
+          pathParameters: [
+            {
+              name: 'resourceId'
+            }
+          ],
+          requestBody: {
+            required: false
+          },
+          queryParameters: [
+            {
+              name: 'query_1',
+              required: true
+            },
+            {
+              name: 'query_2',
+              required: false
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
Please provide a description of what your change does and why it is needed.

Updated `getApiSpecificUsage `method to generate open-api usage code snippet for main API and its operationId based on the closest match found using the levenshtein algo measured against a threshold.

Closes SAP/cloud-sdk-backlog#245

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
