### PR TITLE
fix: move `@types/jsonwebtoken` to type test as dev dependency

### DIFF
--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -42,7 +42,6 @@
     "opossum": "^6.0.0"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "^8.3.8",
     "@types/opossum": "^6.2.0",
     "nock": "^13.0.11"
   }

--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -35,7 +35,6 @@
     "@sap-cloud-sdk/util": "^1.50.0",
     "@sap/xsenv": "^3.0.0",
     "@sap/xssec": "^3.2.7",
-    "@types/jsonwebtoken": "^8.3.8",
     "axios": "^0.24.0",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
@@ -43,6 +42,7 @@
     "opossum": "^6.0.0"
   },
   "devDependencies": {
+    "@types/jsonwebtoken": "^8.3.8",
     "@types/opossum": "^6.2.0",
     "nock": "^13.0.11"
   }

--- a/packages/connectivity/src/index.ts
+++ b/packages/connectivity/src/index.ts
@@ -4,8 +4,6 @@ export {
   toDestinationNameUrl,
   sanitizeDestination,
   Destination,
-  DestinationRetrievalOptions,
-  DestinationOptions,
   DestinationFetchOptions,
   DestinationAccessorOptions,
   getDestination,
@@ -25,13 +23,19 @@ export {
   retrieveJwt,
   VerifyJwtOptions,
   jwtBearerToken,
+  JwtPayload,
   serviceToken,
   Service,
-  ServiceCredentials,
   buildHeadersForDestination,
   getClientCredentialsToken,
   getUserToken,
   registerDestination
+} from './scp-cf';
+
+export type {
+  DestinationRetrievalOptions,
+  DestinationOptions,
+  ServiceCredentials
 } from './scp-cf';
 
 export { getAgentConfig } from './http-agent';

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import { JwtPayload } from 'jsonwebtoken';
+import { JwtPayload } from '../jsonwebtoken-type';
 import { decodeJwt, isUserToken, JwtPair, verifyJwt } from '../jwt';
 import { IsolationStrategy } from '../cache';
 import { jwtBearerToken, serviceToken } from '../token-accessor';

--- a/packages/connectivity/src/scp-cf/destination/destination-service-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-cache.ts
@@ -1,4 +1,4 @@
-import { JwtPayload } from 'jsonwebtoken';
+import { JwtPayload } from '../jsonwebtoken-type';
 import { Cache, IsolationStrategy } from '../cache';
 import { Destination } from './destination-service-types';
 import { getDestinationCacheKey } from './destination-cache';

--- a/packages/connectivity/src/scp-cf/environment-accessor.ts
+++ b/packages/connectivity/src/scp-cf/environment-accessor.ts
@@ -5,7 +5,7 @@ import {
   unique
 } from '@sap-cloud-sdk/util';
 import * as xsenv from '@sap/xsenv';
-import { JwtPayload } from 'jsonwebtoken';
+import { JwtPayload } from './jsonwebtoken-type';
 import { audiences, decodeJwt } from './jwt';
 import {
   DestinationServiceCredentials,

--- a/packages/connectivity/src/scp-cf/index.ts
+++ b/packages/connectivity/src/scp-cf/index.ts
@@ -9,6 +9,7 @@ export * from './environment-accessor-types';
 export * from './get-protocol';
 export * from './header-builder-for-destination';
 export * from './identity-service';
+export * from './jsonwebtoken-type';
 export * from './jwt';
 export * from './protocol';
 export * from './resilience-options';

--- a/packages/connectivity/src/scp-cf/jsonwebtoken-type.ts
+++ b/packages/connectivity/src/scp-cf/jsonwebtoken-type.ts
@@ -1,16 +1,24 @@
 /**
  * @internal
- * This is a copied from @types/jsonwebtoken.
+ * This is copied from `@types/jsonwebtoken`.
  */
 export type Algorithm =
-  'HS256' | 'HS384' | 'HS512' |
-  'RS256' | 'RS384' | 'RS512' |
-  'ES256' | 'ES384' | 'ES512' |
-  'PS256' | 'PS384' | 'PS512' |
-  'none';
+  | 'HS256'
+  | 'HS384'
+  | 'HS512'
+  | 'RS256'
+  | 'RS384'
+  | 'RS512'
+  | 'ES256'
+  | 'ES384'
+  | 'ES512'
+  | 'PS256'
+  | 'PS384'
+  | 'PS512'
+  | 'none';
 
 /**
- * This is a copied from @types/jsonwebtoken.
+ * This is copied from `@types/jsonwebtoken`.
  */
 export interface JwtPayload {
   [key: string]: any;
@@ -25,7 +33,7 @@ export interface JwtPayload {
 
 /**
  * @internal
- * This is a copied from @types/jsonwebtoken.
+ * This is copied from `@types/jsonwebtoken`.
  */
 export interface JwtHeader {
   alg: string | Algorithm;
@@ -42,7 +50,7 @@ export interface JwtHeader {
 
 /**
  * @internal
- * This is a copied from @types/jsonwebtoken.
+ * This is copied from `@types/jsonwebtoken`.
  */
 export interface Jwt {
   header: JwtHeader;

--- a/packages/connectivity/src/scp-cf/jsonwebtoken-type.ts
+++ b/packages/connectivity/src/scp-cf/jsonwebtoken-type.ts
@@ -1,0 +1,51 @@
+/**
+ * @internal
+ * This is a copied from @types/jsonwebtoken.
+ */
+export type Algorithm =
+  'HS256' | 'HS384' | 'HS512' |
+  'RS256' | 'RS384' | 'RS512' |
+  'ES256' | 'ES384' | 'ES512' |
+  'PS256' | 'PS384' | 'PS512' |
+  'none';
+
+/**
+ * This is a copied from @types/jsonwebtoken.
+ */
+export interface JwtPayload {
+  [key: string]: any;
+  iss?: string | undefined;
+  sub?: string | undefined;
+  aud?: string | string[] | undefined;
+  exp?: number | undefined;
+  nbf?: number | undefined;
+  iat?: number | undefined;
+  jti?: string | undefined;
+}
+
+/**
+ * @internal
+ * This is a copied from @types/jsonwebtoken.
+ */
+export interface JwtHeader {
+  alg: string | Algorithm;
+  typ?: string | undefined;
+  cty?: string | undefined;
+  crit?: (string | Exclude<keyof JwtHeader, 'crit'>)[] | undefined;
+  kid?: string | undefined;
+  jku?: string | undefined;
+  x5u?: string | string[] | undefined;
+  'x5t#S256'?: string | undefined;
+  x5t?: string | undefined;
+  x5c?: string | string[] | undefined;
+}
+
+/**
+ * @internal
+ * This is a copied from @types/jsonwebtoken.
+ */
+export interface Jwt {
+  header: JwtHeader;
+  payload: JwtPayload;
+  signature: string;
+}

--- a/packages/connectivity/src/scp-cf/jwt.ts
+++ b/packages/connectivity/src/scp-cf/jwt.ts
@@ -1,8 +1,8 @@
 import { IncomingMessage } from 'http';
 import * as url from 'url';
 import { createLogger, ErrorWithCause } from '@sap-cloud-sdk/util';
-import { Jwt, JwtHeader, JwtPayload } from './jsonwebtoken-type';
 import { decode, verify } from 'jsonwebtoken';
+import { Jwt, JwtHeader, JwtPayload } from './jsonwebtoken-type';
 import { getXsuaaServiceCredentials } from './environment-accessor';
 import { TokenKey } from './xsuaa-service-types';
 import { XsuaaServiceCredentials } from './environment-accessor-types';

--- a/packages/connectivity/src/scp-cf/jwt.ts
+++ b/packages/connectivity/src/scp-cf/jwt.ts
@@ -1,7 +1,8 @@
 import { IncomingMessage } from 'http';
 import * as url from 'url';
 import { createLogger, ErrorWithCause } from '@sap-cloud-sdk/util';
-import { decode, Jwt, JwtHeader, JwtPayload, verify } from 'jsonwebtoken';
+import { Jwt, JwtHeader, JwtPayload } from './jsonwebtoken-type';
+import { decode, verify } from 'jsonwebtoken';
 import { getXsuaaServiceCredentials } from './environment-accessor';
 import { TokenKey } from './xsuaa-service-types';
 import { XsuaaServiceCredentials } from './environment-accessor-types';

--- a/packages/connectivity/src/scp-cf/tenant.ts
+++ b/packages/connectivity/src/scp-cf/tenant.ts
@@ -1,4 +1,4 @@
-import { JwtPayload } from 'jsonwebtoken';
+import { JwtPayload } from './jsonwebtoken-type';
 import {
   checkMandatoryValue,
   JwtKeyMapping,

--- a/packages/connectivity/src/scp-cf/token-accessor.ts
+++ b/packages/connectivity/src/scp-cf/token-accessor.ts
@@ -1,5 +1,5 @@
 import { ErrorWithCause } from '@sap-cloud-sdk/util';
-import { JwtPayload } from 'jsonwebtoken';
+import { JwtPayload } from './jsonwebtoken-type'
 import { decodeJwt } from './jwt';
 import { CachingOptions } from './cache';
 import { clientCredentialsTokenCache } from './client-credentials-token-cache';

--- a/packages/connectivity/src/scp-cf/token-accessor.ts
+++ b/packages/connectivity/src/scp-cf/token-accessor.ts
@@ -1,5 +1,5 @@
 import { ErrorWithCause } from '@sap-cloud-sdk/util';
-import { JwtPayload } from './jsonwebtoken-type'
+import { JwtPayload } from './jsonwebtoken-type';
 import { decodeJwt } from './jwt';
 import { CachingOptions } from './cache';
 import { clientCredentialsTokenCache } from './client-credentials-token-cache';

--- a/packages/connectivity/src/scp-cf/user.ts
+++ b/packages/connectivity/src/scp-cf/user.ts
@@ -1,4 +1,4 @@
-import { JwtPayload } from 'jsonwebtoken';
+import { JwtPayload } from './jsonwebtoken-type';
 import {
   checkMandatoryValue,
   JwtKeyMapping,

--- a/packages/connectivity/src/scp-cf/xsuaa-service.ts
+++ b/packages/connectivity/src/scp-cf/xsuaa-service.ts
@@ -1,6 +1,6 @@
 import * as xssec from '@sap/xssec';
 import CircuitBreaker from 'opossum';
-import { JwtPayload } from 'jsonwebtoken';
+import { JwtPayload } from './jsonwebtoken-type';
 import { parseSubdomain } from './subdomain-replacer';
 import { decodeJwt } from './jwt';
 import { Service } from './environment-accessor-types';

--- a/test-packages/type-tests/package.json
+++ b/test-packages/type-tests/package.json
@@ -12,12 +12,14 @@
     "check:dependencies": "echo Nothing to check here."
   },
   "dependencies": {
+    "@sap-cloud-sdk/connectivity": "^1.50.0",
     "@sap-cloud-sdk/http-client": "^1.50.0",
     "@sap-cloud-sdk/odata-v2": "^1.50.0",
     "@sap-cloud-sdk/odata-v4": "^1.50.0",
     "@sap-cloud-sdk/test-services": "^1.50.0"
   },
   "devDependencies": {
+    "@types/jsonwebtoken": "^8.3.8",
     "dtslint": "^4.0.0"
   }
 }

--- a/test-packages/type-tests/test/jwt.spec.ts
+++ b/test-packages/type-tests/test/jwt.spec.ts
@@ -1,0 +1,5 @@
+import { decodeJwt } from '@sap-cloud-sdk/connectivity';
+import { JwtPayload } from 'jsonwebtoken';
+
+// $ExpectType JwtPayload
+const jwtPayload: JwtPayload = decodeJwt('');


### PR DESCRIPTION
The `@types/jsonwebtoken` is used as dependency in the `connectivity` package, while is is a compile time dependency.

### size
The install size of 
- `@sap-cloud-sdk/connectivity@2.0.0-beta.1-20220113152822.0` is now 8.79MB.
- `@types/jsonwebtoken` is now 1.58MB.

### major changes
- I copied some instances that are necessary
- The `@types/jsonwebtoken` is moved to the test package for testing the compatibility.
