### PR TITLE
fix: move isolation strategy to Destination API

### DIFF
--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -34,12 +34,6 @@ export interface CachingOptions {
    * A boolean value that indicates whether to read destinations from cache.
    */
   useCache?: boolean;
-
-  /**
-   * The isolation strategy used for caching destinations. For the available options, see [[IsolationStrategy]].
-   * By default, IsolationStrategy.Tenant is set.
-   */
-  isolationStrategy?: IsolationStrategy; // TODO: this is kind of too generic. For destinations, this makes sense, whereas for caching access tokens this has no effect at all.
 }
 
 /**

--- a/packages/connectivity/src/scp-cf/circuit-breaker.spec.ts
+++ b/packages/connectivity/src/scp-cf/circuit-breaker.spec.ts
@@ -23,7 +23,9 @@ const attempts = circuitBreakerDefaultOptions.volumeThreshold!;
 describe('circuit breaker', () => {
   it('opens after 50% failed request attempts (with at least 10 recorded requests) for destination service', async () => {
     const request = () =>
-      fetchDestination(destinationServiceUri, jwt, {destinationName:'FINAL-DESTINATION'});
+      fetchDestination(destinationServiceUri, jwt, {
+        destinationName: 'FINAL-DESTINATION'
+      });
 
     nock(destinationServiceUri)
       .get(/.*/)

