### PR TITLE
chore: change method signature for indexFiles

### DIFF
--- a/scripts/check-public-api.spec.ts
+++ b/scripts/check-public-api.spec.ts
@@ -22,7 +22,7 @@ describe('check-public-api', () => {
         }
       }
     });
-    expect(indexFiles('root')).toEqual([
+    expect(indexFiles('root', 'index.ts')).toEqual([
       'root/folder1/folder2/index.ts',
       'root/index.ts'
     ]);

--- a/scripts/check-public-api.ts
+++ b/scripts/check-public-api.ts
@@ -119,7 +119,7 @@ export async function checkApiOfPackage(pathToPackage: string): Promise<void> {
   const allExportedTypes = await parseTypeDefinitionFiles(pathCompiled);
 
   const allExportedIndex = parseIndexFile(
-    await readFile(indexFiles(pathToPackage)[0], 'utf8')
+    await readFile(indexFiles(pathToSource, 'index.ts')[0], 'utf8')
   );
 
   const setsAreEqual = compareApisAndLog(
@@ -204,12 +204,13 @@ export function parseTypeDefinitionFile(
 }
 
 /**
- * Get all index files in the cwd
+ * Get index files in the cwd based on pattern
  * @param cwd - Directory scanned for `index.ts` files.
+ * @param pattern - Pattern for search.
  * @returns List of index files found in the cwd.
  */
-export function indexFiles(cwd: string): string[] {
-  const files = new GlobSync('**/index.ts', { cwd }).found;
+export function indexFiles(cwd: string, pattern: string): string[] {
+  const files = new GlobSync(pattern, { cwd }).found;
   return files.map(file => join(cwd, file));
 }
 
@@ -220,7 +221,7 @@ export function indexFiles(cwd: string): string[] {
 
  */
 export function checkSingleIndexFile(cwd: string): void {
-  const files = indexFiles(cwd);
+  const files = indexFiles(cwd, 'index.ts');
   if (files.length > 1) {
     throw Error(`Too many index files found: ${files.join(',')}`);
   }


### PR DESCRIPTION
Please provide a description of what your change does and why it is needed.

Currently the indexFiles method searches based on pattern `**/index.ts`. This will always search recursively within subfolders, which is not required for checking `checkSingleIndexFile`. This check will also fail when we have an index.ts in all sub folders. Changed the method signature to pass pattern so either `index.ts` or `**/index.ts` can be searched, depending on use case

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
