### PR TITLE
Fix: destination cache vulnerablity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ## Compatibility Notes
 
--
+- [core] Switch the default isolation strategy from `IsolationStrategy.Tenant` to `IsolationStrategy.Tenant_User`, when setting `useCache` to true for destination lookup functions like `getDestination`.
 
 ## New Functionality
 
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- [core] Disable destination cache, when the JWT does not contain necessary information. For example, when using `IsolationStrategy.Tenant_User`, the JWT has to contain both tenant id and user id.
 
 
 # 1.51.0

--- a/packages/core/src/connectivity/scp-cf/cache.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/cache.spec.ts
@@ -86,4 +86,10 @@ describe('Cache', () => {
     expect(cacheTwo.get('expiredToken')).toBeUndefined();
     expect(cacheTwo.get('validToken')).toBe(dummyToken);
   });
+
+  it('should not hit cache for undefined key', () => {
+    cacheOne.set(undefined, {} as Destination)
+    const actual = cacheOne.get(undefined);
+    expect(actual).toBeUndefined();
+  });
 });

--- a/packages/core/src/connectivity/scp-cf/cache.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/cache.spec.ts
@@ -88,7 +88,7 @@ describe('Cache', () => {
   });
 
   it('should not hit cache for undefined key', () => {
-    cacheOne.set(undefined, {} as Destination)
+    cacheOne.set(undefined, {} as Destination);
     const actual = cacheOne.get(undefined);
     expect(actual).toBeUndefined();
   });

