### PR TITLE
fix: consider http(s)Agent key when sending CSRF token requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - [core] Fix verification key retrieval to match the given key id (`kid`).
 - [core] Fix the missing export for files under `http-agent` directory.
+- [core] Support using custom http(s)Agent when sending CSRF token requests.
 
 # 1.48.1
 

--- a/packages/core/src/http-client/http-client.ts
+++ b/packages/core/src/http-client/http-client.ts
@@ -266,7 +266,10 @@ async function getCsrfHeaders(
     : buildCsrfHeaders(destination, {
         params: request.params,
         headers: request.headers,
-        url: request.url
+        url: request.url,
+        proxy: request.proxy,
+        httpAgent: request.httpAgent,
+        httpsAgent: request.httpsAgent
       });
 }
 


### PR DESCRIPTION
Related to: https://github.com/SAP/cloud-sdk-js/issues/1564

When sending CSRF token request, the following keys of the requestConfig are now considered like the real request:
- proxy
- httpAgent
- httpsAgent