### PR TITLE
chore: Lock version of xssec to 3.2.3 until we find a workaround with…

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "@sap-cloud-sdk/analytics": "^1.48.1",
     "@sap-cloud-sdk/util": "^1.48.1",
     "@sap/xsenv": "^3.0.0",
-    "@sap/xssec": "^3.2.3",
+    "@sap/xssec": "3.2.3",
     "@types/jsonwebtoken": "^8.3.8",
     "axios": "^0.21.1",
     "bignumber.js": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,7 +1790,7 @@
     debug "4.2.0"
     verror "1.10.0"
 
-"@sap/xssec@^3.2.3":
+"@sap/xssec@3.2.3":
   version "3.2.3"
   resolved "https://registry.npmjs.org/@sap/xssec/-/xssec-3.2.3.tgz#a7d68e14ed1d6bd24bc58aa23df499bfb49ac5f5"
   integrity sha512-4gOWZszdUFR7c0wZhKgN4YpucIm2iVn+qGjuHLq06WPRO/ufFJYkQ0bY8xDZj/3WrIq2rokx8xiMavNHP92I0A==
@@ -4843,7 +4843,7 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fast-levenshtein@^3.0.0:
+fast-levenshtein@~3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz#37b899ae47e1090e40e3fd2318e4d5f0142ca912"
   integrity sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==


### PR DESCRIPTION
… browsers

As we currently cannot find a solution with react + webpack + sdk, it is a risk to use the latest version of xssec. In order to fulfill the requirements for mTLS we should finally make a release. Therefore, this is a proposal to keep the older version of xssec for the time being.

Relates to SAP/cloud-sdk-backlog#264.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
