### PR TITLE
fix: batch DELETE response error 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- [core] Fix parsing of batch response with HTTP 200 status code and containing empty body.
 
 
 # 1.51.0

--- a/packages/core/src/odata-common/request-builder/batch/batch-response-parser.spec.ts
+++ b/packages/core/src/odata-common/request-builder/batch/batch-response-parser.spec.ts
@@ -272,8 +272,8 @@ describe('batch response parser', () => {
         'Content-Length: 71,',
         'content-transfer-encoding: binary',
         '',
-        'HTTP/1.1 200 Success',
-        'Content-Length: 0',
+        'HTTP/1.1 200 OK',
+        'Content-Length: 10',
         'dataserviceversion: 2.0',
         '',
         '{"valid": "json"}',
@@ -306,6 +306,41 @@ describe('batch response parser', () => {
         headers: {
           'content-type':
             'multipart/mixed; boundary=3B17E95920A7FAF8BCB7495D043515000'
+        }
+      } as HttpResponse;
+      const logger = createLogger({
+        messageContext: 'batch-response-parser'
+      });
+      const errorSpy = jest.spyOn(logger, 'error');
+      parseBatchResponse(batchResponse);
+      expect(errorSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('parses a batch response with HTTP 200 and empty body', () => {
+      const data = [
+        '--batch_89b52e20-aee8-46c8-8fda-a74b4684191b',
+        'Content-Type: multipart/mixed; boundary=changeset_3ff17c33-5fcf-4b0a-ab17-84917374e43e',
+        '',
+        '--changeset_3ff17c33-5fcf-4b0a-ab17-84917374e43e',
+        'Content-Type: application/http',
+        'Content-Transfer-Encoding: binary',
+        '',
+        'HTTP/1.1 200 OK',
+        'DataServiceVersion: 1.0',
+        'Content-Length: 0',
+        '',
+        '',
+        '',
+        '--changeset_3ff17c33-5fcf-4b0a-ab17-84917374e43e--',
+        '',
+        '--batch_89b52e20-aee8-46c8-8fda-a74b4684191b--'
+      ].join(unixEOL);
+      const batchResponse = {
+        data,
+        status: 200,
+        headers: {
+          'content-type':
+            'multipart/mixed; boundary=batch_89b52e20-aee8-46c8-8fda-a74b4684191b'
         }
       } as HttpResponse;
       const logger = createLogger({

--- a/packages/core/src/odata-common/request-builder/batch/batch-response-parser.ts
+++ b/packages/core/src/odata-common/request-builder/batch/batch-response-parser.ts
@@ -126,7 +126,9 @@ export function splitResponse(response: string, boundary: string): string[] {
   const newLineSymbol = detectNewLineSymbol(response);
   const parts = response.split(`--${boundary}`).map(part => {
     const trimmedPart = part.trim();
-    return trimmedPart.includes('204 No Content')
+    return trimmedPart.includes('204 No Content') ||
+      (trimmedPart.includes('200 OK') &&
+        trimmedPart.includes('Content-Length: 0'))
       ? `${trimmedPart}${newLineSymbol}`
       : trimmedPart;
   });


### PR DESCRIPTION
Please provide a description of what your change does and why it is needed.

Closes SAP/cloud-sdk-backlog#413

If the response is HTTP 200 OK but the body is empty (delete request SF), all the empty lines after headers are trimmed (including body) and `getResponseBody` returns the last item in array, which happens to be the header and results in invalid json error. Added a check for HTTP 200 OK and Content-Length: 0 to also append an empty line at the end. 

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
