### PR TITLE
fix: v2 pipeline

### DIFF
--- a/.github/workflows/v2.yaml
+++ b/.github/workflows/v2.yaml
@@ -81,7 +81,7 @@ jobs:
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [tests, checks]
+    needs: [tests, checks, e2e-tests]
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1


### PR DESCRIPTION
The e2e-test is missing as prerequisites of v2 canary release.