### PR TITLE
chore: Export and, or, not from odata-vX packages

### DIFF
--- a/packages/odata-common/src/filter/filterable.ts
+++ b/packages/odata-common/src/filter/filterable.ts
@@ -46,7 +46,6 @@ export type Filterable<
  * @typeparam EntityT - Type of the entity filter on.
  * @param expressions - Filterables to be combined with logical `and`.
  * @returns The newly created FilterList.
- * @internal
  */
 export function and<
   EntityT extends EntityBase,
@@ -54,23 +53,12 @@ export function and<
 >(
   expressions: Filterable<EntityT, DeSerializersT>[]
 ): FilterList<EntityT, DeSerializersT>;
-
-/**
- * @internal
- */
 export function and<
   EntityT extends EntityBase,
   DeSerializersT extends DeSerializers
 >(
   ...expressions: Filterable<EntityT, DeSerializersT>[]
 ): FilterList<EntityT, DeSerializersT>;
-
-/**
- * @param first - first
- * @param rest - rest
- * @returns A FilterList
- * @internal
- */
 export function and<
   EntityT extends EntityBase,
   DeSerializersT extends DeSerializers
@@ -96,7 +84,6 @@ export function and<
  * @typeparam EntityT - Type of the entity filter on.
  * @param expressions - Filterables to be combined with logical `or`
  * @returns The newly created FilterList
- * @internal
  */
 export function or<
   EntityT extends EntityBase,
@@ -104,23 +91,12 @@ export function or<
 >(
   expressions: Filterable<EntityT, DeSerializersT>[]
 ): FilterList<EntityT, DeSerializersT>;
-
-/**
- * @internal
- */
 export function or<
   EntityT extends EntityBase,
   DeSerializersT extends DeSerializers
 >(
   ...expressions: Filterable<EntityT, DeSerializersT>[]
 ): FilterList<EntityT, DeSerializersT>;
-
-/**
- * @param first - first
- * @param rest - rest
- * @returns A FilterList
- * @internal
- */
 export function or<
   EntityT extends EntityBase,
   DeSerializersT extends DeSerializers
@@ -137,7 +113,6 @@ export function or<
  * Negate a filter.
  * @param filter - The filter to negate.
  * @returns The negated filter.
- * @internal
  */
 export function not<
   EntityT extends EntityBase,

--- a/packages/odata-common/src/index.ts
+++ b/packages/odata-common/src/index.ts
@@ -1,0 +1,1 @@
+export { and, or, not } from './filter';

--- a/packages/odata-v2/src/common.ts
+++ b/packages/odata-v2/src/common.ts
@@ -20,3 +20,5 @@ export {
   Link,
   throwErrorWhenReturnTypeIsUnionType
 } from '@sap-cloud-sdk/odata-common/internal';
+
+export { and, or, not } from '@sap-cloud-sdk/odata-common';

--- a/packages/odata-v4/src/common.ts
+++ b/packages/odata-v4/src/common.ts
@@ -21,3 +21,5 @@ export {
   OneToOneLink,
   throwErrorWhenReturnTypeIsUnionType
 } from '@sap-cloud-sdk/odata-common/internal';
+
+export { and, or, not } from '@sap-cloud-sdk/odata-common';


### PR DESCRIPTION
This exports the and, or and not functions from the odata version specific packages instead of common.
Additionally, those are not marked as @internal anymore.

Closes SAP/cloud-sdk-backlog#515.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
