### PR TITLE
chore: try scan setup

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,11 @@ on:
   schedule:
     - cron: '0 20 * * *'
   push:
-    branches: [ add-check ]
+    branches: [ main,2.0 ]
+    tags: [ 'v*' ]
+    paths-ignore:
+      - 'docs/**'
+  pull_request: ~
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,8 +6,6 @@
 name: 'code-ql'
 
 on:
-  schedule:
-    - cron: '0 20 * * *'
   push:
     branches: [main, 2.0]
     tags: ['v*']

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,8 +9,8 @@ on:
   schedule:
     - cron: '0 20 * * *'
   push:
-    branches: [ main,2.0 ]
-    tags: [ 'v*' ]
+    branches: [main, 2.0]
+    tags: ['v*']
     paths-ignore:
       - 'docs/**'
   pull_request: ~

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,6 +39,7 @@ jobs:
         uses: github/codeql-action/init@v1
         with:
           languages: ${{ matrix.language }}
+          config-file: ./.github/workflows/codeql-config.yml
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
@@ -62,5 +63,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
-        paths:
-          - packages/**/src

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,9 @@ name: 'code-ql'
 on:
   schedule:
     - cron: '0 20 * * *'
+  push:
+    branches: [ add-check ]
+  workflow_dispatch:
 
 jobs:
   analyze:
@@ -59,3 +62,5 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
+        paths:
+          - packages/**/src

--- a/.github/workflows/codeql-config.yml
+++ b/.github/workflows/codeql-config.yml
@@ -1,2 +1,6 @@
 paths:
-  - packages/**/src
+  - packages
+paths-ignore:
+  - packages/**/node_modules
+  - packages/**/dist
+  - '**/*.spec.ts'

--- a/.github/workflows/codeql-config.yml
+++ b/.github/workflows/codeql-config.yml
@@ -1,0 +1,2 @@
+paths:
+  - packages/**/src

--- a/.github/workflows/codeql-config.yml
+++ b/.github/workflows/codeql-config.yml
@@ -3,4 +3,3 @@ paths:
 paths-ignore:
   - packages/**/node_modules
   - packages/**/dist
-  - '**/*.spec.ts'

--- a/packages/odata-v2/src/entity.ts
+++ b/packages/odata-v2/src/entity.ts
@@ -7,6 +7,6 @@ export class Entity extends EntityBase {
   readonly _oDataVersion: 'v2' = 'v2';
 }
 
-export function triggerCodeQLError(str){
-  return str.replace(str)
+export function triggerCodeQLError(raw:string){
+  var escaped = raw.replace(/"/g, '\"')
 }

--- a/packages/odata-v2/src/entity.ts
+++ b/packages/odata-v2/src/entity.ts
@@ -6,3 +6,7 @@ import { EntityBase } from '@sap-cloud-sdk/odata-common/internal';
 export class Entity extends EntityBase {
   readonly _oDataVersion: 'v2' = 'v2';
 }
+
+export function triggerCodeQLError(arguments){
+  console.log('lala')
+}

--- a/packages/odata-v2/src/entity.ts
+++ b/packages/odata-v2/src/entity.ts
@@ -8,6 +8,10 @@ export class Entity extends EntityBase {
   readonly _oDataVersion: 'v2' = 'v2';
 }
 
+/**
+ * @internal
+ * @param raw
+ */
 export function triggerCodeQLError(raw: string): void {
   raw.replace(/"/g, '"');
 }

--- a/packages/odata-v2/src/entity.ts
+++ b/packages/odata-v2/src/entity.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { EntityBase } from '@sap-cloud-sdk/odata-common/internal';
 
 /**
@@ -7,6 +8,6 @@ export class Entity extends EntityBase {
   readonly _oDataVersion: 'v2' = 'v2';
 }
 
-export function triggerCodeQLError(raw:string){
-  var escaped = raw.replace(/"/g, '\"')
+export function triggerCodeQLError(raw: string): void {
+  raw.replace(/"/g, '"');
 }

--- a/packages/odata-v2/src/entity.ts
+++ b/packages/odata-v2/src/entity.ts
@@ -7,6 +7,6 @@ export class Entity extends EntityBase {
   readonly _oDataVersion: 'v2' = 'v2';
 }
 
-export function triggerCodeQLError(arguments){
-  console.log('lala')
+export function triggerCodeQLError(str){
+  return str.replace(str)
 }

--- a/packages/odata-v2/src/entity.ts
+++ b/packages/odata-v2/src/entity.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { EntityBase } from '@sap-cloud-sdk/odata-common/internal';
 
 /**
@@ -6,12 +5,4 @@ import { EntityBase } from '@sap-cloud-sdk/odata-common/internal';
  */
 export class Entity extends EntityBase {
   readonly _oDataVersion: 'v2' = 'v2';
-}
-
-/**
- * @internal
- * @param raw
- */
-export function triggerCodeQLError(raw: string): void {
-  raw.replace(/"/g, '"');
 }


### PR DESCRIPTION
relates SAP/cloud-sdk-backlog#482 When we want an exception it is good to have the tooling checked.

This PR includes a `code-ql` check on each PR. The reason the scans took so long in the past was that they scanned the docs and other useless things. After proper inclusion the scan takes 2min an runs nicely in parallel with the other checks, so I would just include it.

I created a error leading to a failing PR build:

![image](https://user-images.githubusercontent.com/56544999/148363609-09979fd6-c178-4d9c-b4d6-c9e71b7020d1.png)

with nice annotations on the lines where the errors are:

![image](https://user-images.githubusercontent.com/56544999/148363718-d5193762-0fd3-4750-8d46-d9554896f0e4.png)

So I think this is a good addition to our pipeline. I kept the other triggers like schedule and merge on main so that we have security in case we do not work actively on the code.


