### PR TITLE
chore: Announce upgrade in postinstall

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,13 +20,14 @@
     "dist/**/*.js.map",
     "dist/**/*.d.ts",
     "dist/**/*.d.ts.map",
+    "postinstall.js",
     "usage-analytics.js"
   ],
   "repository": "github:SAP/cloud-sdk-js",
   "scripts": {
     "compile": "yarn tsc -b",
     "prepare": "yarn compile",
-    "postinstall": "node usage-analytics.js",
+    "postinstall": "node postinstall.js",
     "test": "yarn jest",
     "coverage": "yarn jest --coverage",
     "check:dependencies": "depcheck ."

--- a/packages/core/postinstall.js
+++ b/packages/core/postinstall.js
@@ -13,7 +13,10 @@ function printUpgradeAnnouncement() {
       'The SAP Cloud SDK will release new major versions regularly starting in 2022.'
     );
     console.log(
-      'We will ensure that upgrading takes less than one person day of effort.'
+      'A beta version for version 2 is expected to be released in November 2021.'
+    );
+    console.log(
+      'We will ensure that upgrading takes less than one day of effort when using our upgrade guide.'
     );
     console.log(
       'Read more in our announcement post: https://sap.github.io/cloud-sdk/docs/js/announcing-version-2'

--- a/packages/core/postinstall.js
+++ b/packages/core/postinstall.js
@@ -1,0 +1,28 @@
+require('./usage-analytics');
+
+printUpgradeAnnouncement();
+
+function printUpgradeAnnouncement() {
+  if (!process.env.SAP_CLOUD_SDK_SILENT) {
+    /* eslint-disable no-console */
+    console.log('');
+    console.log('============================================');
+    console.log('🚀 SAP Cloud SDK Announcement');
+    console.log('');
+    console.log(
+      'The SAP Cloud SDK will release new major versions regularly starting in 2022.'
+    );
+    console.log(
+      'We will ensure that upgrading takes less than one person day of effort.'
+    );
+    console.log(
+      'Read more in our announcement post: https://sap.github.io/cloud-sdk/docs/js/announcing-version-2'
+    );
+    console.log('');
+    console.log(
+      'Set environment variable SAP_CLOUD_SDK_SILENT to hide this and future announcements.'
+    );
+    console.log('============================================');
+    console.log('');
+  }
+}


### PR DESCRIPTION
This prints the announcement in the postinstall of the core package. I guess this does not need to be part of the 2.0 branch (yet?). I also added a way to disable the message with a env variable.

Closes SAP/cloud-sdk-backlog#230.
