### PR TITLE
chore: replace moment in cache with Date and number

### DIFF
--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -40,7 +40,6 @@
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
     "jsonwebtoken": "^8.5.1",
-    "moment": "^2.29.0",
     "opossum": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -125,9 +125,9 @@ function inferExpirationTime(
 function inferExpirationTimeFromDate(expirationTime: DateInputObject): number {
   const currentDate = new Date();
   const milliseconds =
-    ((expirationTime?.hours ?? 0) * 60 * 60 * 1000) +
-    ((expirationTime?.minutes ?? 0) * 60 * 1000) +
-    ((expirationTime?.seconds ?? 0) * 1000) +
+    (expirationTime?.hours ?? 0) * 60 * 60 * 1000 +
+    (expirationTime?.minutes ?? 0) * 60 * 1000 +
+    (expirationTime?.seconds ?? 0) * 1000 +
     (expirationTime?.milliseconds ?? 0);
 
   return currentDate

--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -125,9 +125,9 @@ function inferExpirationTime(
 function inferExpirationTimeFromDate(expirationTime: DateInputObject): number {
   const currentDate = new Date();
   const milliseconds =
-    (expirationTime?.hours ?? 0) * 60 * 60 * 1000 +
-    (expirationTime?.minutes ?? 0) * 60 * 1000 +
-    (expirationTime?.seconds ?? 0) * 1000 +
+    ((expirationTime?.hours ?? 0) * 60 * 60 * 1000) +
+    ((expirationTime?.minutes ?? 0) * 60 * 1000) +
+    ((expirationTime?.seconds ?? 0) * 1000) +
     (expirationTime?.milliseconds ?? 0);
 
   return currentDate

--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -111,7 +111,7 @@ function isExpired<T>(item: CacheEntry<T>): boolean {
 function inferExpirationTime(
   expirationTime: DateInputObject | undefined
 ): number | undefined {
-  return expirationTime ? addDate(expirationTime) : undefined;
+  return expirationTime ? inferExpirationTimeFromDate(expirationTime) : undefined;
 }
 
 interface DateInputObject {
@@ -144,7 +144,7 @@ interface DateInputObject {
   ms?: number;
 }
 
-function addDate(expirationTime: DateInputObject): number {
+function inferExpirationTimeFromDate(expirationTime: DateInputObject): number {
   const currentDate = new Date();
   // const years = currentDate.setFullYear(
   //   expirationTime.years ?? expirationTime.year ?? expirationTime.y ??

--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -4,6 +4,13 @@ interface CacheInterface<T> {
   set(key: string, item: T, expirationTime?: number): void;
 }
 
+interface DateInputObject {
+  hours?: number;
+  minutes?: number;
+  seconds?: number;
+  milliseconds?: number;
+}
+
 /**
  * @internal
  */
@@ -104,70 +111,26 @@ function isExpired<T>(item: CacheEntry<T>): boolean {
   if (item.expires === undefined) {
     return false;
   }
-  // return !item.expires.isAfter(moment());
   return item.expires < Date.now();
 }
 
 function inferExpirationTime(
   expirationTime: DateInputObject | undefined
 ): number | undefined {
-  return expirationTime ? inferExpirationTimeFromDate(expirationTime) : undefined;
-}
-
-interface DateInputObject {
-  years?: number;
-  year?: number;
-  y?: number;
-
-  months?: number;
-  month?: number;
-  M?: number;
-
-  dates?: number;
-  date?: number;
-  D?: number;
-
-  hours?: number;
-  hour?: number;
-  h?: number;
-
-  minutes?: number;
-  minute?: number;
-  m?: number;
-
-  seconds?: number;
-  second?: number;
-  s?: number;
-
-  milliseconds?: number;
-  millisecond?: number;
-  ms?: number;
+  return expirationTime
+    ? inferExpirationTimeFromDate(expirationTime)
+    : undefined;
 }
 
 function inferExpirationTimeFromDate(expirationTime: DateInputObject): number {
   const currentDate = new Date();
-  // const years = currentDate.setFullYear(
-  //   expirationTime.years ?? expirationTime.year ?? expirationTime.y ??
-  // const months =
-  //   expirationTime?.months ?? expirationTime.month ?? expirationTime.m ?? 0;
-  // const dates =
-  //   expirationTime?.dates ?? expirationTime.dates ?? expirationTime.D;
-  const hours =
-    expirationTime?.hours ?? expirationTime.hour ?? expirationTime.h ?? 0;
-  const minutes =
-    expirationTime?.minutes ?? expirationTime.minute ?? expirationTime.m ?? 0;
-  const seconds =
-    expirationTime?.seconds ?? expirationTime.second ?? expirationTime.s ?? 0;
   const milliseconds =
-    expirationTime?.milliseconds ??
-    expirationTime.millisecond ??
-    expirationTime.ms ??
-    0;
+    (expirationTime?.hours ?? 0) * 60 * 60 * 1000 +
+    (expirationTime?.minutes ?? 0) * 60 * 1000 +
+    (expirationTime?.seconds ?? 0) * 1000 +
+    (expirationTime?.milliseconds ?? 0);
 
-  currentDate.setHours(currentDate.getHours() + hours);
-  currentDate.setMinutes(currentDate.getMinutes() + minutes);
-  currentDate.setSeconds(currentDate.getSeconds() + seconds);
-  currentDate.setMilliseconds(currentDate.getMilliseconds() + milliseconds);
-
-  return currentDate.valueOf();
+  return currentDate
+    .setMilliseconds(currentDate.getMilliseconds() + milliseconds)
+    .valueOf();
 }

--- a/packages/connectivity/src/scp-cf/client-credentials-token-cache.ts
+++ b/packages/connectivity/src/scp-cf/client-credentials-token-cache.ts
@@ -1,5 +1,4 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import moment from 'moment';
 import { Cache } from './cache';
 import { ClientCredentialsResponse } from './xsuaa-service-types';
 
@@ -22,9 +21,7 @@ const ClientCredentialsTokenCache = (
     cache.set(
       getCacheKey(url, clientId),
       token,
-      token.expires_in
-        ? moment().add(token.expires_in, 'second').unix() * 1000
-        : undefined
+      token.expires_in ? Date.now() + token.expires_in * 1000 : undefined
     );
   },
   clear: (): void => {

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.ts
@@ -1,5 +1,4 @@
 import { createLogger, first } from '@sap-cloud-sdk/util';
-import moment from 'moment';
 import { Cache, IsolationStrategy } from '../cache';
 import { tenantId } from '../tenant';
 import { userId } from '../user';
@@ -108,7 +107,8 @@ function cacheRetrievedDestination(
   const key = getDestinationCacheKey(decodedJwt, destination.name, isolation);
   const expiresIn = first(destination.authTokens || [])?.expiresIn;
   const expirationTime = expiresIn
-    ? moment().add(expiresIn, 'second').unix() * 1000
+    ? // ? moment().add(expiresIn, 'second').unix() * 1000
+      Date.now() + Number(expiresIn) * 1000
     : undefined;
   cache.set(key, destination, expirationTime);
 }

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.ts
@@ -107,8 +107,7 @@ function cacheRetrievedDestination(
   const key = getDestinationCacheKey(decodedJwt, destination.name, isolation);
   const expiresIn = first(destination.authTokens || [])?.expiresIn;
   const expirationTime = expiresIn
-    ? // ? moment().add(expiresIn, 'second').unix() * 1000
-      Date.now() + Number(expiresIn) * 1000
+    ? Date.now() + parseInt(expiresIn) * 1000
     : undefined;
   cache.set(key, destination, expirationTime);
 }


### PR DESCRIPTION
Please provide a description of what your change does and why it is needed.

Replace moment lib using in connectivity pkg for caching with Date and number. 

Closes SAP/cloud-sdk-backlog#490.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