--- a/packages/core/src/connectivity/scp-cf/cache.ts
+++ b/packages/core/src/connectivity/scp-cf/cache.ts
@@ -92,7 +92,7 @@ export class Cache<T> implements CacheInterface<T> {
    * @param expirationTime - The time expressed in UTC in which the given entry expires
    */
   set(key: string | undefined, entry: T, expirationTime?: number): void {
-    if(key) {
+    if (key) {
       const expires = expirationTime
         ? moment(expirationTime)
         : inferExpirationTime(this.defaultValidityTime);

--- a/packages/core/src/connectivity/scp-cf/cache.ts
+++ b/packages/core/src/connectivity/scp-cf/cache.ts
@@ -79,8 +79,8 @@ export class Cache<T> implements CacheInterface<T> {
    * @param key - The key of the entry to retrieve.
    * @returns The corresponding entry to the provided key if it is still valid, returns `undefined` otherwise.
    */
-  get(key: string): T | undefined {
-    return this.hasKey(key) && !isExpired(this.cache[key])
+  get(key: string | undefined): T | undefined {
+    return key && this.hasKey(key) && !isExpired(this.cache[key])
       ? this.cache[key].entry
       : undefined;
   }
@@ -91,11 +91,13 @@ export class Cache<T> implements CacheInterface<T> {
    * @param entry - The entry to cache
    * @param expirationTime - The time expressed in UTC in which the given entry expires
    */
-  set(key: string, entry: T, expirationTime?: number): void {
-    const expires = expirationTime
-      ? moment(expirationTime)
-      : inferExpirationTime(this.defaultValidityTime);
-    this.cache[key] = { entry, expires };
+  set(key: string | undefined, entry: T, expirationTime?: number): void {
+    if(key) {
+      const expires = expirationTime
+        ? moment(expirationTime)
+        : inferExpirationTime(this.defaultValidityTime);
+      this.cache[key] = { entry, expires };
+    }
   }
 }
 

--- a/packages/core/src/connectivity/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-cache.spec.ts
@@ -152,12 +152,14 @@ describe('caching destination integration tests', () => {
       const c3 = getSubscriberCache(IsolationStrategy.User);
       const c4 = getProviderCache(IsolationStrategy.No_Isolation);
       const c5 = getSubscriberCache(IsolationStrategy.Tenant_User);
+      const c6 = getProviderCache(IsolationStrategy.Tenant_User);
 
-      expect(c1!.url).toBe('https://subscriber.example');
+      expect(c1).toBeUndefined();
       expect(c2).toBeUndefined();
       expect(c3).toBeUndefined();
       expect(c4).toBeUndefined();
-      expect(c5).toBeUndefined();
+      expect(c5!.url).toBe('https://subscriber.example');
+      expect(c6).toBeUndefined();
     });
 
     it('retrieved  provider destinations are cached using only destination name in "NoIsolation" type', async () => {

--- a/packages/core/src/connectivity/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-cache.spec.ts
@@ -519,6 +519,10 @@ describe('caching destination integration tests', () => {
 });
 
 describe('caching destination unit tests', () => {
+  beforeEach(() => {
+    destinationCache.clear();
+  });
+
   it('should cache the destination correctly', () => {
     const dummyJwt = { user_id: 'user', zid: 'tenant' };
     destinationCache.cacheRetrievedDestination(

--- a/packages/core/src/connectivity/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-cache.spec.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import { createLogger } from '@sap-cloud-sdk/util';
 import { IsolationStrategy } from '../cache';
 import { decodeJwt, wrapJwtInHeader } from '../jwt';
 import {
@@ -37,11 +38,13 @@ import {
   alwaysSubscriber,
   subscriberFirst
 } from './destination-selection-strategies';
-import { destinationCache, getDestinationCacheKeyStrict } from './destination-cache';
+import {
+  destinationCache,
+  getDestinationCacheKeyStrict
+} from './destination-cache';
 import { AuthenticationType, Destination } from './destination-service-types';
 import { getDestinationFromDestinationService } from './destination-from-service';
 import { parseDestination } from './destination';
-import { createLogger } from '@sap-cloud-sdk/util';
 
 const destinationOne: Destination = {
   url: 'https://destination1.example',
@@ -636,13 +639,14 @@ describe('caching destination unit tests', () => {
   });
 });
 
-
 describe('get destination cache key', () => {
   it('should shown warning, when Tenant_User is chosen, but user id is missing', () => {
     const logger = createLogger('destination-cache');
     const warn = jest.spyOn(logger, 'warn');
 
-    getDestinationCacheKeyStrict({ zid: 'tenant' },'dest');
-    expect(warn).toBeCalledWith('Cannot get cache key. Isolation strategy TenantUser is used, but tenant id or user id is undefined.');
+    getDestinationCacheKeyStrict({ zid: 'tenant' }, 'dest');
+    expect(warn).toBeCalledWith(
+      'Cannot get cache key. Isolation strategy TenantUser is used, but tenant id or user id is undefined.'
+    );
   });
-})
+});

--- a/packages/core/src/connectivity/scp-cf/destination/destination-cache.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-cache.ts
@@ -1,9 +1,9 @@
+import { createLogger } from '@sap-cloud-sdk/util';
 import { Cache, IsolationStrategy } from '../cache';
 import { tenantId } from '../tenant';
 import { userId } from '../user';
 import { Destination } from './destination-service-types';
 import { DestinationsByType } from './destination-accessor-types';
-import { createLogger } from '@sap-cloud-sdk/util';
 
 const logger = createLogger({
   package: 'core',
@@ -55,7 +55,7 @@ const DestinationCache = (cache: Cache<Destination>) => ({
 export function getDestinationCacheKeyStrict(
   decodedJwt: Record<string, any>,
   destinationName: string,
-  isolationStrategy = IsolationStrategy.Tenant_User,
+  isolationStrategy = IsolationStrategy.Tenant_User
 ): string | undefined {
   const tenant = tenantId(decodedJwt);
   const user = userId(decodedJwt);
@@ -63,25 +63,33 @@ export function getDestinationCacheKeyStrict(
     case IsolationStrategy.No_Isolation:
       return `::${destinationName}`;
     case IsolationStrategy.Tenant:
-      if(tenant){
+      if (tenant) {
         return `${tenant}::${destinationName}`;
       }
-      logger.warn(`Cannot get cache key. Isolation strategy ${isolationStrategy} is used, but tenant id is undefined.`);
+      logger.warn(
+        `Cannot get cache key. Isolation strategy ${isolationStrategy} is used, but tenant id is undefined.`
+      );
       return;
     case IsolationStrategy.User:
-      if(user){
+      if (user) {
         return `:${user}:${destinationName}`;
       }
-      logger.warn(`Cannot get cache key. Isolation strategy ${isolationStrategy} is used, but user id is undefined.`);
+      logger.warn(
+        `Cannot get cache key. Isolation strategy ${isolationStrategy} is used, but user id is undefined.`
+      );
       return;
     case IsolationStrategy.Tenant_User:
-      if(tenant && user){
+      if (tenant && user) {
         return `${user}:${tenant}:${destinationName}`;
       }
-      logger.warn(`Cannot get cache key. Isolation strategy ${isolationStrategy} is used, but tenant id or user id is undefined.`);
+      logger.warn(
+        `Cannot get cache key. Isolation strategy ${isolationStrategy} is used, but tenant id or user id is undefined.`
+      );
       return;
     default:
-      logger.warn(`Cannot get cache key. Isolation strategy ${isolationStrategy} is not supported.`);
+      logger.warn(
+        `Cannot get cache key. Isolation strategy ${isolationStrategy} is not supported.`
+      );
       return;
   }
 }
@@ -124,7 +132,11 @@ function cacheRetrievedDestination(
     throw new Error('The destination name is undefined.');
   }
 
-  const key = getDestinationCacheKeyStrict(decodedJwt, destination.name, isolation);
+  const key = getDestinationCacheKeyStrict(
+    decodedJwt,
+    destination.name,
+    isolation
+  );
   cache.set(key, destination);
 }
 

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
@@ -205,7 +205,7 @@ class DestinationFromServiceRetriever {
     readonly providerClientCredentialsToken: JwtPair
   ) {
     const defaultOptions = {
-      isolationStrategy: IsolationStrategy.Tenant,
+      isolationStrategy: IsolationStrategy.Tenant_User,
       selectionStrategy: subscriberFirst,
       useCache: false,
       ...options

--- a/packages/core/src/connectivity/scp-cf/destination/destination-service-cache.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-service-cache.ts
@@ -1,7 +1,7 @@
 import { JwtPayload } from 'jsonwebtoken';
 import { Cache, IsolationStrategy } from '../cache';
 import { Destination } from './destination-service-types';
-import { getDestinationCacheKey } from './destination-cache';
+import { getDestinationCacheKey, getDestinationCacheKeyStrict } from './destination-cache';
 
 const DestinationServiceCache = (cache: Cache<Destination[]>) => ({
   retrieveDestinationsFromCache: (
@@ -37,14 +37,14 @@ function getDestinationCacheKeyService(
   destinationServiceUri: string,
   decodedJwt: JwtPayload,
   isolationStrategy?: IsolationStrategy
-): string {
+): string | undefined {
   const usedIsolationStrategy =
     isolationStrategy === IsolationStrategy.Tenant ||
     isolationStrategy === IsolationStrategy.Tenant_User
       ? isolationStrategy
       : IsolationStrategy.Tenant;
 
-  return getDestinationCacheKey(
+  return getDestinationCacheKeyStrict(
     decodedJwt,
     destinationServiceUri,
     usedIsolationStrategy

--- a/packages/core/src/connectivity/scp-cf/destination/destination-service-cache.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-service-cache.ts
@@ -1,7 +1,7 @@
 import { JwtPayload } from 'jsonwebtoken';
 import { Cache, IsolationStrategy } from '../cache';
 import { Destination } from './destination-service-types';
-import { getDestinationCacheKey, getDestinationCacheKeyStrict } from './destination-cache';
+import { getDestinationCacheKeyStrict } from './destination-cache';
 
 const DestinationServiceCache = (cache: Cache<Destination[]>) => ({
   retrieveDestinationsFromCache: (


### PR DESCRIPTION
- Switch the default isolation strategy from `IsolationStrategy.Tenant` to `IsolationStrategy.Tenant_User`, when setting `useCache` to true for destination lookup functions like `getDestination`.
-  Disable destination cache, when the JWT does not contain necessary information. For example, when using `IsolationStrategy.Tenant_User`, the JWT has to contain both tenant id and user id.

Closes SAP/cloud-sdk-backlog#438
Closes SAP/cloud-sdk-backlog#439

