### PR TITLE
fix: windows flakyness

### DIFF
--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -20,13 +20,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v2
-        id: cache
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - run: yarn test:unit -- -- --no-bail -- -- -- --json --outputFile=unit-test-output.json
       - run: yarn test:integration --json --outputFile=int-test-output.json


### PR DESCRIPTION
This PR is another attempt to fix the flaky windows tests, following the previous PRs.

According to the logs, some compiled code failed, and even some tests that were changed were still running inside the windows tests, leading me to believe that the caching doesn't work as expected with the windows machines.