### PR TITLE
fix: windows tests

### DIFF
--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -2,7 +2,7 @@ name: windows-tests
 
 on:
   push:
-    branches: [main]
+    branches: [2.0]
     paths-ignore:
       - 'docs/**'
 

--- a/packages/generator-common/src/compiler.spec.ts
+++ b/packages/generator-common/src/compiler.spec.ts
@@ -177,7 +177,7 @@ describe('compilation', () => {
     await expect(
       transpileDirectory('broken-src', compilerConfig('broken-dist'))
     ).rejects.toThrowError(
-      "broken-src/file.ts:3:4 - error TS2588: Cannot assign to 'foo' because it is a constant"
+      "error TS2588: Cannot assign to 'foo' because it is a constant"
     );
   });
 

--- a/packages/openapi-generator/src/options/generator-options.spec.ts
+++ b/packages/openapi-generator/src/options/generator-options.spec.ts
@@ -173,7 +173,8 @@ describe('parseGeneratorOptions', () => {
     });
     const parsed = await parseOptionsFromConfig(parameters.config);
     expect(parsed.input).toContain(config.input);
-    expect(parsed.include).toEqual(['/path/config.json', '/path/README.md']);
+    // RegEx to match paths for both *nix and Windows
+    expect(parsed.include).toMatchObject([expect.stringMatching('.*path.*config.json.*'), expect.stringMatching('.*path.*README.md.*')]);
   });
 
   it('logs a warning if wrong configuration keys were used', async () => {

--- a/packages/openapi-generator/src/options/generator-options.spec.ts
+++ b/packages/openapi-generator/src/options/generator-options.spec.ts
@@ -174,7 +174,10 @@ describe('parseGeneratorOptions', () => {
     const parsed = await parseOptionsFromConfig(parameters.config);
     expect(parsed.input).toContain(config.input);
     // RegEx to match paths for both *nix and Windows
-    expect(parsed.include).toMatchObject([expect.stringMatching('.*path.*config.json.*'), expect.stringMatching('.*path.*README.md.*')]);
+    expect(parsed.include).toMatchObject([
+      expect.stringMatching('.*path.*config.json.*'),
+      expect.stringMatching('.*path.*README.md.*')
+    ]);
   });
 
   it('logs a warning if wrong configuration keys were used', async () => {


### PR DESCRIPTION
Closes SAP/cloud-sdk-backlog#305.

Another test that checks for a path, which is displayed differently in windows, is fixed with this new regex approach.


Issue Example:

Mac:
```
/path/config.json
```

Windows:
```
D:\\\\path\\\\config.json\
```

