### PR TITLE
Fix json-schema resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "color-string": ">=1.5.5",
     "dot-prop": ">=5.1.1",
     "expect": ">=27.2.3",
+    "json-schema": ">=0.4.0",
     "netmask": ">=2.0.1 ",
     "path-parse": ">=1.0.7",
     "postcss": ">=8.2.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6431,10 +6431,10 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+json-schema@0.2.3, json-schema@>0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
`json-schema` is vulnerable to prototype pollution before version 0.4.0. This PR fixes its resolution to a non-vulnerable version.