### PR TITLE
fix: registerDestination with different parameter type

### DIFF
--- a/packages/connectivity/src/scp-cf/destination/destination-from-env.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-env.spec.ts
@@ -209,7 +209,7 @@ describe('env-destination-accessor', () => {
 });
 
 describe('registerDestination', () => {
-  const mockDestination: Destination = {
+  const mockDestination = {
     name: 'MockedDestination',
     url: 'https://example.com'
   };
@@ -249,17 +249,6 @@ describe('registerDestination', () => {
     expect(
       getDestination({ destinationName: 'MockedDestination' })
     ).resolves.toMatchObject(mockDestinationFromEnv);
-  });
-
-  it('should throw an exception if a property of the destination is missing', () => {
-    const badDestination: Destination = {
-      url: 'https://test.com'
-    };
-    expect(() => {
-      registerDestination(badDestination);
-    }).toThrowErrorMatchingInlineSnapshot(
-      '"The registerDestination function requires a destination name and url."'
-    );
   });
 
   it('should throw an exception if a name conflict occurs', () => {

--- a/packages/connectivity/src/scp-cf/destination/destination-from-env.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-env.ts
@@ -202,9 +202,9 @@ function destinationHasName(
  * Set a given destination in the `destinations` environment variable.
  *
  * Throws an error if a destination with the same name as the given test destination already exists.
- * @param destination - Test destination to add to the `destinations` environment variable
+ * @param destination - A destination to add to the `destinations` environment variable
  */
-export function registerDestination(destination: Destination): void {
+export function registerDestination(destination: DestinationWithName): void {
   const currentDestinations = getDestinationsFromEnv();
   const existingNames = new Set<string>(
     currentDestinations.filter(destinationHasName).map(dest => dest.name)


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

With this PR the `registerDestination` function expects a different type than before, it now expects `DestinationWithName` which notifies a user at design type of a mistake.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
