### PR TITLE
Fix: missing encoding of `orderby`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [core] Fix verification key retrieval to match the given key id (`kid`).
 - [core] Fix the missing export for files under `http-agent` directory.
 - [core] Support using custom http(s)Agent when sending CSRF token requests.
+- [core] Fix URL encoding for `$orderby` query parameter of OData requests.
 
 # 1.48.1
 

--- a/packages/core/src/odata-common/uri-conversion/get-orderby.ts
+++ b/packages/core/src/odata-common/uri-conversion/get-orderby.ts
@@ -59,5 +59,5 @@ function getOrderByExpressionForOrder<OrderByEntityT extends Entity>(
   return [
     [...parentFieldNames, orderBy._fieldName].join('/'),
     orderBy.orderType
-  ].join(' ');
+  ].join(encodeURIComponent(' '));
 }

--- a/packages/core/src/odata-v2/uri-conversion/get-orderby.spec.ts
+++ b/packages/core/src/odata-v2/uri-conversion/get-orderby.spec.ts
@@ -7,7 +7,7 @@ import { getQueryParametersForOrderBy } from './get-orderby';
 
 describe('get orderby', () => {
   const encodedSpace = encodeURIComponent(' ');
-  
+
   it('is empty for empty orderbys', () => {
     expect(getQueryParametersForOrderBy([])).toEqual({});
   });

--- a/packages/core/src/odata-v2/uri-conversion/get-orderby.spec.ts
+++ b/packages/core/src/odata-v2/uri-conversion/get-orderby.spec.ts
@@ -42,6 +42,8 @@ describe('get orderby', () => {
       getQueryParametersForOrderBy([
         asc(TestEntity.COMPLEX_TYPE_PROPERTY.complexTypeProperty.stringProperty)
       ]).orderby
-    ).toBe(`ComplexTypeProperty/ComplexTypeProperty/StringProperty${encodedSpace}asc`);
+    ).toBe(
+      `ComplexTypeProperty/ComplexTypeProperty/StringProperty${encodedSpace}asc`
+    );
   });
 });

--- a/packages/core/src/odata-v2/uri-conversion/get-orderby.spec.ts
+++ b/packages/core/src/odata-v2/uri-conversion/get-orderby.spec.ts
@@ -6,6 +6,8 @@ import {
 import { getQueryParametersForOrderBy } from './get-orderby';
 
 describe('get orderby', () => {
+  const encodedSpace = encodeURIComponent(' ');
+  
   it('is empty for empty orderbys', () => {
     expect(getQueryParametersForOrderBy([])).toEqual({});
   });
@@ -20,7 +22,7 @@ describe('get orderby', () => {
         )
       ]).orderby
     ).toBe(
-      'Int16Property asc,StringProperty asc,to_SingleLink/GuidProperty desc'
+      `Int16Property${encodedSpace}asc,StringProperty${encodedSpace}asc,to_SingleLink/GuidProperty${encodedSpace}desc`
     );
   });
 
@@ -31,7 +33,7 @@ describe('get orderby', () => {
         desc(TestEntity.COMPLEX_TYPE_PROPERTY.int16Property)
       ]).orderby
     ).toBe(
-      'ComplexTypeProperty/StringProperty asc,ComplexTypeProperty/Int16Property desc'
+      `ComplexTypeProperty/StringProperty${encodedSpace}asc,ComplexTypeProperty/Int16Property${encodedSpace}desc`
     );
   });
 
@@ -40,6 +42,6 @@ describe('get orderby', () => {
       getQueryParametersForOrderBy([
         asc(TestEntity.COMPLEX_TYPE_PROPERTY.complexTypeProperty.stringProperty)
       ]).orderby
-    ).toBe('ComplexTypeProperty/ComplexTypeProperty/StringProperty asc');
+    ).toBe(`ComplexTypeProperty/ComplexTypeProperty/StringProperty${encodedSpace}asc`);
   });
 });

--- a/packages/core/src/odata-v4/uri-conversion/get-expand.spec.ts
+++ b/packages/core/src/odata-v4/uri-conversion/get-expand.spec.ts
@@ -33,6 +33,8 @@ describe('get expand', () => {
   });
 });
 
+const encodedSpace = encodeURIComponent(' ');
+
 const testExpandSingleLink = {
   expand: TestEntity.TO_SINGLE_LINK.select(
     TestEntitySingleLink.STRING_PROPERTY,
@@ -51,5 +53,5 @@ const testExpandMultiLink = {
     .top(1)
     .skip(1),
   odataStr:
-    "to_MultiLink($select=StringProperty,BooleanProperty;$filter=(StringProperty%20eq%20'test');$skip=1;$top=1;$orderby=StringProperty asc)"
+    `to_MultiLink($select=StringProperty,BooleanProperty;$filter=(StringProperty%20eq%20'test');$skip=1;$top=1;$orderby=StringProperty${encodedSpace}asc)`
 };

--- a/packages/core/src/odata-v4/uri-conversion/get-expand.spec.ts
+++ b/packages/core/src/odata-v4/uri-conversion/get-expand.spec.ts
@@ -52,6 +52,5 @@ const testExpandMultiLink = {
     .filter(TestEntityMultiLink.STRING_PROPERTY.equals('test'))
     .top(1)
     .skip(1),
-  odataStr:
-    `to_MultiLink($select=StringProperty,BooleanProperty;$filter=(StringProperty%20eq%20'test');$skip=1;$top=1;$orderby=StringProperty${encodedSpace}asc)`
+  odataStr: `to_MultiLink($select=StringProperty,BooleanProperty;$filter=(StringProperty%20eq%20'test');$skip=1;$top=1;$orderby=StringProperty${encodedSpace}asc)`
 };


### PR DESCRIPTION
Related to: https://github.com/SAP/cloud-sdk-js/issues/1575

The space of the `orderby` query parameter, for example `$orderby=Id desc`, should be encoded to `$orderby=Id%20desc`.