### PR TITLE
fix: datetimeoffset ts error on creating filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- [core] Fix TypeScript error, when `moment()` is used in filtering an OData field of type `Edm.DateTimeOffset`
 
 
 # 1.49.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
-- [core] Fix TypeScript error, when `moment()` is used in filtering an OData field of type `Edm.DateTimeOffset`
+- [core] Fix a type error, when `moment()` is used in filtering an OData field of type `Edm.DateTimeOffset`
 
 
 # 1.49.0

--- a/packages/core/src/odata-common/selectable/edm-type-field.ts
+++ b/packages/core/src/odata-common/selectable/edm-type-field.ts
@@ -53,6 +53,8 @@ type NonNullableFieldTypeByEdmType<
   ? number
   : EdmOrFieldT extends 'Edm.DateTime'
   ? moment.Moment
+  : EdmOrFieldT extends 'Edm.DateTimeOffset'
+  ? moment.Moment
   : EdmOrFieldT extends 'Edm.Time'
   ? Time
   : EdmOrFieldT extends 'Edm.Date'

--- a/packages/core/src/odata-common/selectable/orderable-edm-type-field.spec.ts
+++ b/packages/core/src/odata-common/selectable/orderable-edm-type-field.spec.ts
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import {
   TestComplexTypeField,
   TestEntity
@@ -53,6 +54,35 @@ describe('Number Field', () => {
     it('should create filter for "greaterOrEqual"', () => {
       const filter = field.greaterOrEqual(filterValue);
       checkFilter(filter, fieldName, 'ge', filterValue);
+    });
+  });
+
+  describe('DateTime and DateTimeOffset fields', () => {
+    const dateFilterValue = moment(1425427200000);
+    const datetimefieldName = 'DateTimeProperty';
+    const datetimeOffsetfieldName = 'DateTimeOffSetProperty';
+
+    it('should create filter for type DateTimeOffset by passing moment() ', () => {
+      const filter = TestEntity.DATE_TIME_OFF_SET_PROPERTY.equals(moment());
+      expect(moment.isMoment(filter.value)).toBe(true);
+    });
+
+    it('should create filter for equals for type Edm.DateTime', () => {
+      const filter = TestEntity.DATE_TIME_PROPERTY.equals(
+        moment(1425427200000)
+      );
+      expect(filter.field).toBe(datetimefieldName);
+      expect(filter.operator).toBe('eq');
+      expect(filter.value).toEqual(dateFilterValue);
+    });
+
+    it('should create filter for equals for type Edm.DateTimeOffset', () => {
+      const filter = TestEntity.DATE_TIME_OFF_SET_PROPERTY.equals(
+        moment(1425427200000)
+      );
+      expect(filter.field).toBe(datetimeOffsetfieldName);
+      expect(filter.operator).toBe('eq');
+      expect(filter.value).toEqual(dateFilterValue);
     });
   });
 


### PR DESCRIPTION
Please provide a description of what your change does and why it is needed.

Closes SAP/cloud-sdk-backlog#350

Added moment() mapping for `Edm.DateTimeOffset` 