### PR TITLE
chore: Improve test utils

### DIFF
--- a/packages/odata-common/src/request-builder/batch/batch-request-builder.ts
+++ b/packages/odata-common/src/request-builder/batch/batch-request-builder.ts
@@ -5,7 +5,7 @@ import {
 import { HttpResponse } from '@sap-cloud-sdk/http-client';
 import { MethodRequestBuilder } from '../request-builder-base';
 import { ODataBatchRequestConfig, ODataRequest } from '../../request';
-import { DeSerializers } from '../../de-serializers';
+import { DefaultDeSerializers, DeSerializers } from '../../de-serializers';
 import { EntityApi, EntityBase } from '../../entity-base';
 import { GetAllRequestBuilderBase } from '../get-all-request-builder-base';
 import { GetByKeyRequestBuilderBase } from '../get-by-key-request-builder-base';
@@ -19,7 +19,7 @@ import { serializeBatchRequest } from './batch-request-serializer';
  * @internal
  */
 export class BatchRequestBuilder<
-  DeSerializersT extends DeSerializers
+  DeSerializersT extends DeSerializers = DefaultDeSerializers
 > extends MethodRequestBuilder<ODataBatchRequestConfig> {
   // FIXME: MethodRequestBuilder is too broad here. Should be getAll and getByKey
   /**

--- a/packages/odata-common/src/request-builder/batch/batch-request-builder.ts
+++ b/packages/odata-common/src/request-builder/batch/batch-request-builder.ts
@@ -19,7 +19,7 @@ import { serializeBatchRequest } from './batch-request-serializer';
  * @internal
  */
 export class BatchRequestBuilder<
-  DeSerializersT extends DeSerializers = DefaultDeSerializers
+  DeSerializersT extends DeSerializers
 > extends MethodRequestBuilder<ODataBatchRequestConfig> {
   // FIXME: MethodRequestBuilder is too broad here. Should be getAll and getByKey
   /**

--- a/packages/odata-common/src/request-builder/batch/batch-request-builder.ts
+++ b/packages/odata-common/src/request-builder/batch/batch-request-builder.ts
@@ -5,7 +5,7 @@ import {
 import { HttpResponse } from '@sap-cloud-sdk/http-client';
 import { MethodRequestBuilder } from '../request-builder-base';
 import { ODataBatchRequestConfig, ODataRequest } from '../../request';
-import { DefaultDeSerializers, DeSerializers } from '../../de-serializers';
+import { DeSerializers } from '../../de-serializers';
 import { EntityApi, EntityBase } from '../../entity-base';
 import { GetAllRequestBuilderBase } from '../get-all-request-builder-base';
 import { GetByKeyRequestBuilderBase } from '../get-by-key-request-builder-base';

--- a/packages/odata-common/src/request/odata-delete-request-config.spec.ts
+++ b/packages/odata-common/src/request/odata-delete-request-config.spec.ts
@@ -1,10 +1,7 @@
 import { v4 as uuid } from 'uuid';
-import { testEntityResourcePath } from '../../../../test-resources/test/test-util/test-data';
 import { CommonEntity, commonEntityApi } from '../../test/common-entity';
-import {
-  commonODataUri,
-  commonUriConverter
-} from '../../test/common-request-config';
+import { commonODataUri } from '../../test/common-request-config';
+import { testEntityResourcePath } from '../../test/test-util';
 import { DefaultDeSerializers } from '../de-serializers';
 import { ODataDeleteRequestConfig } from './odata-delete-request-config';
 
@@ -26,12 +23,7 @@ describe('ODataDeleteRequestConfig', () => {
       KeyPropertyString: keyPropString
     };
     expect(config.resourcePath()).toEqual(
-      testEntityResourcePath(
-        keyPropGuid,
-        keyPropString,
-        commonUriConverter,
-        'A_CommonEntity'
-      )
+      testEntityResourcePath(keyPropGuid, keyPropString)
     );
   });
 

--- a/packages/odata-common/src/request/odata-get-by-key-request-config.spec.ts
+++ b/packages/odata-common/src/request/odata-get-by-key-request-config.spec.ts
@@ -1,10 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import { CommonEntity, commonEntityApi } from '../../test/common-entity';
-import {
-  commonODataUri,
-  commonUriConverter
-} from '../../test/common-request-config';
-import { testEntityResourcePath } from '../../../../test-resources/test/test-util';
+import { commonODataUri } from '../../test/common-request-config';
+import { testEntityResourcePath } from '../../test/test-util';
 import { DefaultDeSerializers } from '../de-serializers';
 import { ODataGetByKeyRequestConfig } from './odata-get-by-key-request-config';
 
@@ -26,12 +23,7 @@ describe('ODataGetByKeyRequestConfig', () => {
       KeyPropertyString: keyPropString
     };
     expect(config.resourcePath()).toEqual(
-      testEntityResourcePath(
-        keyPropGuid,
-        keyPropString,
-        commonUriConverter,
-        'A_CommonEntity'
-      )
+      testEntityResourcePath(keyPropGuid, keyPropString)
     );
   });
 

--- a/packages/odata-common/src/request/odata-update-request-config.spec.ts
+++ b/packages/odata-common/src/request/odata-update-request-config.spec.ts
@@ -1,11 +1,8 @@
 import { v4 as uuid } from 'uuid';
-import { testEntityResourcePath } from '../../../../test-resources/test/test-util/test-data';
-import {
-  commonODataUri,
-  commonUriConverter
-} from '../../test/common-request-config';
+import { commonODataUri } from '../../test/common-request-config';
 import { CommonEntity, commonEntityApi } from '../../test/common-entity';
 import { DefaultDeSerializers } from '../de-serializers';
+import { testEntityResourcePath } from '../../test/test-util';
 import { ODataUpdateRequestConfig } from './odata-update-request-config';
 
 describe('ODataUpdateRequestConfig', () => {
@@ -31,12 +28,7 @@ describe('ODataUpdateRequestConfig', () => {
       KeyPropertyString: keyPropString
     };
     expect(config.resourcePath()).toBe(
-      testEntityResourcePath(
-        keyPropGuid,
-        keyPropString,
-        commonUriConverter,
-        'A_CommonEntity'
-      )
+      testEntityResourcePath(keyPropGuid, keyPropString)
     );
   });
 

--- a/packages/odata-common/src/selectable/link.spec.ts
+++ b/packages/odata-common/src/selectable/link.spec.ts
@@ -1,0 +1,13 @@
+import { commonEntityApi } from '../../test/common-entity';
+import { Link } from './link';
+
+describe('link', () => {
+  it('cloned link has the same properties as the original link', () => {
+    const link = new Link('linkedField', commonEntityApi, commonEntityApi);
+    const clone = link.clone();
+
+    Object.keys(link).forEach(key => {
+      expect(link[key]).toStrictEqual(clone[key]);
+    });
+  });
+});

--- a/packages/odata-common/test/test-util.ts
+++ b/packages/odata-common/test/test-util.ts
@@ -1,0 +1,8 @@
+import { commonUriConverter } from './common-request-config';
+
+export function testEntityResourcePath(guid, str): string {
+  return `A_CommonEntity(KeyPropertyGuid=${commonUriConverter(
+    guid,
+    'Edm.Guid'
+  )},KeyPropertyString='${str}')`;
+}

--- a/packages/odata-v2/src/request-builder/create-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/create-request-builder.spec.ts
@@ -1,18 +1,16 @@
 import nock = require('nock');
 import { v4 as uuid } from 'uuid';
-import { createUriConverter } from '@sap-cloud-sdk/odata-common/internal';
 import {
   defaultDestination,
   defaultHost,
-  mockCreateRequest
-} from '../../../../test-resources/test/test-util/request-mocker';
-import { testEntityResourcePath } from '../../../../test-resources/test/test-util/test-data';
-import { testPostRequestOutcome } from '../../../../test-resources/test/test-util/testPostRequestOutcome';
-import { defaultDeSerializers } from '../de-serializers';
+  mockCreateRequest,
+  testPostRequestOutcome
+} from '../../../../test-resources/test/test-util';
 import {
   testEntityApi,
   testEntityMultiLinkApi,
-  testEntitySingleLinkApi
+  testEntitySingleLinkApi,
+  testEntityResourcePath
 } from '../../test/test-util';
 import { CreateRequestBuilder } from './create-request-builder';
 
@@ -208,8 +206,7 @@ describe('CreateRequestBuilder', () => {
 
     const toChildPath = `${testEntityResourcePath(
       parentKeyGuid,
-      parentKeyString,
-      createUriConverter(defaultDeSerializers)
+      parentKeyString
     )}/to_MultiLink`;
 
     mockCreateRequest(

--- a/packages/odata-v2/src/request-builder/delete-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/delete-request-builder.spec.ts
@@ -1,19 +1,15 @@
 import nock from 'nock';
 import { v4 as uuid } from 'uuid';
-import { createUriConverter } from '@sap-cloud-sdk/odata-common/internal';
 import {
   defaultDestination,
   mockDeleteRequest
-} from '../../../../test-resources/test/test-util/request-mocker';
-import { testEntityResourcePath } from '../../../../test-resources/test/test-util/test-data';
-import { defaultDeSerializers } from '../de-serializers';
-import { testEntityApi } from '../../test/test-util';
+} from '../../../../test-resources/test/test-util';
+import { testEntityApi, testEntityResourcePath } from '../../test/test-util';
 import { DeleteRequestBuilder } from './delete-request-builder';
 
 describe('DeleteRequestBuilder', () => {
   const keyPropGuid = uuid();
   const keyPropString = 'TEST_ID';
-  const uriConverter = createUriConverter(defaultDeSerializers);
 
   afterEach(() => {
     nock.cleanAll();
@@ -22,7 +18,7 @@ describe('DeleteRequestBuilder', () => {
   it('delete request with keys should resolve', async () => {
     mockDeleteRequest(
       {
-        path: testEntityResourcePath(keyPropGuid, keyPropString, uriConverter)
+        path: testEntityResourcePath(keyPropGuid, keyPropString)
       },
       testEntityApi
     );
@@ -46,7 +42,7 @@ describe('DeleteRequestBuilder', () => {
 
     mockDeleteRequest(
       {
-        path: testEntityResourcePath(keyPropGuid, keyPropString, uriConverter),
+        path: testEntityResourcePath(keyPropGuid, keyPropString),
         additionalHeaders: {
           'if-match': versionId
         }
@@ -67,7 +63,7 @@ describe('DeleteRequestBuilder', () => {
 
     mockDeleteRequest(
       {
-        path: testEntityResourcePath(keyPropGuid, keyPropString, uriConverter),
+        path: testEntityResourcePath(keyPropGuid, keyPropString),
         additionalHeaders: {
           'if-match': versionId
         }
@@ -88,7 +84,7 @@ describe('DeleteRequestBuilder', () => {
   it('delete requests does not use if-match header when the version identifier is an empty string', async () => {
     mockDeleteRequest(
       {
-        path: testEntityResourcePath(keyPropGuid, keyPropString, uriConverter)
+        path: testEntityResourcePath(keyPropGuid, keyPropString)
       },
       testEntityApi
     );
@@ -106,7 +102,7 @@ describe('DeleteRequestBuilder', () => {
   it('should ignore the version identifier on delete if set', async () => {
     mockDeleteRequest(
       {
-        path: testEntityResourcePath(keyPropGuid, keyPropString, uriConverter),
+        path: testEntityResourcePath(keyPropGuid, keyPropString),
         additionalHeaders: {
           'if-match': '*'
         }
@@ -144,7 +140,7 @@ describe('DeleteRequestBuilder', () => {
     it('returns request and raw response', async () => {
       mockDeleteRequest(
         {
-          path: testEntityResourcePath(keyPropGuid, keyPropString, uriConverter)
+          path: testEntityResourcePath(keyPropGuid, keyPropString)
         },
         testEntityApi
       );

--- a/packages/odata-v2/src/request-builder/function-import-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/function-import-request-builder.spec.ts
@@ -16,7 +16,7 @@ import {
 import {
   defaultDestination,
   defaultHost
-} from '../../../../test-resources/test/test-util/request-mocker';
+} from '../../../../test-resources/test/test-util';
 import { testEntityApi } from '../../test/test-util';
 
 const serviceUrl = '/testination/sap/opu/odata/sap/API_TEST_SRV';

--- a/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
@@ -7,14 +7,9 @@ import {
   mockCountRequest,
   mockDestinationsEnv,
   mockGetRequest,
-  unmockDestinationsEnv
-} from '../../../../test-resources/test/test-util/request-mocker';
-import {
+  unmockDestinationsEnv,
   createOriginalTestEntityData1,
   createOriginalTestEntityData2,
-  createTestEntity
-} from '../../../../test-resources/test/test-util/test-data';
-import {
   expectAllMocksUsed,
   certificateMultipleResponse,
   certificateSingleResponse,
@@ -28,7 +23,11 @@ import {
   providerServiceToken
 } from '../../../../test-resources/test/test-util';
 import { parseDestination } from '../../../connectivity/src/scp-cf/destination/destination';
-import { testEntityApi, testEntitySingleLinkApi } from '../../test/test-util';
+import {
+  testEntityApi,
+  testEntitySingleLinkApi,
+  createTestEntity
+} from '../../test/test-util';
 import { DefaultDeSerializers } from '../de-serializers';
 import { GetAllRequestBuilder } from './get-all-request-builder';
 

--- a/packages/odata-v2/src/request-builder/get-by-key-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-by-key-request-builder.spec.ts
@@ -1,21 +1,17 @@
 import nock = require('nock');
 import { v4 as uuid } from 'uuid';
-import { createUriConverter } from '@sap-cloud-sdk/odata-common/internal';
 import {
   defaultDestination,
-  mockGetRequest
-} from '../../../../test-resources/test/test-util/request-mocker';
-import {
+  mockGetRequest,
   createOriginalTestEntityData1,
-  createOriginalTestEntityDataWithLinks,
+  createOriginalTestEntityDataWithLinks
+} from '../../../../test-resources/test/test-util';
+import {
+  testEntityApi,
   createTestEntity,
   testEntityResourcePath
-} from '../../../../test-resources/test/test-util/test-data';
-import { defaultDeSerializers } from '../de-serializers';
-import { testEntityApi } from '../../test/test-util';
+} from '../../test/test-util';
 import { GetByKeyRequestBuilder } from './get-by-key-request-builder';
-
-const uriConverter = createUriConverter(defaultDeSerializers);
 
 describe('GetByKeyRequestBuilder', () => {
   describe('url', () => {
@@ -44,8 +40,7 @@ describe('GetByKeyRequestBuilder', () => {
         {
           path: testEntityResourcePath(
             expected.keyPropertyGuid,
-            expected.keyPropertyString,
-            uriConverter
+            expected.keyPropertyString
           ),
           responseBody: { d: entityData }
         },
@@ -70,8 +65,7 @@ describe('GetByKeyRequestBuilder', () => {
         {
           path: testEntityResourcePath(
             expected.keyPropertyGuid,
-            expected.keyPropertyString,
-            uriConverter
+            expected.keyPropertyString
           ),
           responseBody: { d: entityData }
         },
@@ -96,8 +90,7 @@ describe('GetByKeyRequestBuilder', () => {
         {
           path: testEntityResourcePath(
             expected.keyPropertyGuid,
-            expected.keyPropertyString,
-            uriConverter
+            expected.keyPropertyString
           ),
           responseBody: { d: entityData },
           responseHeaders: { Etag: versionIdentifier }
@@ -120,8 +113,7 @@ describe('GetByKeyRequestBuilder', () => {
         {
           path: testEntityResourcePath(
             expected.keyPropertyGuid,
-            expected.keyPropertyString,
-            uriConverter
+            expected.keyPropertyString
           ),
           responseBody: { d: { results: entityData } }
         },
@@ -146,8 +138,7 @@ describe('GetByKeyRequestBuilder', () => {
         {
           path: testEntityResourcePath(
             expected.keyPropertyGuid,
-            expected.keyPropertyString,
-            uriConverter
+            expected.keyPropertyString
           ),
           responseBody: { d: entityData }
         },
@@ -170,8 +161,7 @@ describe('GetByKeyRequestBuilder', () => {
         {
           path: `${testEntityResourcePath(
             entity.keyPropertyGuid,
-            entity.keyPropertyString,
-            uriConverter
+            entity.keyPropertyString
           )}/to_SingleLink/to_MultiLink`
         },
         testEntityApi

--- a/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
@@ -1,17 +1,17 @@
 import nock from 'nock';
 import { v4 as uuid } from 'uuid';
 import { createLogger } from '@sap-cloud-sdk/util';
-import { createUriConverter } from '@sap-cloud-sdk/odata-common/internal';
 import {
   defaultDestination,
   mockUpdateRequest
-} from '../../../../test-resources/test/test-util/request-mocker';
-import { testEntityResourcePath } from '../../../../test-resources/test/test-util/test-data';
-import { defaultDeSerializers } from '../de-serializers';
-import { testEntityApi, testEntityMultiLinkApi } from '../../test/test-util';
+} from '../../../../test-resources/test/test-util';
+import {
+  testEntityApi,
+  testEntityMultiLinkApi,
+  testEntityResourcePath
+} from '../../test/test-util';
 import { UpdateRequestBuilder } from './update-request-builder';
 
-const uriConverter = createUriConverter(defaultDeSerializers);
 function createTestEntity() {
   const keyPropGuid = uuid();
   const keyPropString = 'stringId';
@@ -71,8 +71,7 @@ describe('UpdateRequestBuilder', () => {
         body: requestBody,
         path: testEntityResourcePath(
           entity.keyPropertyGuid,
-          entity.keyPropertyString,
-          uriConverter
+          entity.keyPropertyString
         )
       },
       testEntityApi
@@ -100,8 +99,7 @@ describe('UpdateRequestBuilder', () => {
         body: requestBody,
         path: testEntityResourcePath(
           entity.keyPropertyGuid,
-          entity.keyPropertyString,
-          uriConverter
+          entity.keyPropertyString
         )
       },
       testEntityApi
@@ -129,8 +127,7 @@ describe('UpdateRequestBuilder', () => {
         body: requestBody,
         path: testEntityResourcePath(
           entity.keyPropertyGuid,
-          entity.keyPropertyString,
-          uriConverter
+          entity.keyPropertyString
         )
       },
       testEntityApi
@@ -159,8 +156,7 @@ describe('UpdateRequestBuilder', () => {
         body: putRequestBody,
         path: testEntityResourcePath(
           entity.keyPropertyGuid,
-          entity.keyPropertyString,
-          uriConverter
+          entity.keyPropertyString
         ),
         method: 'put'
       },
@@ -183,8 +179,7 @@ describe('UpdateRequestBuilder', () => {
         body: requestBody,
         path: testEntityResourcePath(
           entity.keyPropertyGuid,
-          entity.keyPropertyString,
-          uriConverter
+          entity.keyPropertyString
         )
       },
       testEntityApi
@@ -220,8 +215,7 @@ describe('UpdateRequestBuilder', () => {
         body: requestBody,
         path: testEntityResourcePath(
           entity.keyPropertyGuid,
-          entity.keyPropertyString,
-          uriConverter
+          entity.keyPropertyString
         ),
         additionalHeaders: { 'if-match': 'not-a-star' }
       },
@@ -245,8 +239,7 @@ describe('UpdateRequestBuilder', () => {
         body: requestBody,
         path: testEntityResourcePath(
           entity.keyPropertyGuid,
-          entity.keyPropertyString,
-          uriConverter
+          entity.keyPropertyString
         ),
         additionalHeaders: { 'if-match': customVersionIdentifier }
       },
@@ -270,8 +263,7 @@ describe('UpdateRequestBuilder', () => {
         body: requestBody,
         path: testEntityResourcePath(
           entity.keyPropertyGuid,
-          entity.keyPropertyString,
-          uriConverter
+          entity.keyPropertyString
         ),
         additionalHeaders: { 'if-match': '*' }
       },
@@ -319,8 +311,7 @@ describe('UpdateRequestBuilder', () => {
         body: requestBody,
         path: testEntityResourcePath(
           entity.keyPropertyGuid,
-          entity.keyPropertyString,
-          uriConverter
+          entity.keyPropertyString
         ),
         statusCode: 204,
         responseHeaders: { Etag: eTag }
@@ -349,8 +340,7 @@ describe('UpdateRequestBuilder', () => {
       {
         path: testEntityResourcePath(
           entity.keyPropertyGuid,
-          entity.keyPropertyString,
-          uriConverter
+          entity.keyPropertyString
         ),
         statusCode: 201
       },
@@ -394,8 +384,7 @@ describe('UpdateRequestBuilder', () => {
           body: requestBody,
           path: testEntityResourcePath(
             entity.keyPropertyGuid,
-            entity.keyPropertyString,
-            uriConverter
+            entity.keyPropertyString
           ),
           responseBody: response
         },

--- a/packages/odata-v2/src/uri-conversion/get-resource-path.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-resource-path.spec.ts
@@ -4,9 +4,8 @@ import {
   createGetResourcePathForKeys,
   createUriConverter
 } from '@sap-cloud-sdk/odata-common/internal';
-import { testEntityResourcePath } from '../../../../test-resources/test/test-util/test-data';
 import { defaultDeSerializers } from '../de-serializers';
-import { testEntityApi } from '../../test/test-util';
+import { testEntityApi, testEntityResourcePath } from '../../test/test-util';
 
 const uriConverter = createUriConverter(defaultDeSerializers);
 const { getResourcePathForKeys } = createGetResourcePathForKeys(uriConverter);
@@ -21,7 +20,7 @@ describe('get resource path', () => {
     };
 
     expect(getResourcePathForKeys(keys, testEntityApi)).toEqual(
-      testEntityResourcePath(keyPropGuid, keyPropString, uriConverter)
+      testEntityResourcePath(keyPropGuid, keyPropString)
     );
   });
 

--- a/packages/odata-v2/src/uri-conversion/odata-uri.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/odata-uri.spec.ts
@@ -13,7 +13,7 @@ import {
   testFilterSingleLink,
   testFilterString,
   testFilterStringEncoding
-} from '../../../../test-resources/test/test-util/filter-factory';
+} from '../../../../test-resources/test/test-util';
 import { filterFunctions } from '../filter-functions';
 import { testEntityApi } from '../../test/test-util';
 import { defaultDeSerializers } from '../de-serializers';

--- a/packages/odata-v2/test/test-util.ts
+++ b/packages/odata-v2/test/test-util.ts
@@ -1,4 +1,9 @@
-import { testService } from '@sap-cloud-sdk/test-services/v2/test-service';
+import { createUriConverter } from '@sap-cloud-sdk/odata-common/internal';
+import {
+  TestEntity,
+  testService
+} from '@sap-cloud-sdk/test-services/v2/test-service';
+import { defaultDeSerializers } from '../src';
 
 export const {
   testEntityApi,
@@ -7,3 +12,38 @@ export const {
   testEntityLvl2MultiLinkApi,
   testEntityLvl2SingleLinkApi
 } = testService();
+
+export function createTestEntity(
+  originalData: Record<string, any>
+): TestEntity {
+  const entity = testEntityApi
+    .entityBuilder()
+    .keyPropertyGuid(originalData.KeyPropertyGuid)
+    .keyPropertyString(originalData.KeyPropertyString)
+    .stringProperty(originalData.StringProperty)
+    .booleanProperty(originalData.BooleanProperty)
+    .int16Property(originalData.Int16Property)
+    .build()
+    .setOrInitializeRemoteState();
+
+  if (originalData.to_SingleLink) {
+    entity.toSingleLink = testEntitySingleLinkApi
+      .entityBuilder()
+      .keyProperty(originalData.to_SingleLink.KeyProperty)
+      .build();
+  }
+
+  if (originalData.to_MultiLink) {
+    entity.toMultiLink = originalData.to_MultiLink.map(ml =>
+      testEntityMultiLinkApi.entityBuilder().keyProperty(ml.KeyProperty).build()
+    );
+  }
+
+  return entity;
+}
+
+export function testEntityResourcePath(guid, str): string {
+  return `A_TestEntity(KeyPropertyGuid=${createUriConverter(
+    defaultDeSerializers
+  )(guid, 'Edm.Guid')},KeyPropertyString='${str}')`;
+}

--- a/packages/odata-v4/src/request-builder/delete-request-builder.spec.ts
+++ b/packages/odata-v4/src/request-builder/delete-request-builder.spec.ts
@@ -1,16 +1,11 @@
 import nock from 'nock';
 import { v4 as uuid } from 'uuid';
-import { createUriConverter } from '@sap-cloud-sdk/odata-common/internal';
 import {
   defaultDestination,
   mockDeleteRequest
 } from '../../../../test-resources/test/test-util/request-mocker';
-import { testEntityResourcePath } from '../../../../test-resources/test/test-util/test-data';
-import { defaultDeSerializers } from '../de-serializers';
-import { testEntityApi } from '../../test/test-util';
+import { testEntityApi, testEntityResourcePath } from '../../test/test-util';
 import { DeleteRequestBuilder } from './delete-request-builder';
-
-const convertToUriFormat = createUriConverter(defaultDeSerializers);
 
 describe('DeleteRequestBuilder', () => {
   const keyPropGuid = uuid();
@@ -23,11 +18,7 @@ describe('DeleteRequestBuilder', () => {
   it('should resolve if only the key is given.', async () => {
     mockDeleteRequest(
       {
-        path: testEntityResourcePath(
-          keyPropGuid,
-          keyPropString,
-          convertToUriFormat
-        )
+        path: testEntityResourcePath(keyPropGuid, keyPropString)
       },
       testEntityApi
     );
@@ -51,11 +42,7 @@ describe('DeleteRequestBuilder', () => {
 
     mockDeleteRequest(
       {
-        path: testEntityResourcePath(
-          keyPropGuid,
-          keyPropString,
-          convertToUriFormat
-        ),
+        path: testEntityResourcePath(keyPropGuid, keyPropString),
         additionalHeaders: {
           'if-match': versionId
         }

--- a/packages/odata-v4/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v4/src/request-builder/get-all-request-builder.spec.ts
@@ -3,21 +3,19 @@ import {
   defaultDestination,
   mockCountRequest,
   mockGetRequest,
-  unmockDestinationsEnv
-} from '../../../../test-resources/test/test-util/request-mocker';
-import {
+  unmockDestinationsEnv,
   createOriginalTestEntityData1,
   createOriginalTestEntityData2,
-  createOriginalTestEntityDataWithLinks,
-  createTestEntityV4 as createTestEntity
-} from '../../../../test-resources/test/test-util/test-data';
+  createOriginalTestEntityDataWithLinks
+} from '../../../../test-resources/test/test-util';
 import { any } from '../filter';
 import { DefaultDeSerializers } from '../de-serializers';
 import {
   testEntityApi,
   testEntityLvl2MultiLinkApi,
   testEntityMultiLinkApi,
-  testEntitySingleLinkApi
+  testEntitySingleLinkApi,
+  createTestEntity
 } from '../../test/test-util';
 import { GetAllRequestBuilder } from './get-all-request-builder';
 

--- a/packages/odata-v4/src/request-builder/get-by-key-request-builder.spec.ts
+++ b/packages/odata-v4/src/request-builder/get-by-key-request-builder.spec.ts
@@ -1,20 +1,19 @@
-import { createUriConverter } from '@sap-cloud-sdk/odata-common/internal';
 import {
   defaultDestination,
   mockGetRequest
 } from '../../../../test-resources/test/test-util/request-mocker';
 import {
   createOriginalTestEntityData1,
-  createOriginalTestEntityWithEnumKeyData,
-  createTestEntity,
-  createTestEntityWithEnumKey,
-  testEntityResourcePath
+  createOriginalTestEntityWithEnumKeyData
 } from '../../../../test-resources/test/test-util/test-data';
-import { defaultDeSerializers } from '../de-serializers';
-import { testEntityApi, testEntityWithEnumKeyApi } from '../../test/test-util';
+import {
+  testEntityApi,
+  testEntityWithEnumKeyApi,
+  testEntityResourcePath,
+  createTestEntityWithEnumKey,
+  createTestEntity
+} from '../../test/test-util';
 import { GetByKeyRequestBuilder } from './get-by-key-request-builder';
-
-const convertToUriFormat = createUriConverter(defaultDeSerializers);
 
 describe('GetByKeyRequestBuilder', () => {
   describe('execute', () => {
@@ -26,8 +25,7 @@ describe('GetByKeyRequestBuilder', () => {
         {
           path: testEntityResourcePath(
             expected.keyPropertyGuid,
-            expected.keyPropertyString,
-            convertToUriFormat
+            expected.keyPropertyString
           ),
           responseBody: entityData
         },
@@ -94,8 +92,7 @@ describe('GetByKeyRequestBuilder', () => {
       {
         path: testEntityResourcePath(
           expected.keyPropertyGuid,
-          expected.keyPropertyString,
-          convertToUriFormat
+          expected.keyPropertyString
         ),
         responseBody: entityData
       },
@@ -120,8 +117,7 @@ describe('GetByKeyRequestBuilder', () => {
       {
         path: testEntityResourcePath(
           expected.keyPropertyGuid,
-          expected.keyPropertyString,
-          convertToUriFormat
+          expected.keyPropertyString
         ),
         responseBody: entityData,
         responseHeaders: { Etag: versionIdentifier }

--- a/packages/odata-v4/src/request-builder/response-transformer.spec.ts
+++ b/packages/odata-v4/src/request-builder/response-transformer.spec.ts
@@ -1,9 +1,6 @@
-import {
-  createOriginalTestEntityData1,
-  createTestEntity
-} from '../../../../test-resources/test/test-util/test-data';
+import { createOriginalTestEntityData1 } from '../../../../test-resources/test/test-util/test-data';
 import { defaultDeSerializers, edmToTs } from '../de-serializers';
-import { testEntityApi } from '../../test/test-util';
+import { testEntityApi, createTestEntity } from '../../test/test-util';
 import {
   transformReturnValueForEdmType,
   transformReturnValueForEntity

--- a/packages/odata-v4/src/request-builder/update-request-builder.spec.ts
+++ b/packages/odata-v4/src/request-builder/update-request-builder.spec.ts
@@ -1,16 +1,11 @@
 import nock from 'nock';
 import { v4 as uuid } from 'uuid';
-import { createUriConverter } from '@sap-cloud-sdk/odata-common/internal';
 import {
   defaultDestination,
   mockUpdateRequest
 } from '../../../../test-resources/test/test-util/request-mocker';
-import { testEntityResourcePath } from '../../../../test-resources/test/test-util/test-data';
-import { defaultDeSerializers } from '../de-serializers';
-import { testEntityApi } from '../../test/test-util';
+import { testEntityApi, testEntityResourcePath } from '../../test/test-util';
 import { UpdateRequestBuilder } from './update-request-builder';
-
-const convertToUriFormat = createUriConverter(defaultDeSerializers);
 
 function createTestEntity() {
   const keyPropGuid = uuid();
@@ -43,8 +38,7 @@ describe('UpdateRequestBuilder', () => {
         body: requestBody,
         path: testEntityResourcePath(
           entity.keyPropertyGuid,
-          entity.keyPropertyString,
-          convertToUriFormat
+          entity.keyPropertyString
         )
       },
       testEntityApi

--- a/packages/odata-v4/test/test-util.ts
+++ b/packages/odata-v4/test/test-util.ts
@@ -1,4 +1,10 @@
-import { testService } from '@sap-cloud-sdk/test-services/v4/test-service';
+import { createUriConverter } from '@sap-cloud-sdk/odata-common/internal';
+import {
+  TestEntity,
+  TestEntityWithEnumKey,
+  testService
+} from '@sap-cloud-sdk/test-services/v4/test-service';
+import { defaultDeSerializers } from '../src';
 
 export const {
   testEntityApi,
@@ -10,3 +16,47 @@ export const {
   testEntityCircularLinkParentApi,
   testEntityCircularLinkChildApi
 } = testService();
+
+export function createTestEntity(originalData): TestEntity {
+  const entity = testEntityApi
+    .entityBuilder()
+    .keyPropertyGuid(originalData.KeyPropertyGuid)
+    .keyPropertyString(originalData.KeyPropertyString)
+    .stringProperty(originalData.StringProperty)
+    .booleanProperty(originalData.BooleanProperty)
+    .int16Property(originalData.Int16Property)
+    .enumProperty(originalData.EnumProperty)
+    .build()
+    .setOrInitializeRemoteState();
+
+  if (originalData.to_SingleLink) {
+    entity.toSingleLink = testEntitySingleLinkApi
+      .entityBuilder()
+      .keyProperty(originalData.to_SingleLink.KeyProperty)
+      .build();
+  }
+
+  if (originalData.to_MultiLink) {
+    entity.toMultiLink = originalData.to_MultiLink.map(ml =>
+      testEntityMultiLinkApi.entityBuilder().keyProperty(ml.KeyProperty).build()
+    );
+  }
+
+  return entity;
+}
+
+export function createTestEntityWithEnumKey(
+  originalData
+): TestEntityWithEnumKey {
+  return testEntityWithEnumKeyApi
+    .entityBuilder()
+    .keyPropertyEnum1(originalData.KeyPropertyEnum1)
+    .build()
+    .setOrInitializeRemoteState();
+}
+
+export function testEntityResourcePath(guid, str): string {
+  return `A_TestEntity(KeyPropertyGuid=${createUriConverter(
+    defaultDeSerializers
+  )(guid, 'Edm.Guid')},KeyPropertyString='${str}')`;
+}

--- a/test-resources/test/test-util/test-data.ts
+++ b/test-resources/test/test-util/test-data.ts
@@ -1,25 +1,6 @@
 import { v4 as uuid } from 'uuid';
-import { defaultDeSerializers } from '@sap-cloud-sdk/odata-v4';
-import {
-  TestEntity,
-  testService
-} from '@sap-cloud-sdk/test-services/v2/test-service';
-import {
-  TestEntity as TestEntityV4,
-  TestEntityWithEnumKey,
-  testService as testServiceV4
-} from '@sap-cloud-sdk/test-services/v4/test-service';
-import { TestEnumType } from '@sap-cloud-sdk/test-services/v4/test-service/TestEnumType';
-import { createUriConverter } from '@sap-cloud-sdk/odata-common/internal';
+import { TestEnumType } from '@sap-cloud-sdk/test-services/v4/test-service';
 
-const { testEntityApi, testEntitySingleLinkApi, testEntityMultiLinkApi } =
-  testService();
-const {
-  testEntityApi: testEntityApiV4,
-  testEntityMultiLinkApi: testEntityMultiLinkApiV4,
-  testEntitySingleLinkApi: testEntitySingleLinkApiV4,
-  testEntityWithEnumKeyApi: testEntityWithEnumKeyApiV4
-} = testServiceV4();
 export function createOriginalTestEntityData1() {
   return {
     KeyPropertyGuid: uuid(),
@@ -56,84 +37,8 @@ export function createOriginalTestEntityDataWithLinks() {
   };
 }
 
-export function createTestEntity(originalData): TestEntity {
-  const entity = testEntityApi
-    .entityBuilder()
-    .keyPropertyGuid(originalData.KeyPropertyGuid)
-    .keyPropertyString(originalData.KeyPropertyString)
-    .stringProperty(originalData.StringProperty)
-    .booleanProperty(originalData.BooleanProperty)
-    .int16Property(originalData.Int16Property)
-    .build()
-    .setOrInitializeRemoteState();
-  if (originalData.to_SingleLink) {
-    entity.toSingleLink = testEntitySingleLinkApi
-      .entityBuilder()
-      .keyProperty(originalData.to_SingleLink.KeyProperty)
-      .build();
-  }
-  if (originalData.to_MultiLink) {
-    entity.toMultiLink = originalData.to_MultiLink.map(ml =>
-      testEntityMultiLinkApi.entityBuilder().keyProperty(ml.KeyProperty).build()
-    );
-  }
-  return entity;
-}
-
-export function createTestEntityV4(originalData): TestEntityV4 {
-  const entity = testEntityApiV4
-    .entityBuilder()
-    .keyPropertyGuid(originalData.KeyPropertyGuid)
-    .keyPropertyString(originalData.KeyPropertyString)
-    .stringProperty(originalData.StringProperty)
-    .booleanProperty(originalData.BooleanProperty)
-    .int16Property(originalData.Int16Property)
-    .enumProperty(originalData.EnumProperty)
-    .build()
-    .setOrInitializeRemoteState();
-  if (originalData.to_SingleLink) {
-    entity.toSingleLink = testEntitySingleLinkApiV4
-      .entityBuilder()
-      .keyProperty(originalData.to_SingleLink.KeyProperty)
-      .build();
-  }
-  if (originalData.to_MultiLink) {
-    entity.toMultiLink = originalData.to_MultiLink.map(ml =>
-      testEntityMultiLinkApiV4
-        .entityBuilder()
-        .keyProperty(ml.KeyProperty)
-        .build()
-    );
-  }
-  return entity;
-}
-
-export function testEntityResourcePath(
-  guid,
-  str,
-  toUriFormat = createUriConverter(defaultDeSerializers),
-  entityName = 'A_TestEntity'
-): string {
-  return `${entityName}(KeyPropertyGuid=${toUriFormat(
-    guid,
-    'Edm.Guid'
-  )},KeyPropertyString='${str}')`;
-}
-
 export function createOriginalTestEntityWithEnumKeyData() {
   return {
     KeyPropertyEnum1: TestEnumType.Member1
   };
 }
-
-export function createTestEntityWithEnumKey(
-  originalData
-): TestEntityWithEnumKey {
-  return testEntityWithEnumKeyApiV4
-    .entityBuilder()
-    .keyPropertyEnum1(originalData.KeyPropertyEnum1)
-    .build()
-    .setOrInitializeRemoteState();
-}
-
-// v4 toUriFormat


### PR DESCRIPTION
Improve test-utils to avoid confusion between v2/v4 entities in tests. This also fixes some incorrect usage of v2/v4 entites.