### PR TITLE
chore: add v2 pipeline for releasing `next` versions

### DIFF
--- a/.github/workflows/v2.yaml
+++ b/.github/workflows/v2.yaml
@@ -100,6 +100,6 @@ jobs:
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
           date=`date +%Y%m%d%H%M%S`
-          yarn lerna publish --canary major --no-push --no-git-tag-version --dist-tag next --force-publish --preid "${date}-next" -y
+          yarn lerna publish --canary major --no-push --no-git-tag-version --dist-tag next --force-publish --preid "${date}" -y
         env:
           NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}


### PR DESCRIPTION
This pipeline:
- is triggered when committing to `v2` branch
- will do the `test` step and the `check` step like the `main` branch
- will release a `next` version