### PR TITLE
fix: fix transpilation error

### DIFF
--- a/packages/generator-common/src/compiler.ts
+++ b/packages/generator-common/src/compiler.ts
@@ -29,7 +29,9 @@ export async function transpileDirectory(
 ): Promise<void> {
   logger.verbose(`Transpiling files in the directory: ${path} started.`);
 
-  const files = new GlobSync(resolve(path, '**/*.ts'), {}).found;
+  const files = new GlobSync(resolve(path, '**/*.ts'), {
+    ignore: resolve(path, '**/*.d.ts')
+  }).found;
   const program = await createProgram(files, compilerOptions);
   const emitResult = await program.emit();
 


### PR DESCRIPTION
Please provide a description of what your change does and why it is needed.

Fixed Errors during transpilation process by ignoring the .d.ts files.

Closes SAP/cloud-sdk-backlog#256

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
