### PR TITLE
fix: move `typescript` to dev dependency

### DIFF
--- a/packages/odata-common/package.json
+++ b/packages/odata-common/package.json
@@ -37,9 +37,11 @@
     "@sap-cloud-sdk/connectivity": "^1.50.0",
     "voca": "^1.4.0",
     "@sap-cloud-sdk/util": "^1.50.0",
-    "typescript": "~4.4.4",
     "bignumber.js": "^9.0.0",
     "moment": "^2.29.0",
     "uuid": "^8.2.0"
+  },
+  "devDependencies": {
+    "typescript": "~4.4.4"
   }
 }

--- a/packages/odata-v2/package.json
+++ b/packages/odata-v2/package.json
@@ -39,11 +39,11 @@
     "bignumber.js": "^9.0.0",
     "uuid": "^8.2.0",
     "moment": "^2.29.0",
-    "typescript": "~4.4.4",
     "@js-temporal/polyfill": "^0.3.0"
   },
   "devDependencies": {
     "@sap-cloud-sdk/test-services": "^1.50.0",
-    "nock": "^13.0.11"
+    "nock": "^13.0.11",
+    "typescript": "~4.4.4"
   }
 }

--- a/packages/odata-v4/package.json
+++ b/packages/odata-v4/package.json
@@ -39,11 +39,11 @@
     "bignumber.js": "^9.0.0",
     "moment": "^2.29.0",
     "uuid": "^8.2.0",
-    "typescript": "~4.4.4",
     "@js-temporal/polyfill": "^0.3.0"
   },
   "devDependencies": {
     "@sap-cloud-sdk/test-services": "^1.50.0",
-    "nock": "^13.0.11"
+    "nock": "^13.0.11",
+    "typescript": "~4.4.4"
   }
 }


### PR DESCRIPTION
The `typescript` costs 60+MB, which should be used as dev dependency.