### PR TITLE
test: use beta 1 for next versions

### DIFF
--- a/.github/workflows/v2.yaml
+++ b/.github/workflows/v2.yaml
@@ -100,6 +100,6 @@ jobs:
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
           date=`date +%Y%m%d%H%M%S`
-          yarn lerna publish --canary major --no-push --no-git-tag-version --dist-tag next --force-publish --preid "${date}" -y
+          yarn lerna publish --canary major --no-push --no-git-tag-version --dist-tag next --force-publish --preid "beta.1-${date}" -y
         env:
           NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}


### PR DESCRIPTION
We tested the fixed version in the previous PR: https://github.com/SAP/cloud-sdk-js/pull/1953 which did not work.
This is a new test, and hopefully the `next` versions now are newer than `2.0.0-beta.0`. 