### PR TITLE
fix: Removed warning for custom headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ## Compatibility Notes
 
--
+- [core] Tightened the return type of `getAuthHeaders()` and `buildAuthorizationHeaders()` methods.
 
 ## New Functionality
 
@@ -27,6 +27,7 @@
 ## Fixed Issues
 
 - [core] Fix a type error, when `moment()` is used in filtering an OData field of type `Edm.DateTimeOffset`
+- [core] Fix missing `Proxy-Authorization` header if custom authorization headers are set.
 
 
 # 1.49.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - [core] Fix a type error, when `moment()` is used in filtering an OData field of type `Edm.DateTimeOffset`
 - [core] Fix missing `Proxy-Authorization` header if custom authorization headers are set.
+- [core] Fix warning that custom headers are given and will overwrite destination headers.
 
 
 # 1.49.0


### PR DESCRIPTION
Please provide a description of what your change does and why it is needed.

Closes SAP/cloud-sdk-backlog#74.

We had a warning about `custom headers` which was not correct. We handed actually all headers to the executeRaw method. Not only the custom ones. Since the destination provided headers the warning was triggered . This PR removes this.

It also tightends the types of the `authentication-header.ts`.

I also includes the `Proxy-Authentication` headers if a custom authentication header is provided. 

Debate: I added a `debug` statement which shows the final headers and target. This is meant of you want to have son insight, which header is actually sent. Since this may content auth header I am not sure about this. 