### PR TITLE
fix: Remove warning when using environment destinations

### DIFF
--- a/packages/connectivity/src/scp-cf/destination/destination-from-env.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-env.spec.ts
@@ -101,7 +101,7 @@ describe('env-destination-accessor', () => {
       mockDestinationsEnv(destinationFromEnv);
 
       const logger = createLogger('env-destination-accessor');
-      const warnSpy = jest.spyOn(logger, 'info');
+      const infoSpy = jest.spyOn(logger, 'info');
       await getDestination({ destinationName: 'FINAL-DESTINATION' });
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringMatching(

--- a/packages/connectivity/src/scp-cf/destination/destination-from-env.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-env.spec.ts
@@ -103,7 +103,7 @@ describe('env-destination-accessor', () => {
       const logger = createLogger('env-destination-accessor');
       const infoSpy = jest.spyOn(logger, 'info');
       await getDestination({ destinationName: 'FINAL-DESTINATION' });
-      expect(warnSpy).toHaveBeenCalledWith(
+      expect(infoSpy).toHaveBeenCalledWith(
         expect.stringMatching(
           /Successfully retrieved destination 'FINAL-DESTINATION' from environment variable./
         )

--- a/packages/connectivity/src/scp-cf/destination/destination-from-env.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-env.spec.ts
@@ -101,11 +101,11 @@ describe('env-destination-accessor', () => {
       mockDestinationsEnv(destinationFromEnv);
 
       const logger = createLogger('env-destination-accessor');
-      const warnSpy = jest.spyOn(logger, 'warn');
+      const warnSpy = jest.spyOn(logger, 'info');
       await getDestination({ destinationName: 'FINAL-DESTINATION' });
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringMatching(
-          /from environment variable.This is discouraged for productive applications./
+          /Successfully retrieved destination 'FINAL-DESTINATION' from environment variable./
         )
       );
     });

--- a/packages/connectivity/src/scp-cf/destination/destination-from-env.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-env.ts
@@ -124,16 +124,10 @@ export function searchEnvVariablesForDestination(
       if (destination) {
         if (destination.forwardAuthToken) {
           destination.authTokens = destinationAuthToken(options.jwt);
-          logger.info(
-            `Successfully retrieved destination '${options.destinationName}' from environment variable.`
-          );
-        } else {
-          logger.warn(
-            `Successfully retrieved destination '${options.destinationName}' from environment variable.` +
-              'This is discouraged for productive applications. ' +
-              'Unset the variable to read destinations from the destination service on SAP Business Technology Platform.'
-          );
         }
+        logger.info(
+          `Successfully retrieved destination '${options.destinationName}' from environment variable.`
+        );
         return destination;
       }
     } catch (error) {


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

This PR is a follow-up to our CAP meeting, where we decided to remove the warning.
It removes the warning and adapts the tests to it.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
