### PR TITLE
feature: Auth token forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ## New Functionality
 
--
+- [connectivity] Allow token forwarding for local destination stored in the environment variables.
 
 ## Improvements
 

--- a/packages/core/src/connectivity/scp-cf/destination/destination-accessor.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-accessor.ts
@@ -9,7 +9,7 @@ import {
 import { searchEnvVariablesForDestination } from './destination-from-env';
 import { searchServiceBindingForDestination } from './destination-from-vcap';
 import { getDestinationFromDestinationService } from './destination-from-service';
-import { DestinationAccessorOptions } from './destination-accessor-types';
+import type { DestinationAccessorOptions } from './destination-accessor-types';
 
 /**
  * Returns the parameter if it is a destination, calls [[getDestination]] otherwise (which will try to fetch the destination

--- a/packages/core/src/connectivity/scp-cf/destination/destination-accessor.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-accessor.ts
@@ -77,7 +77,7 @@ export async function getDestination(
   options: DestinationOptions = {}
 ): Promise<Destination | null> {
   return (
-    searchEnvVariablesForDestination(name) ||
+    searchEnvVariablesForDestination(name, options) ||
     searchServiceBindingForDestination(name) ||
     getDestinationFromDestinationService(name, options)
   );

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-env.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-env.ts
@@ -10,8 +10,11 @@ import {
   isDestinationConfiguration,
   parseDestination
 } from './destination';
-import { Destination, DestinationAuthToken } from './destination-service-types';
-import { DestinationOptions } from './destination-accessor';
+import type {
+  Destination,
+  DestinationAuthToken
+} from './destination-service-types';
+import type { DestinationOptions } from './destination-accessor';
 
 const logger = createLogger({
   package: 'core',

--- a/packages/core/src/connectivity/scp-cf/destination/destination-service-types.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-service-types.ts
@@ -145,6 +145,11 @@ export interface Destination {
    * The keys of this object denote the names of the query parameters and the values their values.
    */
   queryParameters?: Record<string, any>;
+
+  /**
+   * If set to true the auth token provided to the request execution is forwarded to the destination target.
+   */
+  forwardAuthToken?: boolean;
 }
 
 /**


### PR DESCRIPTION
Please provide a description of what your change does and why it is needed.

Closes SAP/cloud-sdk-backlog#286.

Enables the `forwardAuthToken` on the enviorment destinations as the [approuter](https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/3cc788ebc00e40a091505c6b3fa485e7.html) also allows it.