### PR TITLE
chore: test node 14 in the pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [14.x]
+        node-version: [12.x, 14.x]
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1
@@ -42,7 +42,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -74,7 +74,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -93,7 +93,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -118,7 +118,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - uses: actions/cache@v2
         id: cache
         with:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - run: yarn install --frozen-lockfile
       - name: Setup git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - run: yarn install --frozen-lockfile
       - name: Version 1 Stable Release
         if: startsWith(github.ref, 'refs/tags/v1')

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1

--- a/.github/workflows/v2.yaml
+++ b/.github/workflows/v2.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [12.x]
+        node-version: [12.x, 14.x]
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1
@@ -38,7 +38,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -68,7 +68,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -87,7 +87,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - uses: actions/cache@v2
         id: cache
         with:


### PR DESCRIPTION
This PR add node 14 test to the pipeline.
The previous blocker `@sap/edm-converters` now also supports node 14.

Follow up:
- ~apply for `main` branch as well~