### PR TITLE
fix: flaky windows tests

### DIFF
--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -2,7 +2,7 @@ name: windows-tests
 
 on:
   push:
-    branches: [2.0]
+    branches: ["2.0"]
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -2,7 +2,7 @@ name: windows-tests
 
 on:
   push:
-    branches: ["2.0"]
+    branches: ['2.0']
     paths-ignore:
       - 'docs/**'
 


### PR DESCRIPTION
This PR tries to solve the issue that the windows tests also run on `main`, in the official syntax branches are always selected by strings, so this PR changes `2.0` to `"2.0"` in an attempt to fix it.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
