### PR TITLE
fix: missing token for OAuth2Password (#1944)

### DIFF
--- a/packages/connectivity/src/scp-cf/authorization-header.spec.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.spec.ts
@@ -216,6 +216,33 @@ describe('getAuthHeaders', () => {
     });
   });
 
+  describe('OAuth2Password', () => {
+    it('should add the auth token from the destination', async () => {
+      const destination: Destination = {
+        ...defaultDestination,
+        authentication: 'OAuth2Password',
+        authTokens: [
+          {
+            type: 'Bearer',
+            value: 'some.token',
+            expiresIn: '3600',
+            error: null,
+            http_header: {
+              key: 'Authorization',
+              value: 'Bearer some.token'
+            }
+          }
+        ]
+      };
+
+      const actual = await getAuthHeaders(destination);
+
+      expect(actual).toEqual({
+        authorization: 'Bearer some.token'
+      });
+    });
+  });
+
   describe('auth token errors', () => {
     it('throws an error if the error property is truthy for all provided authTokens', async () => {
       const destination: Destination = {

--- a/packages/connectivity/src/scp-cf/authorization-header.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.ts
@@ -215,6 +215,7 @@ async function getAuthenticationRelatedHeaders(
     case 'OAuth2UserTokenExchange':
     case 'OAuth2JWTBearer':
     case 'OAuth2ClientCredentials':
+    case 'OAuth2Password':
       return headerFromTokens(
         destination.authentication,
         destination.authTokens


### PR DESCRIPTION
This is a cherry pick commit from #1944 .