### PR TITLE
Fix: release pipeline

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
+          ref: 'main'
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: 'main'
       - uses: actions/setup-node@v2
         with:
           node-version: '12.x'


### PR DESCRIPTION
Explicitly checkout the `main` branch for release pipeline.
Before, as default branch, this was not necessary