### PR TITLE
chore: redo isolation strategy.

### DIFF
--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -19,16 +19,6 @@ export interface CacheEntry<T> {
   entry: T;
 }
 
-/**
- * Enumerator that selects the isolation type of destination in cache.
- */
-export enum IsolationStrategy {
-  Tenant = 'Tenant',
-  User = 'User',
-  Tenant_User = 'TenantUser',
-  No_Isolation = 'NoIsolation'
-}
-
 export interface CachingOptions {
   /**
    * A boolean value that indicates whether to read destinations from cache.

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
@@ -31,7 +31,6 @@ import {
   onPremisePrincipalPropagationMultipleResponse
 } from '../../../../../test-resources/test/test-util/example-destination-service-responses';
 import { decodeJwt, wrapJwtInHeader } from '../jwt';
-import { IsolationStrategy } from '../cache';
 import { destinationServiceCache } from './destination-service-cache';
 import { getDestination } from './destination-accessor';
 import {
@@ -39,7 +38,11 @@ import {
   alwaysSubscriber,
   subscriberFirst
 } from './destination-selection-strategies';
-import { destinationCache, getDestinationCacheKey } from './destination-cache';
+import {
+  destinationCache,
+  getDestinationCacheKey,
+  IsolationStrategy
+} from './destination-cache';
 import {
   AuthenticationType,
   Destination,
@@ -184,40 +187,13 @@ describe('destination cache', () => {
 
       const c1 = getSubscriberCache(IsolationStrategy.Tenant);
       const c2 = getProviderCache(IsolationStrategy.Tenant);
-      const c3 = getSubscriberCache(IsolationStrategy.User);
-      const c4 = getProviderCache(IsolationStrategy.No_Isolation);
       const c5 = getSubscriberCache(IsolationStrategy.Tenant_User);
       const c6 = getProviderCache(IsolationStrategy.Tenant_User);
 
       expect(c1).toBeUndefined();
       expect(c2).toBeUndefined();
-      expect(c3).toBeUndefined();
-      expect(c4).toBeUndefined();
       expect(c5!.url).toBe('https://subscriber.example');
       expect(c6).toBeUndefined();
-    });
-
-    it('retrieved  provider destinations are cached using only destination name in "NoIsolation" type', async () => {
-      await getDestination({
-        destinationName: 'ProviderDest',
-        jwt: subscriberUserJwt,
-        useCache: true,
-        isolationStrategy: IsolationStrategy.No_Isolation,
-        cacheVerificationKeys: false,
-        iasToXsuaaTokenExchange: false
-      });
-
-      const c1 = getSubscriberCache(IsolationStrategy.No_Isolation);
-      const c2 = getProviderCache(IsolationStrategy.No_Isolation);
-      const c3 = getSubscriberCache(IsolationStrategy.User);
-      const c4 = getSubscriberCache(IsolationStrategy.Tenant);
-      const c5 = getSubscriberCache(IsolationStrategy.Tenant_User);
-
-      expect(c1).toBeUndefined();
-      expect(c2!.url).toBe('https://provider.example');
-      expect(c3).toBeUndefined();
-      expect(c4).toBeUndefined();
-      expect(c5).toBeUndefined();
     });
 
     it('caches only subscriber if the destination names are the same and subscriber first', async () => {
@@ -314,6 +290,105 @@ describe('destination cache', () => {
 
       expect(c1).toBeUndefined();
       expect(c2!.url).toBe('https://subscriber2.example');
+    });
+  });
+
+  describe('caching options', () => {
+    beforeEach(() => {
+      mockServiceBindings();
+      mockServiceToken();
+      mockVerifyJwt();
+    });
+
+    const destName = destinationOne.name!;
+
+    it('disables the cache per default', async () => {
+      destinationCache.cacheRetrievedDestination(
+        { user_id: 'user', zid: 'tenant' },
+        destinationOne,
+        IsolationStrategy.Tenant
+      );
+      await expect(
+        getDestination({ destinationName: destName })
+      ).rejects.toThrowError(/Failed to fetch instance destinations./);
+    });
+
+    it('uses cache with isolation strategy Tenant if not JWT is provided', async () => {
+      destinationCache.cacheRetrievedDestination(
+        decodeJwt(providerServiceToken),
+        destinationOne,
+        IsolationStrategy.Tenant
+      );
+      const actual = await getDestination({
+        destinationName: destName,
+        useCache: true
+      });
+      expect(actual).toEqual(destinationOne);
+    });
+
+    it('uses cache with isolation strategy UserTenant if JWT is provided', async () => {
+      destinationCache.cacheRetrievedDestination(
+        decodeJwt(subscriberUserJwt),
+        destinationOne,
+        IsolationStrategy.Tenant_User
+      );
+      const actual = await getDestination({
+        destinationName: destName,
+        useCache: true,
+        jwt: subscriberUserJwt,
+        iasToXsuaaTokenExchange: false
+      });
+      expect(actual).toEqual(destinationOne);
+    });
+
+    it('enables cache if isolation strategy Tenant is provided', async () => {
+      destinationCache.cacheRetrievedDestination(
+        decodeJwt(providerServiceToken),
+        destinationOne,
+        IsolationStrategy.Tenant
+      );
+      const actual = await getDestination({
+        destinationName: destName,
+        isolationStrategy: IsolationStrategy.Tenant,
+        iasToXsuaaTokenExchange: false
+      });
+      expect(actual).toEqual(destinationOne);
+    });
+    it('enables cache if isolation strategy TenantUser is provided', async () => {
+      destinationCache.cacheRetrievedDestination(
+        decodeJwt(subscriberUserJwt),
+        destinationOne,
+        IsolationStrategy.Tenant_User
+      );
+      const actual = await getDestination({
+        destinationName: destName,
+        isolationStrategy: IsolationStrategy.Tenant_User,
+        jwt: subscriberUserJwt,
+        iasToXsuaaTokenExchange: false
+      });
+      expect(actual).toEqual(destinationOne);
+    });
+
+    it('ignores cache if isolation requires user JWT but the JWT is not provided', async () => {
+      const logger = createLogger('destination-cache');
+      const warn = jest.spyOn(logger, 'warn');
+
+      destinationCache.cacheRetrievedDestination(
+        decodeJwt(subscriberUserJwt),
+        destinationOne,
+        IsolationStrategy.Tenant_User
+      );
+      await expect(
+        getDestination({
+          destinationName: destName,
+          isolationStrategy: IsolationStrategy.Tenant_User,
+          jwt: subscriberServiceToken,
+          iasToXsuaaTokenExchange: false
+        })
+      ).rejects.toThrowError(/Failed to fetch instance destinations./);
+      expect(warn).toBeCalledWith(
+        'Cannot get cache key. Isolation strategy TenantUser is used, but tenant id or user id is undefined.'
+      );
     });
   });
 
@@ -494,14 +569,14 @@ describe('destination cache', () => {
       destinationCache.cacheRetrievedDestination(
         decodeJwt(subscriberUserJwt),
         parsedDestination,
-        IsolationStrategy.User
+        IsolationStrategy.Tenant_User
       );
 
       const actual = await getDestination({
         destinationName: 'SubscriberDest',
         jwt: subscriberUserJwt,
         useCache: true,
-        isolationStrategy: IsolationStrategy.User,
+        isolationStrategy: IsolationStrategy.Tenant_User,
         cacheVerificationKeys: false,
         iasToXsuaaTokenExchange: false
       });
@@ -589,32 +664,23 @@ describe('destination cache', () => {
     destinationCache.cacheRetrievedDestination(
       dummyJwt,
       destinationOne,
-      IsolationStrategy.User
+      IsolationStrategy.Tenant_User
     );
+
     const actual1 = destinationCache.retrieveDestinationFromCache(
       dummyJwt,
       'destToCache1',
-      IsolationStrategy.User
+      IsolationStrategy.Tenant_User
     );
     const actual2 = destinationCache.retrieveDestinationFromCache(
       dummyJwt,
       'destToCache1',
       IsolationStrategy.Tenant
     );
-    const actual3 = destinationCache.retrieveDestinationFromCache(
-      dummyJwt,
-      'destToCache1',
-      IsolationStrategy.Tenant_User
-    );
-    const actual4 = destinationCache.retrieveDestinationFromCache(
-      dummyJwt,
-      'destToCache1',
-      IsolationStrategy.No_Isolation
-    );
 
-    const expected = [destinationOne, undefined, undefined, undefined];
+    const expected = [destinationOne, undefined];
 
-    expect([actual1, actual2, actual3, actual4]).toEqual(expected);
+    expect([actual1, actual2]).toEqual(expected);
   });
 
   it('should not hit cache when Tenant_User is chosen but user id is missing', () => {
@@ -624,30 +690,21 @@ describe('destination cache', () => {
       destinationOne,
       IsolationStrategy.Tenant_User
     );
+
     const actual1 = destinationCache.retrieveDestinationFromCache(
-      dummyJwt,
-      'destToCache1',
-      IsolationStrategy.User
-    );
-    const actual2 = destinationCache.retrieveDestinationFromCache(
       dummyJwt,
       'destToCache1',
       IsolationStrategy.Tenant
     );
-    const actual3 = destinationCache.retrieveDestinationFromCache(
+    const actual2 = destinationCache.retrieveDestinationFromCache(
       dummyJwt,
       'destToCache1',
       IsolationStrategy.Tenant_User
     );
-    const actual4 = destinationCache.retrieveDestinationFromCache(
-      dummyJwt,
-      'destToCache1',
-      IsolationStrategy.No_Isolation
-    );
 
-    const expected = [undefined, undefined, undefined, undefined];
+    const expected = [undefined, undefined];
 
-    expect([actual1, actual2, actual3, actual4]).toEqual(expected);
+    expect([actual1, actual2]).toEqual(expected);
   });
 
   it('should not hit cache when Tenant is chosen but tenant id is missing', () => {
@@ -660,27 +717,17 @@ describe('destination cache', () => {
     const actual1 = destinationCache.retrieveDestinationFromCache(
       dummyJwt,
       'destToCache1',
-      IsolationStrategy.User
+      IsolationStrategy.Tenant
     );
     const actual2 = destinationCache.retrieveDestinationFromCache(
       dummyJwt,
       'destToCache1',
-      IsolationStrategy.Tenant
-    );
-    const actual3 = destinationCache.retrieveDestinationFromCache(
-      dummyJwt,
-      'destToCache1',
       IsolationStrategy.Tenant_User
     );
-    const actual4 = destinationCache.retrieveDestinationFromCache(
-      dummyJwt,
-      'destToCache1',
-      IsolationStrategy.No_Isolation
-    );
 
-    const expected = [undefined, undefined, undefined, undefined];
+    const expected = [undefined, undefined];
 
-    expect([actual1, actual2, actual3, actual4]).toEqual(expected);
+    expect([actual1, actual2]).toEqual(expected);
   });
 
   it('should return undefined when the destination is not valid', () => {
@@ -689,7 +736,7 @@ describe('destination cache', () => {
     destinationCache.cacheRetrievedDestination(
       dummyJwt,
       destinationOne,
-      IsolationStrategy.User
+      IsolationStrategy.Tenant_User
     );
     const minutesToExpire = 6;
     jest.advanceTimersByTime(60000 * minutesToExpire);
@@ -697,7 +744,7 @@ describe('destination cache', () => {
     const actual = destinationCache.retrieveDestinationFromCache(
       dummyJwt,
       'destToCache1',
-      IsolationStrategy.User
+      IsolationStrategy.Tenant_User
     );
 
     expect(actual).toBeUndefined();
@@ -713,13 +760,13 @@ describe('destination cache', () => {
     destinationCache.cacheRetrievedDestination(
       dummyJwt,
       destination,
-      IsolationStrategy.User
+      IsolationStrategy.Tenant_User
     );
     const retrieveDestination = () =>
       destinationCache.retrieveDestinationFromCache(
         dummyJwt,
         destination.name!,
-        IsolationStrategy.User
+        IsolationStrategy.Tenant_User
       );
 
     expect(retrieveDestination()).toEqual(destination);

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -1,7 +1,6 @@
 import { createLogger } from '@sap-cloud-sdk/util';
 import { JwtPayload } from '../jsonwebtoken-type';
 import { decodeJwt, isUserToken, JwtPair, verifyJwt } from '../jwt';
-import { IsolationStrategy } from '../cache';
 import { jwtBearerToken, serviceToken } from '../token-accessor';
 import { addProxyConfigurationOnPrem } from '../connectivity-service';
 import {
@@ -28,7 +27,7 @@ import {
   fetchInstanceDestinations,
   fetchSubaccountDestinations
 } from './destination-service';
-import { destinationCache } from './destination-cache';
+import { destinationCache, IsolationStrategy } from './destination-cache';
 import {
   addProxyConfigurationInternet,
   ProxyStrategy,
@@ -199,9 +198,11 @@ class DestinationFromServiceRetriever {
     readonly providerServiceToken: JwtPair
   ) {
     const defaultOptions = {
-      isolationStrategy: IsolationStrategy.Tenant_User,
+      isolationStrategy: options.jwt
+        ? IsolationStrategy.Tenant_User
+        : IsolationStrategy.Tenant,
       selectionStrategy: subscriberFirst,
-      useCache: false,
+      useCache: !!options.isolationStrategy,
       ...options
     };
     this.options = { ...defaultOptions, ...options };

--- a/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
@@ -1,6 +1,7 @@
-import { CachingOptions, IsolationStrategy } from '../cache';
+import { CachingOptions } from '../cache';
 import { ProxyConfiguration } from '../connectivity-service-types';
 import { ResilienceOptions } from '../resilience-options';
+import { IsolationStrategy } from './destination-cache';
 
 /**
  * A resolved destination containing information needed to execute requests, such as the system URL.

--- a/packages/connectivity/src/scp-cf/index.ts
+++ b/packages/connectivity/src/scp-cf/index.ts
@@ -20,3 +20,4 @@ export * from './user';
 export * from './verification-keys';
 export * from './xsuaa-service-types';
 export * from './xsuaa-service';
+export { IsolationStrategy } from './destination';


### PR DESCRIPTION
Relatest to SAP/cloud-sdk-backlog#541

This PR improved the `IsolationStrategy`. We have moved this option to the destination retrival, away from the general cache, which makes a few changes possible:
- The meaningful values are `Tenant` and `TenantUser`. For a destination it does not make sense in a multi-tenant scenario to isolate on `User` level or have `NoIsolation`. If you have a single tenant app you can just go with `Tenant`. So `User` and `NoIsolation` are removed.
- The default value for the IsolationStrategy is based on the other inputs now: If a JWT is provided UserTenant is assumed (highest isolation). If no JWT is provided a user independent service token is used so IsolationStrategy `Tenant` is the only meaningful choice, because you do not have a user.
- If a `IsolationStrategy` is given to the `getDestination()` this enables the cache. No need to provided `useCache: true`
- The destination-service caller also had a cache, which only makes sense for the Destination**s** endpoints we you get all destinations from a tenant, without the auth flow. This data is rather stable and can be cached. The actual destination by name call should not be cached, since the DestinationRetriver does the caching there already.

Please review this carefully because the caching is a security relevant thing.
