### PR TITLE
test: use fixed version for internal dependencies

### DIFF
--- a/packages/odata-v2/package.json
+++ b/packages/odata-v2/package.json
@@ -32,10 +32,10 @@
     "check:dependencies": "depcheck . --ignores=@sap-cloud-sdk/odata-v2"
   },
   "dependencies": {
-    "@sap-cloud-sdk/http-client": "next",
-    "@sap-cloud-sdk/connectivity": "next",
-    "@sap-cloud-sdk/util": "next",
-    "@sap-cloud-sdk/odata-common": "next",
+    "@sap-cloud-sdk/http-client": "1.50.0",
+    "@sap-cloud-sdk/connectivity": "1.50.0",
+    "@sap-cloud-sdk/util": "1.50.0",
+    "@sap-cloud-sdk/odata-common": "1.50.0",
     "bignumber.js": "^9.0.0",
     "uuid": "^8.2.0",
     "moment": "^2.29.0",

--- a/packages/odata-v2/package.json
+++ b/packages/odata-v2/package.json
@@ -32,10 +32,10 @@
     "check:dependencies": "depcheck . --ignores=@sap-cloud-sdk/odata-v2"
   },
   "dependencies": {
-    "@sap-cloud-sdk/http-client": "^1.50.0",
-    "@sap-cloud-sdk/connectivity": "^1.50.0",
-    "@sap-cloud-sdk/util": "^1.50.0",
-    "@sap-cloud-sdk/odata-common": "^1.50.0",
+    "@sap-cloud-sdk/http-client": "next",
+    "@sap-cloud-sdk/connectivity": "next",
+    "@sap-cloud-sdk/util": "next",
+    "@sap-cloud-sdk/odata-common": "next",
     "bignumber.js": "^9.0.0",
     "uuid": "^8.2.0",
     "moment": "^2.29.0",


### PR DESCRIPTION
In `odata-v2` package, we use e.g, `odata-common` as dependency.
When installing `odata-v2@next`, as transitive dependency, `odata-common:^2.0.0-20220107111025.0+a0f3521c` is used.
However, [semver](https://semver.npmjs.com) shows, `odata-common@2.0.0-beta.0` is chosen.

This PR is testing, whether switching to fixed version for all sdk internal dependency can solve the issue.