### PR TITLE
fix: windows tests

### DIFF
--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -2,7 +2,7 @@ name: windows-tests
 
 on:
   push:
-    branches: [main]
+    branches: [2.0]
     paths-ignore:
       - 'docs/**'
 

--- a/packages/generator-common/src/compiler.spec.ts
+++ b/packages/generator-common/src/compiler.spec.ts
@@ -177,7 +177,7 @@ describe('compilation', () => {
     await expect(
       transpileDirectory('broken-src', compilerConfig('broken-dist'))
     ).rejects.toThrowError(
-      "broken-src/file.ts:3:4 - error TS2588: Cannot assign to 'foo' because it is a constant"
+      "error TS2588: Cannot assign to 'foo' because it is a constant"
     );
   });
 


### PR DESCRIPTION
The issue was caused by windows error message handling, our test tested the concrete error message that looks like this on mac:

```
broken-src/file.ts:3:4 - error TS2588: Cannot assign to 'foo' because it is a constant
```

but it looks like this on windows:

```
Compilation Errors:·\n    D:/a/cloud-sdk-js/cloud-sdk-js/packages/generator-common/broken-src/file.ts:3:5 - error TS2588: Cannot assign to 'foo' because it is a constant.
```

Closes SAP/cloud-sdk-backlog#305.

