### PR TITLE
fix: move `odata-common` to dev dependency

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@sap-cloud-sdk/generator-common": "^1.50.0",
-    "@sap-cloud-sdk/odata-common": "^1.50.0",
     "@sap-cloud-sdk/util": "^1.50.0",
     "@sap/edm-converters": "~1.0.21",
     "@types/fs-extra": "^9.0.1",
@@ -51,6 +50,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
+    "@sap-cloud-sdk/odata-common": "^1.50.0",
     "@types/yargs": "^17.0.0",
     "mock-fs": "^5.0.0",
     "jest-extended": "^1.0.0",

--- a/packages/generator/src/generator-utils.ts
+++ b/packages/generator/src/generator-utils.ts
@@ -1,4 +1,4 @@
-import { EdmTypeShared } from '@sap-cloud-sdk/odata-common/internal';
+import type { EdmTypeShared } from '@sap-cloud-sdk/odata-common/internal';
 import { createLogger, ODataVersion } from '@sap-cloud-sdk/util';
 import {
   VdmNavigationProperty,


### PR DESCRIPTION
The `@sap-cloud-sdk/odata-common` is used as dependency in the `generator` package, while only a type is used.
As the type has nothing to do with runtime, I move it to dev dependency.