### PR TITLE
Add default (de-)serializers to the request builders

### DIFF
--- a/packages/odata-v2/src/index.ts
+++ b/packages/odata-v2/src/index.ts
@@ -18,6 +18,7 @@ export {
 
 export {
   CreateRequestBuilder,
+  CountRequestBuilder,
   DeleteRequestBuilder,
   GetAllRequestBuilder,
   GetByKeyRequestBuilder,

--- a/packages/odata-v2/src/request-builder/batch-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/batch-request-builder.ts
@@ -9,7 +9,7 @@ import {
   BatchRequestBuilder
 } from '@sap-cloud-sdk/odata-common/internal';
 import { DeSerializers } from '../de-serializers/de-serializers';
-import { entityDeserializer } from '../de-serializers';
+import { DefaultDeSerializers, entityDeserializer } from '../de-serializers';
 import { BatchResponse } from '../batch-response';
 import { responseDataAccessor } from './response-data-accessor';
 
@@ -18,7 +18,7 @@ import { responseDataAccessor } from './response-data-accessor';
  * The retrieve and change sets will be executed in order, while the order within a change set can vary.
  */
 export class ODataBatchRequestBuilder<
-  DeSerializersT extends DeSerializers
+  DeSerializersT extends DeSerializers = DefaultDeSerializers
 > extends BatchRequestBuilder<DeSerializersT> {
   /**
    * Execute the given request and return the according promise. Please notice: The sub-requests may fail even the main request is successful.

--- a/packages/odata-v2/src/request-builder/count-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/count-request-builder.ts
@@ -1,0 +1,16 @@
+import { CountRequestBuilder as CountRequestBuilderCommon } from '@sap-cloud-sdk/odata-common/internal';
+import { Entity } from '../entity';
+import { DeSerializers, DefaultDeSerializers } from '../de-serializers';
+
+/**
+ * Create an OData request to count entities based on the configuration of the request.
+ * A `CountRequestBuilder` allows only for execution of the request.
+ * If you want to apply query parameters like filter, skip or top do it on the [[GetAllRequestBuilder]] the count is created from.
+ * @typeparam EntityT - Type of the entity to be requested
+ * @typeparam EntityT - Type of the entity to be requested
+ * @internal
+ */
+export class CountRequestBuilder<
+  EntityT extends Entity,
+  DeSerializersT extends DeSerializers = DefaultDeSerializers
+> extends CountRequestBuilderCommon<EntityT, DeSerializersT> {}

--- a/packages/odata-v2/src/request-builder/create-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/create-request-builder.ts
@@ -4,7 +4,7 @@ import {
   entitySerializer,
   EntityApi
 } from '@sap-cloud-sdk/odata-common/internal';
-import { DeSerializers, entityDeserializer } from '../de-serializers';
+import { DefaultDeSerializers, DeSerializers, entityDeserializer } from '../de-serializers';
 import { Entity } from '../entity';
 import { createODataUri } from '../uri-conversion';
 import { responseDataAccessor } from './response-data-accessor';
@@ -15,7 +15,7 @@ import { responseDataAccessor } from './response-data-accessor';
  */
 export class CreateRequestBuilder<
     EntityT extends Entity,
-    DeSerializersT extends DeSerializers
+    DeSerializersT extends DeSerializers = DefaultDeSerializers
   >
   extends CreateRequestBuilderBase<EntityT, DeSerializersT>
   implements EntityIdentifiable<EntityT, DeSerializersT>

--- a/packages/odata-v2/src/request-builder/create-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/create-request-builder.ts
@@ -4,7 +4,11 @@ import {
   entitySerializer,
   EntityApi
 } from '@sap-cloud-sdk/odata-common/internal';
-import { DefaultDeSerializers, DeSerializers, entityDeserializer } from '../de-serializers';
+import {
+  DefaultDeSerializers,
+  DeSerializers,
+  entityDeserializer
+} from '../de-serializers';
 import { Entity } from '../entity';
 import { createODataUri } from '../uri-conversion';
 import { responseDataAccessor } from './response-data-accessor';

--- a/packages/odata-v2/src/request-builder/delete-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/delete-request-builder.ts
@@ -2,7 +2,7 @@ import {
   DeleteRequestBuilderBase,
   EntityApi
 } from '@sap-cloud-sdk/odata-common/internal';
-import { DeSerializers } from '../de-serializers';
+import { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import { Entity } from '../entity';
 import { createODataUri } from '../uri-conversion';
 
@@ -12,7 +12,7 @@ import { createODataUri } from '../uri-conversion';
  */
 export class DeleteRequestBuilder<
   EntityT extends Entity,
-  DeSerializersT extends DeSerializers
+  DeSerializersT extends DeSerializers = DefaultDeSerializers
 > extends DeleteRequestBuilderBase<EntityT, DeSerializersT> {
   /**
    * Creates an instance of DeleteRequestBuilder. If the entity is passed, version identifier will also be added.

--- a/packages/odata-v2/src/request-builder/get-all-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/get-all-request-builder.ts
@@ -8,13 +8,17 @@ import {
 } from '@sap-cloud-sdk/odata-common/internal';
 import { variadicArgumentToArray } from '@sap-cloud-sdk/util';
 import { Entity } from '../entity';
-import { DeSerializers, entityDeserializer } from '../de-serializers';
+import {
+  DefaultDeSerializers,
+  DeSerializers,
+  entityDeserializer
+} from '../de-serializers';
 import { createODataUri } from '../uri-conversion';
 import { responseDataAccessor } from './response-data-accessor';
 
 export class GetAllRequestBuilder<
     EntityT extends Entity,
-    DeSerializersT extends DeSerializers
+    DeSerializersT extends DeSerializers = DefaultDeSerializers
   >
   extends GetAllRequestBuilderBase<EntityT, DeSerializersT>
   implements EntityIdentifiable<EntityT, DeSerializersT>

--- a/packages/odata-v2/src/request-builder/get-by-key-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/get-by-key-request-builder.ts
@@ -3,7 +3,11 @@ import {
   EntityIdentifiable,
   GetByKeyRequestBuilderBase
 } from '@sap-cloud-sdk/odata-common/internal';
-import { DeSerializers, entityDeserializer } from '../de-serializers';
+import {
+  DefaultDeSerializers,
+  DeSerializers,
+  entityDeserializer
+} from '../de-serializers';
 import { Entity } from '../entity';
 import { createODataUri } from '../uri-conversion';
 import { responseDataAccessor } from './response-data-accessor';
@@ -16,7 +20,7 @@ import { responseDataAccessor } from './response-data-accessor';
  */
 export class GetByKeyRequestBuilder<
     EntityT extends Entity,
-    DeSerializersT extends DeSerializers
+    DeSerializersT extends DeSerializers = DefaultDeSerializers
   >
   extends GetByKeyRequestBuilderBase<EntityT, DeSerializersT>
   implements EntityIdentifiable<EntityT, DeSerializersT>

--- a/packages/odata-v2/src/request-builder/index.ts
+++ b/packages/odata-v2/src/request-builder/index.ts
@@ -1,5 +1,6 @@
 export * from './batch-request-builder';
 export * from './create-request-builder';
+export * from './count-request-builder';
 export * from './delete-request-builder';
 export * from './function-import-request-builder';
 export * from './get-all-request-builder';

--- a/packages/odata-v2/src/request-builder/update-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/update-request-builder.ts
@@ -16,7 +16,7 @@ import {
 } from '@sap-cloud-sdk/odata-common/internal';
 import { Entity } from '../entity';
 import { extractODataEtag } from '../extract-odata-etag';
-import { DeSerializers } from '../de-serializers';
+import { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import { createODataUri } from '../uri-conversion';
 
 const logger = createLogger({
@@ -30,7 +30,7 @@ const logger = createLogger({
  */
 export class UpdateRequestBuilder<
     EntityT extends Entity,
-    DeSerializersT extends DeSerializers
+    DeSerializersT extends DeSerializers = DefaultDeSerializers
   >
   extends UpdateRequestBuilderBase<EntityT, DeSerializersT>
   implements EntityIdentifiable<EntityT, DeSerializersT>

--- a/packages/odata-v4/src/index.ts
+++ b/packages/odata-v4/src/index.ts
@@ -25,6 +25,7 @@ export {
 
 export {
   ActionImportRequestBuilder,
+  CountRequestBuilder,
   CreateRequestBuilder,
   DeleteRequestBuilder,
   FunctionImportRequestBuilder,

--- a/packages/odata-v4/src/request-builder/batch-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/batch-request-builder.ts
@@ -8,7 +8,11 @@ import {
   BatchRequestBuilder,
   deserializeBatchResponse
 } from '@sap-cloud-sdk/odata-common/internal';
-import { DeSerializers, entityDeserializer } from '../de-serializers';
+import {
+  DefaultDeSerializers,
+  DeSerializers,
+  entityDeserializer
+} from '../de-serializers';
 import { BatchResponse } from '../batch-response';
 import { responseDataAccessor } from './response-data-accessor';
 
@@ -17,7 +21,7 @@ import { responseDataAccessor } from './response-data-accessor';
  * The retrieve and change sets will be executed in order, while the order within a change set can vary.
  */
 export class ODataBatchRequestBuilder<
-  DeSerializersT extends DeSerializers
+  DeSerializersT extends DeSerializers = DefaultDeSerializers
 > extends BatchRequestBuilder<DeSerializersT> {
   /**
    * Execute the given request and return the according promise. Please notice: The sub-requests may fail even the main request is successful.

--- a/packages/odata-v4/src/request-builder/count-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/count-request-builder.ts
@@ -1,0 +1,16 @@
+import { CountRequestBuilder as CountRequestBuilderCommon } from '@sap-cloud-sdk/odata-common/internal';
+import { Entity } from '../entity';
+import { DeSerializers, DefaultDeSerializers } from '../de-serializers';
+
+/**
+ * Create an OData request to count entities based on the configuration of the request.
+ * A `CountRequestBuilder` allows only for execution of the request.
+ * If you want to apply query parameters like filter, skip or top do it on the [[GetAllRequestBuilder]] the count is created from.
+ * @typeparam EntityT - Type of the entity to be requested
+ * @typeparam EntityT - Type of the entity to be requested
+ * @internal
+ */
+export class CountRequestBuilder<
+  EntityT extends Entity,
+  DeSerializersT extends DeSerializers = DefaultDeSerializers
+> extends CountRequestBuilderCommon<EntityT, DeSerializersT> {}

--- a/packages/odata-v4/src/request-builder/create-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/create-request-builder.ts
@@ -4,7 +4,11 @@ import {
   entitySerializer,
   EntityIdentifiable
 } from '@sap-cloud-sdk/odata-common/internal';
-import { DeSerializers, entityDeserializer } from '../de-serializers';
+import {
+  DefaultDeSerializers,
+  DeSerializers,
+  entityDeserializer
+} from '../de-serializers';
 import { Entity } from '../entity';
 import { createODataUri } from '../uri-conversion';
 import { responseDataAccessor } from './response-data-accessor';
@@ -14,7 +18,7 @@ import { responseDataAccessor } from './response-data-accessor';
  */
 export class CreateRequestBuilder<
     EntityT extends Entity,
-    DeSerializersT extends DeSerializers
+    DeSerializersT extends DeSerializers = DefaultDeSerializers
   >
   extends CreateRequestBuilderBase<EntityT, DeSerializersT>
   implements EntityIdentifiable<EntityT, DeSerializersT>

--- a/packages/odata-v4/src/request-builder/delete-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/delete-request-builder.ts
@@ -3,7 +3,7 @@ import {
   EntityApi,
   FieldType
 } from '@sap-cloud-sdk/odata-common/internal';
-import { DeSerializers } from '../de-serializers';
+import { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import { Entity } from '../entity';
 import { createODataUri } from '../uri-conversion';
 
@@ -13,7 +13,7 @@ import { createODataUri } from '../uri-conversion';
  */
 export class DeleteRequestBuilder<
   EntityT extends Entity,
-  DeSerializersT extends DeSerializers
+  DeSerializersT extends DeSerializers = DefaultDeSerializers
 > extends DeleteRequestBuilderBase<EntityT, DeSerializersT> {
   readonly _entity: EntityT;
 

--- a/packages/odata-v4/src/request-builder/get-all-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/get-all-request-builder.ts
@@ -10,13 +10,17 @@ import {
 } from '@sap-cloud-sdk/odata-common/internal';
 import { variadicArgumentToArray } from '@sap-cloud-sdk/util';
 import { Entity } from '../entity';
-import { DeSerializers, entityDeserializer } from '../de-serializers';
+import {
+  DefaultDeSerializers,
+  DeSerializers,
+  entityDeserializer
+} from '../de-serializers';
 import { createODataUri } from '../uri-conversion';
 import { responseDataAccessor } from './response-data-accessor';
 
 export class GetAllRequestBuilder<
     EntityT extends Entity,
-    DeSerializersT extends DeSerializers
+    DeSerializersT extends DeSerializers = DefaultDeSerializers
   >
   extends GetAllRequestBuilderBase<EntityT, DeSerializersT>
   implements EntityIdentifiable<EntityT, DeSerializersT>

--- a/packages/odata-v4/src/request-builder/get-by-key-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/get-by-key-request-builder.ts
@@ -5,7 +5,11 @@ import {
   GetByKeyRequestBuilderBase,
   EntityApi
 } from '@sap-cloud-sdk/odata-common/internal';
-import { DeSerializers, entityDeserializer } from '../de-serializers';
+import {
+  DefaultDeSerializers,
+  DeSerializers,
+  entityDeserializer
+} from '../de-serializers';
 import { Entity } from '../entity';
 import { createODataUri } from '../uri-conversion';
 import { responseDataAccessor } from './response-data-accessor';
@@ -19,7 +23,7 @@ import { responseDataAccessor } from './response-data-accessor';
  */
 export class GetByKeyRequestBuilder<
     EntityT extends Entity,
-    DeSerializersT extends DeSerializers
+    DeSerializersT extends DeSerializers = DefaultDeSerializers
   >
   extends GetByKeyRequestBuilderBase<EntityT, DeSerializersT>
   implements EntityIdentifiable<EntityT, DeSerializersT>

--- a/packages/odata-v4/src/request-builder/index.ts
+++ b/packages/odata-v4/src/request-builder/index.ts
@@ -1,5 +1,6 @@
 export * from './action-import-request-builder';
 export * from './create-request-builder';
+export * from './count-request-builder';
 export * from './delete-request-builder';
 export * from './function-import-request-builder';
 export * from './get-all-request-builder';

--- a/packages/odata-v4/src/request-builder/update-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/update-request-builder.ts
@@ -12,12 +12,12 @@ import {
 } from '@sap-cloud-sdk/odata-common/internal';
 import { Entity } from '../entity';
 import { extractODataEtag } from '../extract-odata-etag';
-import { DeSerializers } from '../de-serializers';
+import { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import { createODataUri } from '../uri-conversion';
 
 export class UpdateRequestBuilder<
     EntityT extends Entity,
-    DeSerializersT extends DeSerializers
+    DeSerializersT extends DeSerializers = DefaultDeSerializers
   >
   extends UpdateRequestBuilderBase<EntityT, DeSerializersT>
   implements EntityIdentifiable<EntityT, DeSerializersT>


### PR DESCRIPTION
Users should not **have** to write out `DefaultDeSerializers` at any time. Before this PR, in some cases, they would have to do this. Therefore I added defaults to the types

Relates to SAP/cloud-sdk-backlog#515.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
