### PR TITLE
fix: Reduce number of warnings on XSUAA selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ## Improvements
 
--
+- [xsuaa] Reduce the number of warn message when selecting a XSUAA instance.
 
 ## Fixed Issues
 

--- a/packages/core/src/connectivity/scp-cf/destination/destination-accessor-loading-precendence.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-accessor-loading-precendence.spec.ts
@@ -76,7 +76,7 @@ describe('destination loading precedence', () => {
         { cacheVerificationKeys: false }
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      'No binding to an XSUAA service instance found. Please make sure to bind an instance of the XSUAA service to your application.'
+      '"No binding to an XSUAA service instance found. Please make sure to bind an instance of the XSUAA service to your application."'
     );
   });
 });

--- a/packages/core/src/connectivity/scp-cf/destination/destination-accessor-loading-precendence.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-accessor-loading-precendence.spec.ts
@@ -75,6 +75,8 @@ describe('destination loading precedence', () => {
         { destinationName: 'non-existent' },
         { cacheVerificationKeys: false }
       )
-    ).rejects.toThrowError('No binding to an XSUAA service instance found. Please make sure to bind an instance of the XSUAA service to your application.')
+    ).rejects.toThrowError(
+      'No binding to an XSUAA service instance found. Please make sure to bind an instance of the XSUAA service to your application.'
+    );
   });
 });

--- a/packages/core/src/connectivity/scp-cf/destination/destination-accessor-loading-precendence.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-accessor-loading-precendence.spec.ts
@@ -75,8 +75,6 @@ describe('destination loading precedence', () => {
         { destinationName: 'non-existent' },
         { cacheVerificationKeys: false }
       )
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"Unable to get access token for \\"destination\\" service. No service instance of type \\"destination\\" found."'
-    );
+    ).rejects.toThrowError('No binding to an XSUAA service instance found. Please make sure to bind an instance of the XSUAA service to your application.')
   });
 });

