### PR TITLE
fix: Overwrite default expiration times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@
 ## Fixed Issues
 
 - [core] Disable destination cache, when the JWT does not contain necessary information. For example, when using `IsolationStrategy.Tenant_User`, the JWT has to contain both tenant id and user id.
-- [core] Provider token used in retrieving destination from cache.
+- [core] Use provider token to retrieve destinations from cache.
+- [core] Overwrite default expiration time of the destination cache with the expiration time of its auth tokens, if available.
 
 
 # 1.51.0

--- a/packages/core/src/connectivity/scp-cf/destination/destination-cache.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-cache.ts
@@ -139,7 +139,9 @@ function cacheRetrievedDestination(
     isolation
   );
   const expiresIn = first(destination.authTokens || [])?.expiresIn;
-  const expirationTime = expiresIn ? moment().add(expiresIn, 'second').unix() * 1000 : undefined;
+  const expirationTime = expiresIn
+    ? moment().add(expiresIn, 'second').unix() * 1000
+    : undefined;
   cache.set(key, destination, expirationTime);
 }
 

--- a/packages/core/src/connectivity/scp-cf/destination/destination-cache.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-cache.ts
@@ -1,4 +1,5 @@
-import { createLogger } from '@sap-cloud-sdk/util';
+import { createLogger, first } from '@sap-cloud-sdk/util';
+import moment from 'moment';
 import { Cache, IsolationStrategy } from '../cache';
 import { tenantId } from '../tenant';
 import { userId } from '../user';
@@ -137,7 +138,9 @@ function cacheRetrievedDestination(
     destination.name,
     isolation
   );
-  cache.set(key, destination);
+  const expiresIn = first(destination.authTokens || [])?.expiresIn;
+  const expirationTime = expiresIn ? moment().add(expiresIn, 'second').unix() * 1000 : undefined;
+  cache.set(key, destination, expirationTime);
 }
 
 export const destinationCache = DestinationCache(


### PR DESCRIPTION
This fixes the issue of shorter expiration times than 5 minutes. Before this if the expiration of a token was 1 min, you would have to wait for 4 mins to make the next call to the destination instead...
Relates to SAP/cloud-sdk-backlog#437.