--- a/packages/connectivity/src/scp-cf/circuit-breaker.spec.ts
+++ b/packages/connectivity/src/scp-cf/circuit-breaker.spec.ts
@@ -23,7 +23,7 @@ const attempts = circuitBreakerDefaultOptions.volumeThreshold!;
 describe('circuit breaker', () => {
   it('opens after 50% failed request attempts (with at least 10 recorded requests) for destination service', async () => {
     const request = () =>
-      fetchDestination(destinationServiceUri, jwt, 'FINAL-DESTINATION');
+      fetchDestination(destinationServiceUri, jwt, {destinationName:'FINAL-DESTINATION'});
 
     nock(destinationServiceUri)
       .get(/.*/)

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -20,7 +20,6 @@ import {
 } from './destination-selection-strategies';
 import {
   DestinationFetchOptions,
-  DestinationOptions,
   DestinationsByType
 } from './destination-accessor-types';
 import {
@@ -339,7 +338,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
     destinationResult: DestinationSearchResult
   ): Promise<AuthAndExchangeTokens> {
     const { destination, origin } = destinationResult;
-    const {destinationName} = this.options
+    const { destinationName } = this.options;
     if (!this.subscriberToken || !isUserToken(this.subscriberToken.userJwt)) {
       throw Error(
         `No user token (JWT) has been provided. This is strictly necessary for '${destination.authentication}'.`
@@ -504,7 +503,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
         subscriber,
         provider: emptyDestinationByType
       },
-     this.options.destinationName
+      this.options.destinationName
     );
 
     if (destination) {

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -98,7 +98,6 @@ class DestinationFromServiceRetriever {
       await DestinationFromServiceRetriever.getProviderServiceToken(options);
 
     const da = new DestinationFromServiceRetriever(
-      options.destinationName,
       options,
       subscriberToken,
       providerToken
@@ -190,13 +189,12 @@ class DestinationFromServiceRetriever {
   }
 
   private options: RequiredProperties<
-    Omit<DestinationOptions, 'userJwt' | 'iss'>,
+    Omit<DestinationFetchOptions, 'userJwt' | 'iss'>,
     'isolationStrategy' | 'selectionStrategy' | 'useCache'
   >;
 
   private constructor(
-    readonly name: string,
-    options: DestinationOptions,
+    options: DestinationFetchOptions,
     readonly subscriberToken: SubscriberTokens | undefined,
     readonly providerServiceToken: JwtPair
   ) {
@@ -283,7 +281,6 @@ class DestinationFromServiceRetriever {
     return fetchDestination(
       this.destinationServiceCredentials.uri,
       jwt,
-      this.name,
       this.options
     );
   }
@@ -342,6 +339,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
     destinationResult: DestinationSearchResult
   ): Promise<AuthAndExchangeTokens> {
     const { destination, origin } = destinationResult;
+    const {destinationName} = this.options
     if (!this.subscriberToken || !isUserToken(this.subscriberToken.userJwt)) {
       throw Error(
         `No user token (JWT) has been provided. This is strictly necessary for '${destination.authentication}'.`
@@ -353,7 +351,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
     // Case 1 Destination in provider and jwt issued for provider account -> not extra x-user-token header needed
     if (this.isProviderAndSubscriberSameTenant()) {
       logger.debug(
-        `UserExchange flow started without user exchange token for destination ${this.name} of the provider account.`
+        `UserExchange flow started without user exchange token for destination ${destinationName} of the provider account.`
       );
       return {
         authHeaderJwt: await jwtBearerToken(
@@ -369,7 +367,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
         ? this.subscriberToken.serviceJwt
         : this.providerServiceToken;
     logger.debug(
-      `UserExchange flow started for destination ${this.name} of the ${origin} account.`
+      `UserExchange flow started for destination ${destinationName} of the ${origin} account.`
     );
 
     return {
@@ -466,7 +464,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
         subscriber: emptyDestinationByType,
         provider
       },
-      this.name
+      this.options.destinationName
     );
     if (destination) {
       return {
@@ -480,7 +478,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
   private getProviderDestinationCache(): DestinationSearchResult | undefined {
     const destination = destinationCache.retrieveDestinationFromCache(
       this.providerServiceToken.decoded,
-      this.name,
+      this.options.destinationName,
       this.options.isolationStrategy
     );
 
@@ -506,7 +504,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
         subscriber,
         provider: emptyDestinationByType
       },
-      this.name
+     this.options.destinationName
     );
 
     if (destination) {
@@ -517,7 +515,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
   private getSubscriberDestinationCache(): DestinationSearchResult | undefined {
     const destination = destinationCache.retrieveDestinationFromCache(
       this.selectSubscriberJwt(),
-      this.name,
+      this.options.destinationName,
       this.options.isolationStrategy
     );
 

--- a/packages/connectivity/src/scp-cf/destination/destination-service-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-cache.spec.ts
@@ -104,11 +104,10 @@ describe('DestinationServiceCache', () => {
     );
     expect(directCall.originalProperties).toEqual(singleDest);
     await expect(
-      fetchDestination(
-        destinationServiceUrl,
-        subscriberServiceToken,
-        { useCache: true,destinationName: singleDest.Name }
-      )
+      fetchDestination(destinationServiceUrl, subscriberServiceToken, {
+        useCache: true,
+        destinationName: singleDest.Name
+      })
     ).resolves.not.toThrow();
 
     const cache = getDestinationFromCache(
@@ -129,7 +128,11 @@ describe('DestinationServiceCache', () => {
     const directCall = await fetchDestination(
       destinationServiceUrl,
       subscriberUserJwt,
-      { useCache: true, isolationStrategy: IsolationStrategy.Tenant_User,destinationName: singleDest.Name }
+      {
+        useCache: true,
+        isolationStrategy: IsolationStrategy.Tenant_User,
+        destinationName: singleDest.Name
+      }
     );
 
     const cache = getDestinationFromCache(

--- a/packages/connectivity/src/scp-cf/destination/destination-service-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-cache.spec.ts
@@ -100,16 +100,14 @@ describe('DestinationServiceCache', () => {
     const directCall = await fetchDestination(
       destinationServiceUrl,
       subscriberServiceToken,
-      singleDest.Name,
-      { useCache: true }
+      { useCache: true, destinationName: singleDest.Name }
     );
     expect(directCall.originalProperties).toEqual(singleDest);
     await expect(
       fetchDestination(
         destinationServiceUrl,
         subscriberServiceToken,
-        singleDest.Name,
-        { useCache: true }
+        { useCache: true,destinationName: singleDest.Name }
       )
     ).resolves.not.toThrow();
 
@@ -131,8 +129,7 @@ describe('DestinationServiceCache', () => {
     const directCall = await fetchDestination(
       destinationServiceUrl,
       subscriberUserJwt,
-      singleDest.Name,
-      { useCache: true, isolationStrategy: IsolationStrategy.Tenant_User }
+      { useCache: true, isolationStrategy: IsolationStrategy.Tenant_User,destinationName: singleDest.Name }
     );
 
     const cache = getDestinationFromCache(

--- a/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
@@ -194,7 +194,7 @@ export type DestinationRetrievalOptions = CachingOptions &
   ResilienceOptions & {
     /**
      * The isolation strategy used for caching destinations. For the available options, see [[IsolationStrategy]].
-     * By default, IsolationStrategy.Tenant is set.
+     * By default, IsolationStrategy.Tenant_User is set.
      */
     isolationStrategy?: IsolationStrategy;
   };

--- a/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
@@ -1,4 +1,4 @@
-import {CachingOptions, IsolationStrategy} from '../cache';
+import { CachingOptions, IsolationStrategy } from '../cache';
 import { ProxyConfiguration } from '../connectivity-service-types';
 import { ResilienceOptions } from '../resilience-options';
 
@@ -190,13 +190,14 @@ export interface DestinationCertificate {
 /**
  * Options to use while fetching destinations. Encompasses both [[DestinationCachingOptions]] and [[ResilienceOptions]] interfaces.
  */
-export type DestinationRetrievalOptions = CachingOptions & ResilienceOptions & {
-  /**
-   * The isolation strategy used for caching destinations. For the available options, see [[IsolationStrategy]].
-   * By default, IsolationStrategy.Tenant is set.
-   */
-  isolationStrategy?: IsolationStrategy;
-}
+export type DestinationRetrievalOptions = CachingOptions &
+  ResilienceOptions & {
+    /**
+     * The isolation strategy used for caching destinations. For the available options, see [[IsolationStrategy]].
+     * By default, IsolationStrategy.Tenant is set.
+     */
+    isolationStrategy?: IsolationStrategy;
+  };
 
 /**
  * Typeguard to find if object is DestinationFetchOptions.

--- a/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
@@ -1,4 +1,4 @@
-import { CachingOptions } from '../cache';
+import {CachingOptions, IsolationStrategy} from '../cache';
 import { ProxyConfiguration } from '../connectivity-service-types';
 import { ResilienceOptions } from '../resilience-options';
 
@@ -190,7 +190,13 @@ export interface DestinationCertificate {
 /**
  * Options to use while fetching destinations. Encompasses both [[DestinationCachingOptions]] and [[ResilienceOptions]] interfaces.
  */
-export type DestinationRetrievalOptions = CachingOptions & ResilienceOptions;
+export type DestinationRetrievalOptions = CachingOptions & ResilienceOptions & {
+  /**
+   * The isolation strategy used for caching destinations. For the available options, see [[IsolationStrategy]].
+   * By default, IsolationStrategy.Tenant is set.
+   */
+  isolationStrategy?: IsolationStrategy;
+}
 
 /**
  * Typeguard to find if object is DestinationFetchOptions.

--- a/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
@@ -200,7 +200,7 @@ export type DestinationRetrievalOptions = CachingOptions &
   };
 
 /**
- * Typeguard to find if object is DestinationFetchOptions.
+ * Typeguard to find if object is a Destination.
  * @param destination - Destination to be checked
  * @returns boolean
  * @internal

--- a/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
@@ -265,7 +265,7 @@ describe('destination service', () => {
         destinationServiceUri,
         jwt,
 
-        { destinationName,enableCircuitBreaker: false }
+        { destinationName, enableCircuitBreaker: false }
       );
       expect(actual).toMatchObject(expected);
     });
@@ -300,7 +300,8 @@ describe('destination service', () => {
         .get('/destination-configuration/v1/destinations/HTTP-OAUTH')
         .reply(200, response);
       const spy = jest.spyOn(axios, 'request');
-      await fetchDestination(destinationServiceUri, jwt, {destinationName,
+      await fetchDestination(destinationServiceUri, jwt, {
+        destinationName,
         enableCircuitBreaker: false
       });
       const expectedConfig: AxiosRequestConfig = {
@@ -354,7 +355,8 @@ describe('destination service', () => {
         .get('/destination-configuration/v1/destinations/HTTP-OAUTH')
         .reply(200, response);
       const spy = jest.spyOn(axios, 'request');
-      await fetchDestination(destinationServiceUri, jwt,  {destinationName,
+      await fetchDestination(destinationServiceUri, jwt, {
+        destinationName,
         enableCircuitBreaker: false
       });
       const expectedConfig: AxiosRequestConfig = {
@@ -452,7 +454,7 @@ describe('destination service', () => {
         destinationServiceUri,
         jwt,
 
-        {destinationName, enableCircuitBreaker: false }
+        { destinationName, enableCircuitBreaker: false }
       );
       expect(actual).toMatchObject(expected);
     });
@@ -469,7 +471,8 @@ describe('destination service', () => {
         .reply(500);
 
       await expect(
-        fetchDestination(destinationServiceUri, jwt,  {destinationName,
+        fetchDestination(destinationServiceUri, jwt, {
+          destinationName,
           enableCircuitBreaker: false
         })
       ).rejects.toThrowError();
@@ -491,7 +494,8 @@ describe('destination service', () => {
         .reply(400, response);
 
       await expect(() =>
-        fetchDestination(destinationServiceUri, jwt,  {destinationName,
+        fetchDestination(destinationServiceUri, jwt, {
+          destinationName,
           enableCircuitBreaker: false
         })
       ).rejects.toThrowError();

--- a/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
@@ -264,8 +264,8 @@ describe('destination service', () => {
       const actual = await fetchDestination(
         destinationServiceUri,
         jwt,
-        destinationName,
-        { enableCircuitBreaker: false }
+
+        { destinationName,enableCircuitBreaker: false }
       );
       expect(actual).toMatchObject(expected);
     });
@@ -300,7 +300,7 @@ describe('destination service', () => {
         .get('/destination-configuration/v1/destinations/HTTP-OAUTH')
         .reply(200, response);
       const spy = jest.spyOn(axios, 'request');
-      await fetchDestination(destinationServiceUri, jwt, destinationName, {
+      await fetchDestination(destinationServiceUri, jwt, {destinationName,
         enableCircuitBreaker: false
       });
       const expectedConfig: AxiosRequestConfig = {
@@ -354,7 +354,7 @@ describe('destination service', () => {
         .get('/destination-configuration/v1/destinations/HTTP-OAUTH')
         .reply(200, response);
       const spy = jest.spyOn(axios, 'request');
-      await fetchDestination(destinationServiceUri, jwt, destinationName, {
+      await fetchDestination(destinationServiceUri, jwt,  {destinationName,
         enableCircuitBreaker: false
       });
       const expectedConfig: AxiosRequestConfig = {
@@ -451,8 +451,8 @@ describe('destination service', () => {
       const actual = await fetchDestination(
         destinationServiceUri,
         jwt,
-        destinationName,
-        { enableCircuitBreaker: false }
+
+        {destinationName, enableCircuitBreaker: false }
       );
       expect(actual).toMatchObject(expected);
     });
@@ -469,7 +469,7 @@ describe('destination service', () => {
         .reply(500);
 
       await expect(
-        fetchDestination(destinationServiceUri, jwt, destinationName, {
+        fetchDestination(destinationServiceUri, jwt,  {destinationName,
           enableCircuitBreaker: false
         })
       ).rejects.toThrowError();
@@ -491,7 +491,7 @@ describe('destination service', () => {
         .reply(400, response);
 
       await expect(() =>
-        fetchDestination(destinationServiceUri, jwt, destinationName, {
+        fetchDestination(destinationServiceUri, jwt,  {destinationName,
           enableCircuitBreaker: false
         })
       ).rejects.toThrowError();

--- a/packages/connectivity/src/scp-cf/destination/destination-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.ts
@@ -19,6 +19,7 @@ import {
 } from './destination';
 import { Destination, DestinationType } from './destination-service-types';
 import { destinationServiceCache } from './destination-service-cache';
+import {DestinationFetchOptions, DestinationOptions} from "./destination-accessor-types";
 
 const logger = createLogger({
   package: 'connectivity',
@@ -45,7 +46,7 @@ let circuitBreaker: DestinationCircuitBreaker<
 export function fetchInstanceDestinations(
   destinationServiceUri: string,
   jwt: string,
-  options?: ResilienceOptions & CachingOptions
+  options?: DestinationOptions
 ): Promise<Destination[]> {
   return fetchDestinations(
     destinationServiceUri,
@@ -66,7 +67,7 @@ export function fetchInstanceDestinations(
 export function fetchSubaccountDestinations(
   destinationServiceUri: string,
   jwt: string,
-  options?: ResilienceOptions & CachingOptions
+  options?: DestinationOptions
 ): Promise<Destination[]> {
   return fetchDestinations(
     destinationServiceUri,
@@ -80,7 +81,7 @@ async function fetchDestinations(
   destinationServiceUri: string,
   jwt: string,
   type: DestinationType,
-  options?: ResilienceOptions & CachingOptions
+  options?: DestinationOptions
 ): Promise<Destination[]> {
   const targetUri = `${destinationServiceUri.replace(
     /\/$/,
@@ -142,7 +143,6 @@ export interface AuthAndExchangeTokens {
  * Fetches a specific destination with authenticationType OAuth2UserTokenExchange by name from the given URI, including authorization tokens.
  * @param destinationServiceUri - The URI of the destination service
  * @param token - The access token or AuthAndExchangeTokens if you want to include the X-user-token for OAuth2UserTokenExchange.
- * @param destinationName - The name of the desired destination
  * @param options - Options to use by retrieving destinations
  * @returns A Promise resolving to the destination
  * @internal
@@ -150,13 +150,11 @@ export interface AuthAndExchangeTokens {
 export async function fetchDestination(
   destinationServiceUri: string,
   token: string | AuthAndExchangeTokens,
-  destinationName: string,
-  options?: ResilienceOptions & CachingOptions
+  options: DestinationFetchOptions
 ): Promise<Destination> {
   return fetchDestinationByTokens(
     destinationServiceUri,
     typeof token === 'string' ? { authHeaderJwt: token } : token,
-    destinationName,
     options
   );
 }
@@ -164,13 +162,12 @@ export async function fetchDestination(
 async function fetchDestinationByTokens(
   destinationServiceUri: string,
   tokens: AuthAndExchangeTokens,
-  destinationName: string,
-  options?: ResilienceOptions & CachingOptions
+  options: DestinationFetchOptions
 ): Promise<Destination> {
   const targetUri = `${destinationServiceUri.replace(
     /\/$/,
     ''
-  )}/destination-configuration/v1/destinations/${destinationName}`;
+  )}/destination-configuration/v1/destinations/${options.destinationName}`;
 
   if (options?.useCache) {
     const destinationsFromCache =
@@ -213,7 +210,7 @@ async function fetchDestinationByTokens(
     .catch(error => {
       {
         throw new ErrorWithCause(
-          `Failed to fetch destination ${destinationName}.${errorMessageFromResponse(
+          `Failed to fetch destination ${options.destinationName}.${errorMessageFromResponse(
             error
           )}`,
           error

--- a/packages/connectivity/src/scp-cf/destination/destination-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.ts
@@ -10,7 +10,6 @@ import {
   circuitBreakerDefaultOptions,
   ResilienceOptions
 } from '../resilience-options';
-import { CachingOptions } from '../cache';
 import { urlAndAgent } from '../../http-agent';
 import {
   DestinationConfiguration,
@@ -19,7 +18,10 @@ import {
 } from './destination';
 import { Destination, DestinationType } from './destination-service-types';
 import { destinationServiceCache } from './destination-service-cache';
-import {DestinationFetchOptions, DestinationOptions} from "./destination-accessor-types";
+import {
+  DestinationFetchOptions,
+  DestinationOptions
+} from './destination-accessor-types';
 
 const logger = createLogger({
   package: 'connectivity',
@@ -210,9 +212,9 @@ async function fetchDestinationByTokens(
     .catch(error => {
       {
         throw new ErrorWithCause(
-          `Failed to fetch destination ${options.destinationName}.${errorMessageFromResponse(
-            error
-          )}`,
+          `Failed to fetch destination ${
+            options.destinationName
+          }.${errorMessageFromResponse(error)}`,
           error
         );
       }

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -385,7 +385,7 @@ describe('OAuth flows', () => {
     const destination = await fetchDestination(
       destinationService!.credentials.uri,
       clientGrant,
-      systems.workflow.providerOAuth2ClientCredentials
+      { destinationName: systems.workflow.providerOAuth2ClientCredentials }
     );
     expect(destination.authTokens![0].error).toBeNull();
 


### PR DESCRIPTION
Closes SAP/cloud-sdk-backlog#465.

The isolation strategy was part of the `cahcingOptions` which is missleading because it is only meaningful for the destination cache. Adjusted the API and put the `isolationStrategy` to the destination options.

I also used the `fetchDestinationOptions` along the way of our fetch methods.