### PR TITLE
chore: run windows test and archive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,38 +35,6 @@ jobs:
           SANDBOX_TOKEN: ${{ secrets.API_HUB_SANDBOX_TOKEN }}
       - run: yarn test:integration
       - run: yarn test:type
-  tests-windows:
-    runs-on: ${{ matrix.os }}
-    continue-on-error: true
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        os: [windows-latest]
-        node-version: [12.x]
-    steps:
-      - uses: actions/checkout@v2
-      - run: git fetch --depth=1
-      - uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v2
-        id: cache
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-      - run: yarn test:unit -- -- --no-bail -- -- -- --json --outputFile=unit-test-output.json
-      - run: yarn test:integration --json --outputFile=int-test-output.json
-        if: always()
-      - run: yarn test:type
-      - name: Archive results
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: windows-test-results
-          path: '*packages/**/*-test-output.json'
   checks:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,38 @@ jobs:
           SANDBOX_TOKEN: ${{ secrets.API_HUB_SANDBOX_TOKEN }}
       - run: yarn test:integration
       - run: yarn test:type
+  tests-windows:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        os: [windows-latest]
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --depth=1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn test:unit -- -- --no-bail -- -- -- --json --outputFile=unit-test-output.json
+      - run: yarn test:integration --json --outputFile=int-test-output.json
+        if: always()
+      - run: yarn test:type
+      - name: Archive results
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: windows-test-results
+          path: '*packages/**/*-test-output.json'
   checks:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -1,0 +1,40 @@
+name: windows-tests
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  test-windows:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        os: [windows-latest]
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --depth=1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn test:unit -- -- --no-bail -- -- -- --json --outputFile=unit-test-output.json
+      - run: yarn test:integration --json --outputFile=int-test-output.json
+        if: always()
+      - run: yarn test:type
+      - name: Archive results
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: windows-test-results
+          path: '*packages/**/*-test-output.json'

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -7,7 +7,7 @@ on:
       - 'docs/**'
 
 jobs:
-  test-windows:
+  tests:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -38,3 +38,4 @@ jobs:
         with:
           name: windows-test-results
           path: '*packages/**/*-test-output.json'
+          retention-days: 30

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "postinstall": "yarn compile && yarn run readme",
     "test": "yarn workspaces run test",
-    "test:unit": "yarn lerna run test --ignore \"@sap-cloud-sdk/integration-tests\" --ignore \"@sap-cloud-sdk/type-tests\" --ignore \"@sap-cloud-sdk/e2e-tests\" --ignore \"@sap-cloud-sdk/nightly-tests\"",
+    "test:unit": "yarn lerna run test -- --ignore \"@sap-cloud-sdk/integration-tests\" --ignore \"@sap-cloud-sdk/type-tests\" --ignore \"@sap-cloud-sdk/e2e-tests\" --ignore \"@sap-cloud-sdk/nightly-tests\"",
     "test:integration": "yarn integration-tests test",
     "test:type": "yarn type-tests test",
     "test:e2e": "yarn e2e-tests test",


### PR DESCRIPTION
Please provide a description of what your change does and why it is needed.

Closes SAP/cloud-sdk-backlog#304

Added new tests-windows workflow to run the tests on windows and archive the results on failure.

Adjusted `test:unit` script to pass `--ignore` workspaces correctly to lerna on windows. Added `--json --outputFile=unit-test-output.json` to jest which outputs the test results within each workspace.

