### PR TITLE
chore: Update edm converters version explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## Improvements
 
--
+- [generator] Update the version of `@sap/edm-converters` to solve a node 14 related warning.
 
 ## Fixed Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## Improvements
 
-- [generator] Update the version of `@sap/edm-converters` to solve a node 14 related warning.
+- [generator] Update the version of `@sap/edm-converters` to make sure node 14 is supported.
 
 ## Fixed Issues
 

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -38,7 +38,7 @@
     "@sap-cloud-sdk/core": "^1.53.0",
     "@sap-cloud-sdk/generator-common": "^1.53.0",
     "@sap-cloud-sdk/util": "^1.53.0",
-    "@sap/edm-converters": "~1.0.21",
+    "@sap/edm-converters": "~1.0.41",
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.2",
     "execa": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1703,7 +1703,7 @@
   dependencies:
     "@sap-cloud-sdk/core" "^1.47.1"
 
-"@sap/edm-converters@^1.0.41", "@sap/edm-converters@~1.0.21":
+"@sap/edm-converters@^1.0.41", "@sap/edm-converters@~1.0.41":
   version "1.0.41"
   resolved "https://registry.npmjs.org/@sap/edm-converters/-/edm-converters-1.0.41.tgz#e38cdd69b49ac407ef3c6637f78f1c6ea26ada4d"
   integrity sha512-Af7L7amlh06YXfOK2ufjKUZXhcuwXSt0uzPDrHbVBvN1lQS8Gj4BxzXTbnskiFweTR2CFuhoqsSaV2r/7l9mYw==


### PR DESCRIPTION
The old version of this lib caused the node 14 warning.
We fixed it implicitly in the lock file by applying the upgrade by dependabot.
This PR explicitly update the version from our package.json.