### PR TITLE
chore: Add security updates for main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,14 @@ updates:
       time: '01:00'
       timezone: 'Europe/Berlin'
     open-pull-requests-limit: 10
+
+  - package-ecosystem: npm
+    target-branch: main
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '01:00'
+      timezone: 'Europe/Berlin'
+    allowed_updates:
+      - match:
+          update_type: 'security'


### PR DESCRIPTION
Make dependabot operate on `2.0` and on `main` for security updates.