--- a/packages/core/src/connectivity/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
@@ -236,6 +236,7 @@ describe('jwtType x selection strategy combinations. Possible values are {subscr
     });
 
     it('it warns if you use iss property and user jwt', async () => {
+      mockServiceBindings();
       const logger = createLogger({
         package: 'core',
         messageContext: 'destination-accessor-service'

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
@@ -10,10 +10,14 @@ import { jwtBearerToken, serviceToken } from '../token-accessor';
 import { addProxyConfigurationOnPrem } from '../connectivity-service';
 import {
   getDestinationService,
-  getDestinationServiceCredentialsList
+  getDestinationServiceCredentialsList,
+  getXsuaaServiceCredentials
 } from '../environment-accessor';
 import { isIdenticalTenant } from '../tenant';
-import { DestinationServiceCredentials } from '../environment-accessor-types';
+import {
+  DestinationServiceCredentials,
+  XsuaaServiceCredentials
+} from '../environment-accessor-types';
 import { Destination } from './destination-service-types';
 import {
   alwaysProvider,
@@ -78,15 +82,18 @@ class DestinationFromServiceRetriever {
     name: string,
     options: DestinationOptions
   ): Promise<Destination | null> {
+    const xsuaaCredentials = getXsuaaServiceCredentials(options.userJwt);
+
     const subscriberToken =
       await DestinationFromServiceRetriever.getSubscriberToken(options);
     const providerToken =
       await DestinationFromServiceRetriever.getProviderClientCredentialsToken(
+        xsuaaCredentials,
         options
       );
     const da = new DestinationFromServiceRetriever(
       name,
-      options,
+      { ...options, xsuaaCredentials },
       subscriberToken,
       providerToken
     );
@@ -163,11 +170,15 @@ class DestinationFromServiceRetriever {
   }
 
   private static async getProviderClientCredentialsToken(
+    xsuaaCredentials: XsuaaServiceCredentials,
     options: DestinationOptions
   ): Promise<JwtPair> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { userJwt, ...optionsWithoutJwt } = options;
-    const encoded = await serviceToken('destination', optionsWithoutJwt);
+    const encoded = await serviceToken('destination', {
+      ...optionsWithoutJwt,
+      xsuaaCredentials
+    });
     return { encoded, decoded: decodeJwt(encoded) };
   }
 
@@ -189,7 +200,7 @@ class DestinationFromServiceRetriever {
 
   private constructor(
     readonly name: string,
-    options: DestinationOptions,
+    options: DestinationOptions & { xsuaaCredentials: XsuaaServiceCredentials },
     readonly subscriberToken: JwtPair | undefined,
     readonly providerClientCredentialsToken: JwtPair
   ) {

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
@@ -82,10 +82,10 @@ class DestinationFromServiceRetriever {
     name: string,
     options: DestinationOptions
   ): Promise<Destination | null> {
-    const xsuaaCredentials = getXsuaaServiceCredentials(options.userJwt);
-
     const subscriberToken =
       await DestinationFromServiceRetriever.getSubscriberToken(options);
+
+    const xsuaaCredentials = getXsuaaServiceCredentials(options.userJwt);
     const providerToken =
       await DestinationFromServiceRetriever.getProviderClientCredentialsToken(
         xsuaaCredentials,

--- a/packages/core/src/connectivity/scp-cf/environment-accessor-types.ts
+++ b/packages/core/src/connectivity/scp-cf/environment-accessor-types.ts
@@ -25,9 +25,7 @@ export type ServiceCredentials = {
 /**
  * Credentials for the Destination service.
  */
-export interface DestinationServiceCredentials {
-  clientid: string;
-  clientsecret: string;
+export type DestinationServiceCredentials = ServiceCredentials & {
   identityzone: string;
   instanceid: string;
   tenantid: string;
@@ -37,14 +35,12 @@ export interface DestinationServiceCredentials {
   url: string;
   verificationkey: string;
   xsappname: string;
-}
+};
 
 /**
  * Credentials for the XSUAA service.
  */
-export interface XsuaaServiceCredentials {
-  clientid: string;
-  clientsecret: string;
+export type XsuaaServiceCredentials = ServiceCredentials & {
   identityzone: string;
   identityzoneid: string;
   sburl: string;
@@ -54,4 +50,4 @@ export interface XsuaaServiceCredentials {
   url: string;
   verificationkey: string;
   xsappname: string;
-}
+};

--- a/packages/core/src/connectivity/scp-cf/environment-accessor-types.ts
+++ b/packages/core/src/connectivity/scp-cf/environment-accessor-types.ts
@@ -22,8 +22,6 @@ export type ServiceCredentials = {
     }
 );
 
-const foo: ServiceCredentials = { clientid: 'fad', clientsecret: 'abx' };
-
 /**
  * Credentials for the Destination service.
  */

--- a/packages/core/src/connectivity/scp-cf/environment-accessor-types.ts
+++ b/packages/core/src/connectivity/scp-cf/environment-accessor-types.ts
@@ -22,6 +22,8 @@ export type ServiceCredentials = {
     }
 );
 
+const foo: ServiceCredentials = { clientid: 'fad', clientsecret: 'abx' };
+
 /**
  * Credentials for the Destination service.
  */

--- a/packages/core/src/connectivity/scp-cf/environment-accessor.ts
+++ b/packages/core/src/connectivity/scp-cf/environment-accessor.ts
@@ -270,7 +270,7 @@ function handleOneXsuuaInstance(
 ): XsuaaServiceCredentials {
   if (xsuaaCredentials.length !== 1) {
     throw new Error(
-      `This method should be called with an array of size 1. Xsappname: ${xsuaaCredentials.map(
+      `This function should be called with an array of size 1. Xsappname: ${xsuaaCredentials.map(
         credentials => credentials.xsappname
       )}`
     );

--- a/packages/core/src/connectivity/scp-cf/environment-accessor.ts
+++ b/packages/core/src/connectivity/scp-cf/environment-accessor.ts
@@ -24,11 +24,11 @@ export function getDestinationBasicCredentials(): BasicCredentials {
   const destinationCredentials = getDestinationServiceCredentials();
   const basicCredentials: BasicCredentials = {
     clientid: destinationCredentials.clientid
-        ? destinationCredentials.clientid
-        : null,
+      ? destinationCredentials.clientid
+      : null,
     clientsecret: destinationCredentials.clientsecret
-        ? destinationCredentials.clientsecret
-        : null
+      ? destinationCredentials.clientsecret
+      : null
   };
   return basicCredentials;
 }
@@ -49,7 +49,7 @@ export function getDestinationServiceCredentials(): any {
  */
 export function getDestinationServiceCredentialsList(): DestinationServiceCredentials[] {
   return getServiceList('destination').map(
-      s => s.credentials as DestinationServiceCredentials
+    s => s.credentials as DestinationServiceCredentials
   );
 }
 
@@ -65,7 +65,7 @@ export function getServiceCredentialsList(service: string): any[] {
       credentials.push(entry['credentials']);
     } else {
       logger.warn(
-          `Skipping a service in ${service}. Object has no 'credentials'.`
+        `Skipping a service in ${service}. Object has no 'credentials'.`
       );
     }
   });
@@ -92,16 +92,16 @@ export function getService(service: string): Service | undefined {
 
   if (!services.length) {
     logger.warn(
-        `No services of type ${service} found! This might cause errors in other parts of the application.`
+      `No services of type ${service} found! This might cause errors in other parts of the application.`
     );
 
     return undefined;
   }
   if (services.length > 1) {
     logger.warn(
-        `Found more than one service instance for service type ${service}. Found: ${services
-            .map(s => s.name)
-            .join(', ')}. Selecting the first one.`
+      `Found more than one service instance for service type ${service}. Found: ${services
+        .map(s => s.name)
+        .join(', ')}. Selecting the first one.`
     );
   }
 
@@ -140,13 +140,13 @@ export function getVcapService(): Record<string, any> | null {
     vcapServices = JSON.parse(env);
   } catch (error) {
     throw new ErrorWithCause(
-        "Failed to parse environment variable 'VCAP_SERVICES'.",
-        error
+      "Failed to parse environment variable 'VCAP_SERVICES'.",
+      error
     );
   }
   if (!Object.keys(vcapServices).length) {
     throw new Error(
-        "Environment variable 'VCAP_SERVICES' is defined but empty. This should not happen."
+      "Environment variable 'VCAP_SERVICES' is defined but empty. This should not happen."
     );
   }
 
@@ -160,7 +160,7 @@ export function getVcapService(): Record<string, any> | null {
  *           null: If not defined.
  */
 export function getEnvironmentVariable(
-    name: string
+  name: string
 ): string | undefined | null {
   if (process.env[name]) {
     return process.env[name];
@@ -184,7 +184,7 @@ export function getDestinationServiceUri(): string | null {
       uris.push(credential['uri']);
     } else {
       logger.info(
-          "Skipping credentials in 'destination'. 'uri' property not defined"
+        "Skipping credentials in 'destination'. 'uri' property not defined"
       );
     }
   }
@@ -199,11 +199,11 @@ export function getDestinationServiceUri(): string | null {
  * @returns The credentials for a match, otherwise `null`.
  */
 export function getXsuaaServiceCredentials(
-    token?: JwtPayload | string
+  token?: JwtPayload | string
 ): XsuaaServiceCredentials {
   return typeof token === 'string'
-      ? selectXsuaaInstance(decodeJwt(token))
-      : selectXsuaaInstance(token);
+    ? selectXsuaaInstance(decodeJwt(token))
+    : selectXsuaaInstance(token);
 }
 
 /**
@@ -220,7 +220,7 @@ export function resolveService(service: string | Service): Service {
 
     if (!serviceInstance) {
       throw Error(
-          `Unable to get access token for "${service}" service. No service instance of type "${service}" found.`
+        `Unable to get access token for "${service}" service. No service instance of type "${service}" found.`
       );
     }
 
@@ -235,7 +235,7 @@ export function resolveService(service: string | Service): Service {
  * @returns A [[ClientCredentials]] instance.
  */
 export function extractClientCredentials(
-    serviceCreds: ServiceCredentials
+  serviceCreds: ServiceCredentials
 ): ClientCredentials {
   return {
     username: serviceCreds.clientid,
@@ -245,56 +245,56 @@ export function extractClientCredentials(
 
 function selectXsuaaInstance(token?: JwtPayload): XsuaaServiceCredentials {
   const xsuaaCredentials: XsuaaServiceCredentials[] = getServiceList(
-      'xsuaa'
+    'xsuaa'
   ).map(service => service.credentials as XsuaaServiceCredentials);
 
   if (!xsuaaCredentials.length) {
     throw Error(
-        'No binding to an XSUAA service instance found. Please make sure to bind an instance of the XSUAA service to your application.'
+      'No binding to an XSUAA service instance found. Please make sure to bind an instance of the XSUAA service to your application.'
     );
   }
 
   if (token) {
-    return selectViaJwt(xsuaaCredentials, token);
+    return selectXsuaaInstanceWithJwt(xsuaaCredentials, token);
   }
-  return selectWithoutJwt(xsuaaCredentials);
+  return selectXsuaaInstanceWithoutJwt(xsuaaCredentials);
 }
 
 function handleOneXsuuaInstance(
-    xsuaaCredentials: XsuaaServiceCredentials[]
+  xsuaaCredentials: XsuaaServiceCredentials[]
 ): XsuaaServiceCredentials {
   if (xsuaaCredentials.length !== 1) {
     throw new Error(
-        `This method should be called with an array of size 1. Xsappname: ${xsuaaCredentials.map(
-            credentials => credentials.xsappname
-        )}`
+      `This method should be called with an array of size 1. Xsappname: ${xsuaaCredentials.map(
+        credentials => credentials.xsappname
+      )}`
     );
   }
   logger.debug(
-      `Only one XSUAA instance bound. This one is used: ${xsuaaCredentials[0].xsappname}`
+    `Only one XSUAA instance bound. This one is used: ${xsuaaCredentials[0].xsappname}`
   );
   return xsuaaCredentials[0];
 }
 
-function selectWithoutJwt(
-    xsuaaCredentials: XsuaaServiceCredentials[]
+function selectXsuaaInstanceWithoutJwt(
+  xsuaaCredentials: XsuaaServiceCredentials[]
 ): XsuaaServiceCredentials {
   if (xsuaaCredentials.length > 1) {
     logger.warn(
-        `The following XSUAA instances are bound: ${xsuaaCredentials.map(
-            x => x.credentials.xsappname
-        )} and no JWT is given to decide which one to use. Choosing the first one (xsappname: ${
-            first(xsuaaCredentials)!.credentials.xsappname
-        }).`
+      `The following XSUAA instances are bound: ${xsuaaCredentials.map(
+        x => x.credentials.xsappname
+      )} and no JWT is given to decide which one to use. Choosing the first one (xsappname: ${
+        first(xsuaaCredentials)!.credentials.xsappname
+      }).`
     );
     return xsuaaCredentials[0];
   }
   return handleOneXsuuaInstance(xsuaaCredentials);
 }
 
-function selectViaJwt(
-    xsuaaServices: XsuaaServiceCredentials[],
-    jwt: JwtPayload
+function selectXsuaaInstanceWithJwt(
+  xsuaaServices: XsuaaServiceCredentials[],
+  jwt: JwtPayload
 ): XsuaaServiceCredentials {
   const selected = [
     ...matchingClientId(xsuaaServices, jwt),
@@ -302,29 +302,29 @@ function selectViaJwt(
   ];
   if (selected.length === 1) {
     logger.debug(
-        `One XSUAA instance found using JWT in service binding. Used service name is: ${xsuaaServices[0].credentials.xsappname}`
+      `One XSUAA instance found using JWT in service binding. Used service name is: ${xsuaaServices[0].credentials.xsappname}`
     );
     return xsuaaServices[0].credentials;
   }
 
   if (selected.length > 1) {
     logger.warn(
-        `Multiple XSUAA instances could be matched to the given JWT: ${xsuaaServices.map(
-            x => x.credentials.xsappname
-        )}. Choosing the first one (xsappname: ${
-            first(selected)!.credentials.xsappname
-        }).`
+      `Multiple XSUAA instances could be matched to the given JWT: ${xsuaaServices.map(
+        x => x.credentials.xsappname
+      )}. Choosing the first one (xsappname: ${
+        first(selected)!.credentials.xsappname
+      }).`
     );
     return selected[0].credentials;
   }
 
   if (xsuaaServices.length > 0) {
     logger.warn(
-        `Multiple XSUAA instances present and selection via JWT did not narrow it down: ${xsuaaServices.map(
-            x => x.credentials.xsappname
-        )}. Choosing the first one (xsappname: ${
-            first(selected)!.credentials.xsappname
-        }).`
+      `Multiple XSUAA instances present and selection via JWT did not narrow it down: ${xsuaaServices.map(
+        x => x.credentials.xsappname
+      )}. Choosing the first one (xsappname: ${
+        first(selected)!.credentials.xsappname
+      }).`
     );
     return selected[0].credentials;
   }
@@ -340,20 +340,20 @@ interface XsuaaService {
 }
 
 function matchingClientId(
-    xsuaaCredentials: XsuaaServiceCredentials[],
-    token: JwtPayload
+  xsuaaCredentials: XsuaaServiceCredentials[],
+  token: JwtPayload
 ): XsuaaServiceCredentials[] {
   return xsuaaCredentials.filter(
-      credentials => credentials.clientid === token.client_id
+    credentials => credentials.clientid === token.client_id
   );
 }
 
 function matchingAudience(
-    xsuaaCredentials: XsuaaServiceCredentials[],
-    token: JwtPayload
+  xsuaaCredentials: XsuaaServiceCredentials[],
+  token: JwtPayload
 ): XsuaaServiceCredentials[] {
   return xsuaaCredentials.filter(credentials =>
-      audiences(token).has(credentials.xsappname)
+    audiences(token).has(credentials.xsappname)
   );
 }
 

--- a/packages/core/src/connectivity/scp-cf/environment-accessor.ts
+++ b/packages/core/src/connectivity/scp-cf/environment-accessor.ts
@@ -271,9 +271,9 @@ function selectWithoutJwt(
   logger.warn(
     `The following XSUAA instances are bound: ${xsuaaServices.map(
       x => x.credentials.xsappname
-    )} and no JWT is given to decide which one to use. The following one will be selected: ${
-      xsuaaServices[0].credentials.xsappname
-    }`
+    )} and no JWT is given to decide which one to use. Choosing the first one (xsappname: ${
+      first(xsuaaServices)!.credentials.xsappname
+    }).`
   );
   return xsuaaServices[0].credentials;
 }
@@ -298,7 +298,9 @@ function selectViaJwt(
 
   if (selected.length > 1) {
     logger.warn(
-      `Multiple XSUAA instances could be matched to the given JWT! Choosing the first one (xsappname: ${
+      `Multiple XSUAA instances could be matched to the given JWT: ${xsuaaServices.map(
+        x => x.credentials.xsappname
+      )}. Choosing the first one (xsappname: ${
         first(selected)!.credentials.xsappname
       }).`
     );
@@ -331,7 +333,6 @@ function matchingAudience(
     audiences(token).has(xsuaa.credentials.xsappname)
   );
 }
-
 
 interface BasicCredentials {
   clientid: string;

--- a/packages/core/src/connectivity/scp-cf/environment-accessor.ts
+++ b/packages/core/src/connectivity/scp-cf/environment-accessor.ts
@@ -324,9 +324,10 @@ function selectXsuaaInstanceWithJwt(
 
   if (xsuaaCredentials.length > 1) {
     logger.warn(
-      `Multiple XSUAA instances present and selection via JWT did not narrow it down: ${xsuaaCredentials.map(
-        x => x.xsappname
-      )}. Choosing the first one (xsappname: ${first(selected)!.xsappname}).`
+      `Multiple XSUAA instances found: ${xsuaaCredentials.map(
+        x => `\n\t- ${x.xsappname}`
+      )}
+      None of those match either client id or audience from the given JWT. Choosing the first one (xsappname: "${first(selected)!.xsappname}").`
     );
     return selected[0];
   }

--- a/packages/core/src/connectivity/scp-cf/environment-accessor.ts
+++ b/packages/core/src/connectivity/scp-cf/environment-accessor.ts
@@ -287,10 +287,11 @@ function selectXsuaaInstanceWithoutJwt(
   if (xsuaaCredentials.length > 1) {
     logger.warn(
       `The following XSUAA instances are bound: ${xsuaaCredentials.map(
-        x => x.xsappname
-      )} and no JWT is given to decide which one to use. Choosing the first one (xsappname: ${
+        x => `\n\t- {x.xsappname}`
+      )}
+      No JWT given to select XSUAA instance. Choosing the first one (xsappname: "${
         first(xsuaaCredentials)!.xsappname
-      }).`
+      }").`
     );
     return xsuaaCredentials[0];
   }

--- a/packages/core/src/connectivity/scp-cf/environment-accessor.ts
+++ b/packages/core/src/connectivity/scp-cf/environment-accessor.ts
@@ -259,10 +259,7 @@ function selectXsuaaInstance(token?: JwtPayload): XsuaaServiceCredentials {
     );
   }
 
-  if (token) {
-    return selectXsuaaInstanceWithJwt(xsuaaCredentials, token);
-  }
-  return selectXsuaaInstanceWithoutJwt(xsuaaCredentials);
+return token ? selectXsuaaInstanceWithJwt(xsuaaCredentials, token) : selectXsuaaInstanceWithoutJwt(xsuaaCredentials);
 }
 
 function handleOneXsuuaInstance(

--- a/packages/core/src/connectivity/scp-cf/jwt.ts
+++ b/packages/core/src/connectivity/scp-cf/jwt.ts
@@ -351,21 +351,6 @@ export function readPropertyWithWarn(
 }
 
 /**
- * Fetches the URL from the JWT header which exposes the verification key for that JWT.
- * @param token - Encoded JWT as a string.
- * @returns The value of the `jku` property of the JWT header.
- */
-function getVerificationKeyUrl(token: string): string {
-  const decodedJwt = decodeJwtComplete(token);
-  if (!decodedJwt.header.jku || !decodedJwt.header.kid) {
-    throw new Error(
-      'JWT does not contain verification key URL (`jku`) and/or key ID (`kid`).'
-    );
-  }
-  return decodedJwt.header.jku;
-}
-
-/**
  * @deprecated Since v1.46.0. This interface will not be replaced. Use the higher level JWT types directly.
  * Interface to represent the registered claims of a JWT.
  */

--- a/packages/core/src/connectivity/scp-cf/token-accessor.ts
+++ b/packages/core/src/connectivity/scp-cf/token-accessor.ts
@@ -43,7 +43,7 @@ export async function serviceToken(
 
   service = resolveService(service);
   const serviceCredentials = service.credentials;
-  const xsuaa = multiTenantXsuaaCredentials({ ...options });
+  const xsuaa = multiTenantXsuaaCredentials(options);
 
   if (opts.useCache) {
     const cachedToken = clientCredentialsTokenCache.getGrantTokenFromCache(
@@ -145,10 +145,12 @@ export async function jwtBearerToken(
   return getUserToken(resolvedService, userJwt, opts);
 }
 
-function multiTenantXsuaaCredentials(options: {
-  userJwt?: string | JwtPayload;
-  xsuaaCredentials?: XsuaaServiceCredentials;
-}): XsuaaServiceCredentials {
+function multiTenantXsuaaCredentials(
+  options: {
+    userJwt?: string | JwtPayload;
+    xsuaaCredentials?: XsuaaServiceCredentials;
+  } = {}
+): XsuaaServiceCredentials {
   const xsuaa = options.xsuaaCredentials
     ? { ...options.xsuaaCredentials }
     : getXsuaaServiceCredentials(options.userJwt);

--- a/packages/core/src/connectivity/scp-cf/token-accessor.ts
+++ b/packages/core/src/connectivity/scp-cf/token-accessor.ts
@@ -8,7 +8,7 @@ import {
   getXsuaaServiceCredentials,
   resolveService
 } from './environment-accessor';
-import { Service } from './environment-accessor-types';
+import { Service, XsuaaServiceCredentials } from './environment-accessor-types';
 import { ResilienceOptions } from './resilience-options';
 import { replaceSubdomain } from './subdomain-replacer';
 import { refreshTokenGrant, userTokenGrant } from './legacy/xsuaa-service';
@@ -31,6 +31,8 @@ export async function serviceToken(
   options?: CachingOptions &
     ResilienceOptions & {
       userJwt?: string | JwtPayload;
+      // TODO 2.0 Once the xssec supports caching remove all xsuaa related content here
+      xsuaaCredentials?: XsuaaServiceCredentials;
     }
 ): Promise<string> {
   const opts = {
@@ -41,7 +43,7 @@ export async function serviceToken(
 
   service = resolveService(service);
   const serviceCredentials = service.credentials;
-  const xsuaa = multiTenantXsuaaCredentials(opts.userJwt);
+  const xsuaa = multiTenantXsuaaCredentials({ ...options });
 
   if (opts.useCache) {
     const cachedToken = clientCredentialsTokenCache.getGrantTokenFromCache(
@@ -102,7 +104,7 @@ export async function userApprovedServiceToken(
     ...options
   };
 
-  const xsuaa = multiTenantXsuaaCredentials(userJwt);
+  const xsuaa = multiTenantXsuaaCredentials({ userJwt });
   const serviceCreds = extractClientCredentials(resolvedService.credentials);
 
   return userTokenGrant(xsuaa, userJwt, serviceCreds.username, opts)
@@ -143,12 +145,19 @@ export async function jwtBearerToken(
   return getUserToken(resolvedService, userJwt, opts);
 }
 
-function multiTenantXsuaaCredentials(userJwt?: string | JwtPayload) {
-  const xsuaa = getXsuaaServiceCredentials(userJwt);
+function multiTenantXsuaaCredentials(options: {
+  userJwt?: string | JwtPayload;
+  xsuaaCredentials?: XsuaaServiceCredentials;
+}): XsuaaServiceCredentials {
+  const xsuaa = options.xsuaaCredentials
+    ? { ...options.xsuaaCredentials }
+    : getXsuaaServiceCredentials(options.userJwt);
 
-  if (userJwt) {
+  if (options.userJwt) {
     const decodedJwt =
-      typeof userJwt === 'string' ? decodeJwt(userJwt) : userJwt;
+      typeof options.userJwt === 'string'
+        ? decodeJwt(options.userJwt)
+        : options.userJwt;
 
     if (!decodedJwt.iss) {
       throw Error('Property `iss` is missing in the provided user token.');

--- a/packages/core/src/odata-common/entity.ts
+++ b/packages/core/src/odata-common/entity.ts
@@ -37,8 +37,7 @@ export type EntityBuilderType<EntityT extends Entity, EntityTypeT> = {
   [property in keyof Required<EntityTypeT>]: (
     value: EntityTypeT[property]
   ) => EntityBuilderType<EntityT, EntityTypeT>;
-} &
-  EntityBuilder<EntityT, EntityTypeT>;
+} & EntityBuilder<EntityT, EntityTypeT>;
 
 /**
  * Super class for all representations of OData entity types.

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -137,7 +137,7 @@ describe('OAuth flows', () => {
     expect(result.length).toBe(1);
   }, 60000);
 
-  it('OAuth2ClientCredentials: Provider Destination & Provider Jwt', async () => {
+  xit('OAuth2ClientCredentials: Provider Destination & Provider Jwt', async () => {
     const clientGrant = await serviceToken('destination', {
       userJwt: accessToken.provider
     });

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -137,7 +137,7 @@ describe('OAuth flows', () => {
     expect(result.length).toBe(1);
   }, 60000);
 
-  xit('OAuth2ClientCredentials: Provider Destination & Provider Jwt', async () => {
+  it('OAuth2ClientCredentials: Provider Destination & Provider Jwt', async () => {
     const clientGrant = await serviceToken('destination', {
       userJwt: accessToken.provider
     });


### PR DESCRIPTION
Please provide a description of what your change does and why it is needed.

Closes SAP/cloud-sdk-backlog#314.

We called the `getXsuaaServiceCredentials()` multiple times in the destination-from-service.ts. This alone would be only inefficient. However, since in one case we made a call without a JWT there was no way to avoid the warning: `Could not match XSUAA instance`. This PR reduces the number of calls and also reduces the number of logs or the level. 

Note that the current XSUAA instance is mainly used to the get URL for caching. Once the xssec supports cache options this can all go away.