### PR TITLE
fix: wrong support link

### DIFF
--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -17,8 +17,6 @@ The recommended way to get in touch with us is to create an issue in our [github
 Select the issue category `Bug`, `Feature` or `Question` depending on the nature of your request.
 We try to provide fixes, features and answers as soon as possible.
 
-We also monitor questions on [StackOverflow](https://stackoverflow.com/questions/tagged/sap-cloud-sdk?tab=Newest) and [ansers.sap.com](https://answers.sap.com/tags/73555000100800000895) but prefer issues on github.
-
 ## Contribute
 
 If you would like to contribute to the SAP Cloud SDK, please make yourself familiar with our [contributing guidelines](https://github.com/SAP/cloud-sdk-js/blob/main/CONTRIBUTING.md) and follow the given instructions.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,8 +46,6 @@ The recommended way to get in touch with us is to create an issue in our [github
 Select the issue category `Bug`, `Feature` or `Question` depending on the nature of your request.
 We try to provide fixes, features and answers as soon as possible.
 
-We also monitor questions on [StackOverflow](https://stackoverflow.com/questions/tagged/sap-cloud-sdk?tab=Newest) and [ansers.sap.com](https://answers.sap.com/tags/73555000100800000895) but prefer issues on github.
-
 ## Contribute
 
 If you would like to contribute to the SAP Cloud SDK, please make yourself familiar with our [contributing guidelines](https://github.com/SAP/cloud-sdk-js/blob/main/CONTRIBUTING.md) and follow the given instructions.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -40,8 +40,6 @@ The recommended way to get in touch with us is to create an issue in our [github
 Select the issue category `Bug`, `Feature` or `Question` depending on the nature of your request.
 We try to provide fixes, features and answers as soon as possible.
 
-We also monitor questions on [StackOverflow](https://stackoverflow.com/questions/tagged/sap-cloud-sdk?tab=Newest) and [ansers.sap.com](https://answers.sap.com/tags/73555000100800000895) but prefer issues on github.
-
 ## Contribute
 
 If you would like to contribute to the SAP Cloud SDK, please make yourself familiar with our [contributing guidelines](https://github.com/SAP/cloud-sdk-js/blob/main/CONTRIBUTING.md) and follow the given instructions.

--- a/packages/generator-common/README.md
+++ b/packages/generator-common/README.md
@@ -16,8 +16,6 @@ The recommended way to get in touch with us is to create an issue in our [github
 Select the issue category `Bug`, `Feature` or `Question` depending on the nature of your request.
 We try to provide fixes, features and answers as soon as possible.
 
-We also monitor questions on [StackOverflow](https://stackoverflow.com/questions/tagged/sap-cloud-sdk?tab=Newest) and [ansers.sap.com](https://answers.sap.com/tags/73555000100800000895) but prefer issues on github.
-
 ## Contribute
 
 If you would like to contribute to the SAP Cloud SDK, please make yourself familiar with our [contributing guidelines](https://github.com/SAP/cloud-sdk-js/blob/main/CONTRIBUTING.md) and follow the given instructions.

--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -47,8 +47,6 @@ The recommended way to get in touch with us is to create an issue in our [github
 Select the issue category `Bug`, `Feature` or `Question` depending on the nature of your request.
 We try to provide fixes, features and answers as soon as possible.
 
-We also monitor questions on [StackOverflow](https://stackoverflow.com/questions/tagged/sap-cloud-sdk?tab=Newest) and [ansers.sap.com](https://answers.sap.com/tags/73555000100800000895) but prefer issues on github.
-
 ## Contribute
 
 If you would like to contribute to the SAP Cloud SDK, please make yourself familiar with our [contributing guidelines](https://github.com/SAP/cloud-sdk-js/blob/main/CONTRIBUTING.md) and follow the given instructions.

--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -125,8 +125,6 @@ The recommended way to get in touch with us is to create an issue in our [github
 Select the issue category `Bug`, `Feature` or `Question` depending on the nature of your request.
 We try to provide fixes, features and answers as soon as possible.
 
-We also monitor questions on [StackOverflow](https://stackoverflow.com/questions/tagged/sap-cloud-sdk?tab=Newest) and [ansers.sap.com](https://answers.sap.com/tags/73555000100800000895) but prefer issues on github.
-
 ## Contribute
 
 If you would like to contribute to the SAP Cloud SDK, please make yourself familiar with our [contributing guidelines](https://github.com/SAP/cloud-sdk-js/blob/main/CONTRIBUTING.md) and follow the given instructions.

--- a/packages/test-util/README.md
+++ b/packages/test-util/README.md
@@ -59,8 +59,6 @@ The recommended way to get in touch with us is to create an issue in our [github
 Select the issue category `Bug`, `Feature` or `Question` depending on the nature of your request.
 We try to provide fixes, features and answers as soon as possible.
 
-We also monitor questions on [StackOverflow](https://stackoverflow.com/questions/tagged/sap-cloud-sdk?tab=Newest) and [ansers.sap.com](https://answers.sap.com/tags/73555000100800000895) but prefer issues on github.
-
 ## Contribute
 
 If you would like to contribute to the SAP Cloud SDK, please make yourself familiar with our [contributing guidelines](https://github.com/SAP/cloud-sdk-js/blob/main/CONTRIBUTING.md) and follow the given instructions.

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -32,8 +32,6 @@ The recommended way to get in touch with us is to create an issue in our [github
 Select the issue category `Bug`, `Feature` or `Question` depending on the nature of your request.
 We try to provide fixes, features and answers as soon as possible.
 
-We also monitor questions on [StackOverflow](https://stackoverflow.com/questions/tagged/sap-cloud-sdk?tab=Newest) and [ansers.sap.com](https://answers.sap.com/tags/73555000100800000895) but prefer issues on github.
-
 ## Contribute
 
 If you would like to contribute to the SAP Cloud SDK, please make yourself familiar with our [contributing guidelines](https://github.com/SAP/cloud-sdk-js/blob/main/CONTRIBUTING.md) and follow the given instructions.

--- a/scripts/COMMON-README-PART.md
+++ b/scripts/COMMON-README-PART.md
@@ -4,8 +4,6 @@ The recommended way to get in touch with us is to create an issue in our [github
 Select the issue category `Bug`, `Feature` or `Question` depending on the nature of your request.
 We try to provide fixes, features and answers as soon as possible.
 
-We also monitor questions on [StackOverflow](https://stackoverflow.com/questions/tagged/sap-cloud-sdk?tab=Newest) and [ansers.sap.com](https://answers.sap.com/tags/73555000100800000895) but prefer issues on github.
-
 ## Contribute
 
 If you would like to contribute to the SAP Cloud SDK, please make yourself familiar with our [contributing guidelines](https://github.com/SAP/cloud-sdk-js/blob/main/CONTRIBUTING.md) and follow the given instructions.


### PR DESCRIPTION
I removed the link to stack overflow and  answers.sap.com and only keep the GH issues as suggested by Artem.

### TODOs
- [x] Regenerate all the readme files.
- [ ] Apply the changes for 2.0.