### PR TITLE
fix: missing token for OAuth2Password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- [core] Fix `OAuth2Password` auth type for the missing token in the header. 
 
 
 # 1.53.0

--- a/packages/core/src/connectivity/scp-cf/authorization-header.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/authorization-header.spec.ts
@@ -226,6 +226,33 @@ describe('getAuthHeaders', () => {
     });
   });
 
+  describe('OAuth2Password', () => {
+    it('should add the auth token from the destination', async () => {
+      const destination: Destination = {
+        ...defaultDestination,
+        authentication: 'OAuth2Password',
+        authTokens: [
+          {
+            type: 'Bearer',
+            value: 'some.token',
+            expiresIn: '3600',
+            error: null,
+            http_header: {
+              key: 'Authorization',
+              value: 'Bearer some.token'
+            }
+          }
+        ]
+      };
+
+      const actual = await getAuthHeaders(destination);
+
+      expect(actual).toEqual({
+        authorization: 'Bearer some.token'
+      });
+    });
+  });
+
   describe('auth token errors', () => {
     it('throws an error if the error property is truthy for all provided authTokens', async () => {
       const destination: Destination = {

--- a/packages/core/src/connectivity/scp-cf/authorization-header.ts
+++ b/packages/core/src/connectivity/scp-cf/authorization-header.ts
@@ -257,6 +257,7 @@ async function getAuthenticationRelatedHeaders(
     case 'OAuth2UserTokenExchange':
     case 'OAuth2JWTBearer':
     case 'OAuth2ClientCredentials':
+    case 'OAuth2Password':
       return headerFromTokens(
         destination.authentication,
         destination.authTokens

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -25,7 +25,6 @@ describe('OAuth flows', () => {
     accessToken = readUserAccessToken();
     systems = readSystems();
     loadLocalVcap();
-    destinationService = getService('destination');
   });
 
   xit('OAuth2Password: Fetches destination and destination service has token', async () => {

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -1,7 +1,6 @@
 import {
   Destination,
   executeHttpRequest,
-  getService,
   wrapJwtInHeader,
   getDestination,
   getDestinationFromDestinationService


### PR DESCRIPTION
Related to: https://github.com/SAP/cloud-sdk-backlog/issues/510

The SDK receives the destination object from the destination service successfully for this auth type, including auth token.
However, the token is not added to the header of the real request.

This PR fixes the missing token.

Follow up:
- check the token in the header for all the auth type, which might introduce breaking changes (v2 only implementation), as the `AuthenticationType` is a type, which is gone in runtime. Use e.g., enum as alternatives.