### PR TITLE
chore: Rename origin options to lower case

### DIFF
--- a/CHANGELOG-v2.md
+++ b/CHANGELOG-v2.md
@@ -432,8 +432,8 @@
 ## New Functionality
 
 - [connectivity] Create a new package with minimal API.
-  - `registerDestination` function to add destinations to the environment variables
-- [http-client] Create a new package with minimal API
+- [http-client] Create a new package with minimal API.
+- [connectivity] Add `registerDestination` function to create destinations in the `destinations` environment variable.
 
 ## Improvements
 

--- a/CHANGELOG-v2.md
+++ b/CHANGELOG-v2.md
@@ -432,8 +432,8 @@
 ## New Functionality
 
 - [connectivity] Create a new package with minimal API.
-- [http-client] Create a new package with minimal API.
 - [connectivity] Add `registerDestination` function to create destinations in the `destinations` environment variable.
+- [http-client] Create a new package with minimal API.
 
 ## Improvements
 

--- a/packages/http-client/src/http-client-types.ts
+++ b/packages/http-client/src/http-client-types.ts
@@ -89,17 +89,9 @@ export interface HttpRequestOptions {
   fetchCsrfToken?: boolean;
 }
 
-/**
- * Origins of http request options. This indicates the priority of an http request option.
- * Http request options with higher priorities will be used when reaching conflicts.
- * The priority is "Custom" \> "DestinationProperty" \> "Destination" \> "RequestConfig"
- */
-export type Origin =
-  | 'Custom'
-  | 'DestinationProperty'
-  | 'Destination'
-  | 'RequestConfig';
-
-export type OriginOptions = {
-  [key in Origin]?: Record<string, string>;
-};
+export interface OriginOptions {
+  requestConfig?: Record<string, string>;
+  destination?: Record<string, string>;
+  destinationProperty?: Record<string, string>;
+  custom?: Record<string, string>;
+}

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -153,7 +153,7 @@ export async function buildAxiosRequestConfig<T extends HttpRequestConfig>(
  * and executes it (using Axios).
  * @param destination - A destination or a destination name and a JWT.
  * @param requestConfig - Any object representing an HTTP request.
- * @param options - An [[HttpRequestOptions]] of the http request for configuring e.g., csrf token delegation. By default, the SDK will not fetch the csrf token.
+ * @param options - An [[HttpRequestOptions]] of the http request for configuring e.g., CSRF token delegation. By default, the SDK will not fetch the CSRF token.
  * @returns A promise resolving to an [[HttpResponse]].
  */
 export function executeHttpRequest<T extends HttpRequestConfig>(
@@ -169,7 +169,7 @@ export function executeHttpRequest<T extends HttpRequestConfig>(
  * and executes it (using Axios).
  * @param destination - A destination or a destination name and a JWT.
  * @param requestConfig - Any object representing an HTTP request.
- * @param options - An [[HttpRequestOptions]] of the http request for configuring e.g., csrf token delegation. By default, the SDK will not fetch the csrf token.
+ * @param options - An [[HttpRequestOptions]] of the http request for configuring e.g., CSRF token delegation. By default, the SDK will not fetch the CSRF token.
  * @returns A promise resolving to an [[HttpResponse]].
  */
 export function executeHttpRequestWithOrigin<

--- a/packages/http-client/src/http-request-config.spec.ts
+++ b/packages/http-client/src/http-request-config.spec.ts
@@ -39,12 +39,12 @@ describe('buildHttpRequestConfig', () => {
     const withOrigin: HttpRequestConfigWithOrigin = {
       method: 'get',
       headers: {
-        DestinationProperty: { Authorization: 'destProp' },
-        RequestConfig: { Authorization: 'reqConfig' }
+        destinationProperty: { Authorization: 'destProp' },
+        requestConfig: { Authorization: 'reqConfig' }
       },
       params: {
-        Custom: { param: 'custom' },
-        RequestConfig: { param: 'reqConfig' }
+        custom: { param: 'custom' },
+        requestConfig: { param: 'reqConfig' }
       }
     };
 
@@ -60,9 +60,9 @@ describe('buildHttpRequestConfig', () => {
 describe('getOptionWithPriority', () => {
   it('should merge options', () => {
     const originOptions: OriginOptions = {
-      Custom: { Authorization: 'customAuth' },
-      Destination: { 'sap-client': '001' },
-      RequestConfig: { 'if-match': 'etag' }
+      custom: { Authorization: 'customAuth' },
+      destination: { 'sap-client': '001' },
+      requestConfig: { 'if-match': 'etag' }
     };
     const expected = {
       Authorization: 'customAuth',
@@ -74,13 +74,13 @@ describe('getOptionWithPriority', () => {
 
   it('should use options with higher priority', () => {
     const originOptions: OriginOptions = {
-      Custom: { param1: 'customParam1' },
-      DestinationProperty: {
+      custom: { param1: 'customParam1' },
+      destinationProperty: {
         param1: 'destPropParam1',
         param2: 'destPropParam2'
       },
-      Destination: { param2: 'destParam2', param3: 'destParam3' },
-      RequestConfig: { param3: 'reqParam3', param4: 'reqParam4' }
+      destination: { param2: 'destParam2', param3: 'destParam3' },
+      requestConfig: { param3: 'reqParam3', param4: 'reqParam4' }
     };
     const expected = {
       param1: 'customParam1',
@@ -93,8 +93,8 @@ describe('getOptionWithPriority', () => {
 
   it('should use options with higher priority and ignore case', () => {
     const originOptions: OriginOptions = {
-      Custom: { Authorization: 'customAuth' },
-      Destination: { AuTHORizaTION: 'destAuth', 'sap-client': '001' }
+      custom: { Authorization: 'customAuth' },
+      destination: { AuTHORizaTION: 'destAuth', 'sap-client': '001' }
     };
     const expected = {
       Authorization: 'customAuth',

--- a/packages/http-client/src/http-request-config.ts
+++ b/packages/http-client/src/http-request-config.ts
@@ -2,7 +2,6 @@ import { createLogger, exclude, mergeIgnoreCase } from '@sap-cloud-sdk/util';
 import {
   HttpRequestConfig,
   HttpRequestConfigWithOrigin,
-  Origin,
   OriginOptions
 } from './http-client-types';
 
@@ -71,18 +70,20 @@ export function mergeOptionsWithPriority(
   headersOrParams?: OriginOptions
 ): Record<string, string> | undefined {
   if (headersOrParams) {
-    return getAllOriginsAsc().reduce(
-      (prev, origin) => mergeIgnoreCase(prev, headersOrParams[origin]),
-      {} as Record<string, string>
+    return origins.reduce(
+      (mergedHeadersOrParams, origin) =>
+        mergeIgnoreCase(mergedHeadersOrParams, headersOrParams[origin]),
+      {}
     );
   }
 }
 
 /**
- * Get all [[Origin]]s as an array in an ascent order (from low to high priority).
- * @returns Origins in an ascent oder.
- * @internal
+ * All origins ordered from low to high priority.
  */
-export function getAllOriginsAsc(): Origin[] {
-  return ['RequestConfig', 'Destination', 'DestinationProperty', 'Custom'];
-}
+const origins = [
+  'requestConfig',
+  'destination',
+  'destinationProperty',
+  'custom'
+];

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -8,7 +8,6 @@ export {
   HttpRequestOptions,
   HttpResponse,
   Method,
-  Origin,
   OriginOptions
 } from './http-client-types';
 export { mergeOptionsWithPriority } from './http-request-config';

--- a/packages/odata-common/src/header-builder.spec.ts
+++ b/packages/odata-common/src/header-builder.spec.ts
@@ -19,7 +19,7 @@ describe('Header-Builder', () => {
     request.config.customHeaders = { authorization: authString };
 
     const headers = await buildHeaders(request);
-    expect(headers.Custom!.authorization).toBe(authString);
+    expect(headers.custom!.authorization).toBe(authString);
   });
 
   it('uses authTokens if present on a destination', async () => {
@@ -42,7 +42,7 @@ describe('Header-Builder', () => {
     const request = new ODataRequest(getAllRequestConfig(), destination);
     const headers = await buildHeaders(request);
 
-    expect(headers.Destination!.authorization).toBe('Bearer some.token');
+    expect(headers.destination!.authorization).toBe('Bearer some.token');
   });
 
   const commonEntity = new CommonEntityApi().entityBuilder().build();
@@ -69,7 +69,7 @@ describe('Header-Builder', () => {
       mockHeaderRequest({ request });
 
       const actual = await buildHeaders(request);
-      expect(actual.RequestConfig!['if-match']).toBe('W//');
+      expect(actual.requestConfig!['if-match']).toBe('W//');
     });
 
     it('if-match should be set to * when version identifier is ignored', async () => {
@@ -84,7 +84,7 @@ describe('Header-Builder', () => {
       mockHeaderRequest({ request });
 
       const actual = await buildHeaders(request);
-      expect(actual.RequestConfig!['if-match']).toBe('*');
+      expect(actual.requestConfig!['if-match']).toBe('*');
     });
   });
 
@@ -107,8 +107,8 @@ describe('Header-Builder', () => {
     const request = new ODataRequest(getAllRequestConfig(), destination);
     const headers = await request.headers();
 
-    expect(headers.Destination!['Proxy-Authorization']).toBe('Bearer jwt');
-    expect(headers.Destination!['SAP-Connectivity-Authentication']).toBe(
+    expect(headers.destination!['Proxy-Authorization']).toBe('Bearer jwt');
+    expect(headers.destination!['SAP-Connectivity-Authentication']).toBe(
       'Bearer jwt'
     );
   });
@@ -121,7 +121,7 @@ describe('Header-Builder', () => {
 
     const request = new ODataRequest(getAllRequestConfig(), destination);
     const headers = await request.headers();
-    expect(headers.Destination!['SAP-Connectivity-SCC-Location_ID']).toBe(
+    expect(headers.destination!['SAP-Connectivity-SCC-Location_ID']).toBe(
       'Potsdam'
     );
   });
@@ -133,7 +133,7 @@ describe('Header-Builder', () => {
     });
 
     const headers = await request.headers();
-    expect(headers.Destination!.authorization).toBe('Basic SOMETHINGSOMETHING');
+    expect(headers.destination!.authorization).toBe('Basic SOMETHINGSOMETHING');
   });
 
   it('Prioritizes custom Authorization headers (lower case A)', async () => {
@@ -143,6 +143,6 @@ describe('Header-Builder', () => {
     });
 
     const headers = await request.headers();
-    expect(headers.Destination!.authorization).toBe('Basic SOMETHINGSOMETHING');
+    expect(headers.destination!.authorization).toBe('Basic SOMETHINGSOMETHING');
   });
 });

--- a/packages/odata-common/src/request/odata-request.ts
+++ b/packages/odata-common/src/request/odata-request.ts
@@ -167,9 +167,9 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
         this.config.customHeaders
       );
       return {
-        Custom: this.customHeaders(),
-        Destination: destinationRelatedHeaders,
-        RequestConfig: { ...this.defaultHeaders(), ...this.eTagHeaders() }
+        custom: this.customHeaders(),
+        destination: destinationRelatedHeaders,
+        requestConfig: { ...this.defaultHeaders(), ...this.eTagHeaders() }
       };
     } catch (error) {
       throw new ErrorWithCause(
@@ -257,9 +257,9 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
 
   private queryParameters(): OriginOptions {
     return {
-      Custom: this.config.customQueryParameters,
-      Destination: this.destination?.queryParameters,
-      RequestConfig: this.config.queryParameters()
+      custom: this.config.customQueryParameters,
+      destination: this.destination?.queryParameters,
+      requestConfig: this.config.queryParameters()
     };
   }
 }

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -129,11 +129,11 @@ export class OpenApiRequestBuilder<ResponseT = any> {
   }
 
   private getHeaders(): OriginOptions {
-    return { Custom: this.customHeaders };
+    return { custom: this.customHeaders };
   }
 
   private getParameters(): OriginOptions {
-    return { RequestConfig: this.parameters?.queryParameters };
+    return { requestConfig: this.parameters?.queryParameters };
   }
 
   private getPath(): string {


### PR DESCRIPTION
Rename origin options for http requests to lower case