### PR TITLE
chore: make allowed licences more strict

### DIFF
--- a/scripts/check-licenses.ts
+++ b/scripts/check-licenses.ts
@@ -4,7 +4,7 @@ import { createLogger } from '@sap-cloud-sdk/util';
 
 const logger = createLogger('check-licenses');
 
-// Here all FLOSS licenses are ok, see https://en.wikipedia.org/wiki/Category:Free_and_open-source_software_licenses
+// Here all permissive FLOSS licenses are ok, see https://en.wikipedia.org/wiki/Permissive_software_license
 // We just added the most common ones here. If one is in the wiki list and not here add it.
 const allowedLicenses = [
   'MIT',
@@ -12,14 +12,10 @@ const allowedLicenses = [
   'ISC',
   'BSD',
   'WTFPL',
-  'Artistic',
   'CC-BY',
   'CC0',
   'Unlicense',
-  'Public Domain',
-  'Python-2.0',
-  'GPL-3.0',
-  'MPL-2.0'
+  'Public Domain'
 ];
 
 async function getLicenses(): Promise<ModuleInfos> {
@@ -29,7 +25,8 @@ async function getLicenses(): Promise<ModuleInfos> {
         start: resolve(__dirname, '..'),
         direct: true,
         summary: true,
-        json: true
+        json: true,
+        production: true
       },
       function (err, packages: ModuleInfos) {
         if (err) {


### PR DESCRIPTION
In the discussion about code scanning tools to used, I realized that the list of licences is a bit too broad. Luckily there we did not use any of the GPL in production code, only in some test libs.