### PR TITLE
chore: Run all odata-request tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "connectivity": "yarn workspace @sap-cloud-sdk/connectivity",
     "generator": "yarn workspace @sap-cloud-sdk/generator",
     "generator-common": "yarn workspace @sap-cloud-sdk/generator-common",
+    "http-client": "yarn workspace @sap-cloud-sdk/http-client",
     "openapi-generator": "yarn workspace @sap-cloud-sdk/openapi-generator",
     "odata-common": "yarn workspace @sap-cloud-sdk/odata-common",
     "odata-v2": "yarn workspace @sap-cloud-sdk/odata-v2",

--- a/packages/http-client/src/__snapshots__/http-client.spec.ts.snap
+++ b/packages/http-client/src/__snapshots__/http-client.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generic http client executeHttpRequest throws an error if the destination URL uses neither "http" nor "https" as protocol (e.g. RFC) 1`] = `"Protocol of the provided destination (rfc://example.com) is not supported! Currently only HTTP and HTTPS are supported."`;

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -511,6 +511,100 @@ sap-client:001`);
       );
     });
 
+    it('rejectUnauthorized property of HttpsAgent should be set to true when isTrustingAllCertificates is false', async () => {
+      jest.spyOn(axios, 'request').mockResolvedValue({});
+      const destination: Destination = {
+        url: 'https://example.com',
+        isTrustingAllCertificates: true
+      };
+
+      await executeHttpRequest(destination, { method: 'get' });
+      const expectedJsonHttpsAgent = {
+        httpsAgent: expect.objectContaining({
+          options: expect.objectContaining({ rejectUnauthorized: false })
+        })
+      };
+      expect(axios.request).toHaveBeenCalledWith(
+        expect.objectContaining(expectedJsonHttpsAgent)
+      );
+    });
+
+    it('rejectUnauthorized property of HttpsAgent should be set to false when isTrustingAllCertificates is true', async () => {
+      jest.spyOn(axios, 'request').mockResolvedValue({});
+      const destination: Destination = {
+        url: 'https://example.com',
+        isTrustingAllCertificates: false
+      };
+      await executeHttpRequest(destination, { method: 'get' });
+      const expectedJsonHttpsAgent = {
+        httpsAgent: expect.objectContaining({
+          options: expect.objectContaining({ rejectUnauthorized: true })
+        })
+      };
+      expect(axios.request).toHaveBeenCalledWith(
+        expect.objectContaining(expectedJsonHttpsAgent)
+      );
+    });
+
+    it('request config contains headers without ETag value when there is no ETag config', async () => {
+      jest.spyOn(axios, 'request').mockResolvedValue({});
+      const destination: Destination = {
+        url: 'http://example.com'
+      };
+
+      await executeHttpRequest(destination, { method: 'get' });
+
+      expect(axios.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            'if-match': expect.anything()
+          })
+        })
+      );
+    });
+
+    it('request config contains httpAgent when destination URL uses "http" as protocol', async () => {
+      jest.spyOn(axios, 'request').mockResolvedValue({});
+
+      const expectedConfigEntry = { httpAgent: expect.anything() };
+      const destination: Destination = {
+        url: 'http://example.com',
+        authentication: 'NoAuthentication'
+      };
+
+      await executeHttpRequest(destination, { method: 'get' });
+      expect(axios.request).toHaveBeenCalledWith(
+        expect.objectContaining(expectedConfigEntry)
+      );
+    });
+
+    it('request config contains httpsAgent when destination URL uses "https" as protocol', async () => {
+      jest.spyOn(axios, 'request').mockResolvedValue({});
+      const expectedConfigEntry = { httpsAgent: expect.anything() };
+      const destination: Destination = {
+        url: 'https://example.com',
+        authentication: 'NoAuthentication'
+      };
+
+      await executeHttpRequest(destination, { method: 'get' });
+
+      expect(axios.request).toHaveBeenCalledWith(
+        expect.objectContaining(expectedConfigEntry)
+      );
+    });
+
+    it('throws an error if the destination URL uses neither "http" nor "https" as protocol (e.g. RFC)', async () => {
+      jest.spyOn(axios, 'request').mockResolvedValue({});
+      const destination: Destination = {
+        url: 'rfc://example.com',
+        authentication: 'NoAuthentication'
+      };
+
+      await expect(
+        executeHttpRequest(destination, { method: 'get' })
+      ).rejects.toThrowErrorMatchingSnapshot();
+    });
+
     it('includes the default axios config in request', async () => {
       const destination: Destination = { url: 'https://destinationUrl' };
       const requestSpy = jest.spyOn(axios, 'request').mockResolvedValue(true);

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -546,23 +546,6 @@ sap-client:001`);
       );
     });
 
-    it('request config contains headers without ETag value when there is no ETag config', async () => {
-      jest.spyOn(axios, 'request').mockResolvedValue({});
-      const destination: Destination = {
-        url: 'http://example.com'
-      };
-
-      await executeHttpRequest(destination, { method: 'get' });
-
-      expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          headers: expect.not.objectContaining({
-            'if-match': expect.anything()
-          })
-        })
-      );
-    });
-
     it('request config contains httpAgent when destination URL uses "http" as protocol', async () => {
       jest.spyOn(axios, 'request').mockResolvedValue({});
 

--- a/packages/odata-common/package.json
+++ b/packages/odata-common/package.json
@@ -39,7 +39,6 @@
     "typescript": "~4.4.4",
     "bignumber.js": "^9.0.0",
     "moment": "^2.29.0",
-    "axios": "^0.23.0",
     "uuid": "^8.2.0"
   },
   "devDependencies": {

--- a/packages/odata-common/src/request/__snapshots__/odata-request.spec.ts.snap
+++ b/packages/odata-common/src/request/__snapshots__/odata-request.spec.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`OData Request execute throws an error if the destination URL uses neither "http" nor "https" as protocol (e.g. RFC) 1`] = `"Protocol of the provided destination (rfc://example.com) is not supported! Currently only HTTP and HTTPS are supported."`;

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -131,10 +131,8 @@ describe('OData Request', () => {
     const request = createRequest(ODataGetAllRequestConfig, destination);
 
     expect(request.headers()).toEqual(
-      expect.objectContaining({
-        headers: expect.not.objectContaining({
-          'if-match': expect.anything()
-        })
+      expect.not.objectContaining({
+        'if-match': expect.anything()
       })
     );
   });

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -99,7 +99,7 @@ describe('OData Request', () => {
   });
 
   describe('query', () => {
-    it.only('should have json parameter by default for get request', () => {
+    it('should have json parameter by default for get request', () => {
       const request = createRequest(ODataGetAllRequestConfig);
       expect(request.query()).toEqual('?$format=json');
     });

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -10,35 +10,8 @@ import {
 import { commonODataUri } from '../../test/common-request-config';
 import { CommonEntity } from '../../test/common-entity';
 
-// jest.mock('../../http-client/node_modules/axios', () => ({
-//   request: () => Promise.resolve()
-// }));
-//   .spyOn(axios, 'request')
-//   .mockResolvedValue({ 'x-csrf-token': 'test' });
-
-// jest.mock('@sap-cloud-sdk/http-client');
-
-jest.mock('@sap-cloud-sdk/http-client', () => {
-  const actual = jest.requireActual('@sap-cloud-sdk/http-client');
-  return {
-    ...actual,
-    executeHttpRequestWithOrigin: jest
-      .fn()
-      .mockResolvedValue({ 'x-csrf-token': 'test' })
-  };
-});
-
 describe('OData Request', () => {
-  // const requestSpy
   describe('format', () => {
-    beforeEach(() => {
-      // requestSpy.mockResolvedValue({ 'x-csrf-token': 'test' });
-    });
-
-    afterEach(() => {
-      // requestSpy.mockReset();
-    });
-
     it('should be json for GET', async () => {
       const request = createRequestWithHeaders(ODataGetAllRequestConfig);
       expect(request.url()).toContain('$format=json');
@@ -148,6 +121,22 @@ describe('OData Request', () => {
         'sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity/?$format=json'
       );
     });
+  });
+
+  it('request config contains headers without ETag value when there is no ETag config', async () => {
+    const destination: Destination = {
+      url: 'http://example.com'
+    };
+
+    const request = createRequest(ODataGetAllRequestConfig, destination);
+
+    expect(request.headers()).toEqual(
+      expect.objectContaining({
+        headers: expect.not.objectContaining({
+          'if-match': expect.anything()
+        })
+      })
+    );
   });
 });
 

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -45,7 +45,7 @@ describe('OData Request', () => {
     });
 
     describe('isTrustingAllCertificates is defined', () => {
-      it('rejectUnauthorized property of HttpsAgent should be set to TRUE when TrustAll is false', async () => {
+      it('rejectUnauthorized property of HttpsAgent should be set to true when TrustAll is false', async () => {
         const destination: Destination = {
           url: 'https://example.com',
           isTrustingAllCertificates: true
@@ -66,7 +66,7 @@ describe('OData Request', () => {
         );
       });
 
-      it('rejectUnauthorized property of HttpsAgent should be set to FALSE when TrustAll is true', async () => {
+      it('rejectUnauthorized property of HttpsAgent should be set to false when TrustAll is true', async () => {
         const destination: Destination = {
           url: 'https://example.com',
           isTrustingAllCertificates: false
@@ -135,7 +135,7 @@ describe('OData Request', () => {
   describe('serviceUrl', () => {
     it('should contain "sap/opu/odata/sap/"', () => {
       const request = createRequest(ODataGetAllRequestConfig);
-      expect(request.serviceUrl()).toBe('/sap/opu/odata/sap/API_TEST_SRV');
+      expect(request.serviceUrl()).toBe('/sap/opu/odata/sap/API_COMMON_SRV');
     });
 
     it('should contain custom service path', () => {
@@ -164,7 +164,7 @@ describe('OData Request', () => {
         request.config as ODataGetAllRequestConfig<CommonEntity>;
       requestConfig.appendPath('/$value');
       expect(request.relativeUrl()).toBe(
-        'sap/opu/odata/sap/API_TEST_SRV/A_CommonEntity/$value?$format=json'
+        'sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity/$value?$format=json'
       );
     });
 
@@ -174,7 +174,7 @@ describe('OData Request', () => {
         request.config as ODataGetAllRequestConfig<CommonEntity>;
       requestConfig.appendPath('/');
       expect(request.relativeUrl()).toBe(
-        'sap/opu/odata/sap/API_TEST_SRV/A_CommonEntity/?$format=json'
+        'sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity/?$format=json'
       );
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2568,13 +2568,6 @@ axios@^0.21.0, axios@^0.21.1, axios@^0.21.4:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz#b0fa5d0948a8d1d75e3d5635238b6c4625b05149"
-  integrity sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==
-  dependencies:
-    follow-redirects "^1.14.4"
-
 axios@^0.24.0:
   version "0.24.0"
   resolved "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"


### PR DESCRIPTION
Re-enable all odata-request tests, that were accidentally skipped.