### PR TITLE
feature: Add support for proxy type PrivateLink

### DIFF
--- a/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
@@ -780,10 +780,10 @@ describe('get destination with PrivateLink proxy type', () => {
     isTrustingAllCertificates: false,
     name: 'PrivateLinkDest',
     originalProperties: {
-          'Authentication': 'NoAuthentication',
-          'Name': 'PrivateLinkDest',
-          'ProxyType': 'PrivateLink',
-          'URL': 'https://subscriber.example',
+      Authentication: 'NoAuthentication',
+      Name: 'PrivateLinkDest',
+      ProxyType: 'PrivateLink',
+      URL: 'https://subscriber.example'
     },
     proxyType: 'PrivateLink',
     url: 'https://subscriber.example'
@@ -808,7 +808,10 @@ describe('get destination with PrivateLink proxy type', () => {
     );
   });
   it('should behave like internet proxy, so call addProxyConfigurationInternet but still use proxy type PrivateLink', async () => {
-    const internetConfig = jest.spyOn(ProxyUtil, 'addProxyConfigurationInternet');
+    const internetConfig = jest.spyOn(
+      ProxyUtil,
+      'addProxyConfigurationInternet'
+    );
 
     const destinationFromFirstCall = await getDestination({
       destinationName: 'PrivateLinkDest',

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
@@ -742,3 +742,44 @@ describe('get destination cache key', () => {
     );
   });
 });
+
+describe('get destination with PrivateLink proxy type', () => {
+  const privateLinkDest = {
+    URL: 'https://subscriber.example',
+    Name: 'PrivateLinkDest',
+    ProxyType: 'PrivateLink',
+    Authentication: 'NoAuthentication'
+  };
+
+  it('should log that PrivateLink proxy type is used.', async () => {
+    mockServiceBindings();
+    mockVerifyJwt();
+    mockServiceToken();
+    mockJwtBearerToken();
+
+    mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken);
+    mockSubaccountDestinationsCall(
+      nock,
+      [privateLinkDest],
+      200,
+      subscriberServiceToken
+    );
+
+    const logger = createLogger({
+      package: 'connectivity',
+      messageContext: 'proxy-util'
+    });
+    const info = jest.spyOn(logger, 'info');
+    const destinationFromFirstCall = await getDestination({
+      destinationName: 'PrivateLinkDest',
+      jwt: subscriberUserJwt,
+      useCache: true,
+      cacheVerificationKeys: false,
+      iasToXsuaaTokenExchange: false
+    });
+    expect(info).toBeCalledWith(
+      'PrivateLink destination proxy settings will be used.'
+    );
+    expect(destinationFromFirstCall?.proxyType).toBe('PrivateLink');
+  });
+});

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
@@ -796,7 +796,7 @@ describe('get destination with PrivateLink proxy type', () => {
     });
     const info = jest.spyOn(logger, 'info');
 
-    const destinationFromFirstCall = await getDestination({
+    await getDestination({
       destinationName: 'PrivateLinkDest',
       jwt: subscriberUserJwt,
       useCache: true,
@@ -807,6 +807,7 @@ describe('get destination with PrivateLink proxy type', () => {
       'PrivateLink destination proxy settings will be used.'
     );
   });
+
   it('should behave like internet proxy, so call addProxyConfigurationInternet but still use proxy type PrivateLink', async () => {
     const internetConfig = jest.spyOn(
       ProxyUtil,

--- a/packages/connectivity/src/scp-cf/destination/destination-from-env.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-env.ts
@@ -74,7 +74,8 @@ export function getDestinationFromEnvByName(name: string): Destination | null {
     );
   }
   const destination = matchingDestinations[0];
-  return (proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY || proxyStrategy(destination) === ProxyStrategy.PRIVATELINK_PROXY)
+  return proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY ||
+    proxyStrategy(destination) === ProxyStrategy.PRIVATELINK_PROXY
     ? addProxyConfigurationInternet(destination)
     : destination;
 }

--- a/packages/connectivity/src/scp-cf/destination/destination-from-env.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-env.ts
@@ -74,7 +74,7 @@ export function getDestinationFromEnvByName(name: string): Destination | null {
     );
   }
   const destination = matchingDestinations[0];
-  return proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY
+  return (proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY || proxyStrategy(destination) === ProxyStrategy.PRIVATELINK_PROXY)
     ? addProxyConfigurationInternet(destination)
     : destination;
 }

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -416,6 +416,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
           this.subscriberToken?.userJwt
         );
       case ProxyStrategy.INTERNET_PROXY:
+      case ProxyStrategy.PRIVATELINK_PROXY:
         return addProxyConfigurationInternet(destination);
       case ProxyStrategy.NO_PROXY:
         return destination;

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -374,7 +374,6 @@ Possible alternatives for such technical user authentication are BasicAuthentica
       authHeaderJwt: serviceJwt.encoded, // token to get destination from service
       exchangeHeaderJwt: this.subscriberToken.userJwt.encoded // token considered for user and tenant
     };
-
   }
 
   /**

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -375,9 +375,6 @@ Possible alternatives for such technical user authentication are BasicAuthentica
       exchangeHeaderJwt: this.subscriberToken.userJwt.encoded // token considered for user and tenant
     };
 
-    throw new Error(
-      `Not possible to build tokens for ${destination.authentication} flow for destination ${destination.name}.`
-    );
   }
 
   /**

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
@@ -32,7 +32,7 @@ export function destinationForServiceBinding(
     : transform(selected);
 
   return destination &&
-    proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY
+    (proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY || proxyStrategy(destination) === ProxyStrategy.PRIVATELINK_PROXY)
     ? addProxyConfigurationInternet(destination)
     : destination;
 }

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
@@ -32,7 +32,8 @@ export function destinationForServiceBinding(
     : transform(selected);
 
   return destination &&
-    (proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY || proxyStrategy(destination) === ProxyStrategy.PRIVATELINK_PROXY)
+    (proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY ||
+      proxyStrategy(destination) === ProxyStrategy.PRIVATELINK_PROXY)
     ? addProxyConfigurationInternet(destination)
     : destination;
 }

--- a/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
@@ -164,7 +164,11 @@ export interface DestinationAuthToken {
 /**
  * @internal
  */
-export type DestinationProxyType = 'OnPremise' | 'Internet' | 'PrivateLink' | null;
+export type DestinationProxyType =
+  | 'OnPremise'
+  | 'Internet'
+  | 'PrivateLink'
+  | null;
 
 /**
  * Represents a certificate attached to a destination.

--- a/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
@@ -164,7 +164,7 @@ export interface DestinationAuthToken {
 /**
  * @internal
  */
-export type DestinationProxyType = 'OnPremise' | 'Internet' | null;
+export type DestinationProxyType = 'OnPremise' | 'Internet' | 'PrivateLink' | null;
 
 /**
  * Represents a certificate attached to a destination.

--- a/packages/connectivity/src/scp-cf/destination/proxy-util.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/proxy-util.spec.ts
@@ -33,6 +33,12 @@ describe('proxy-util', () => {
     url: 'http://example.com'
   };
 
+  const privateLinkDestination: Destination = {
+    name: 'privateLinkDestination',
+    url: 'https://example.com',
+    proxyType: 'PrivateLink'
+  };
+
   it('should use proxy type OnPrem if the destination is onPrem - even if HTTP(S)_PROXY env are present.', () => {
     process.env['https_proxy'] = 'https://some.proxy.com:443';
 
@@ -76,6 +82,10 @@ describe('proxy-util', () => {
 
     process.env['http_proxy'] = 'envIsNowSet';
     expect(proxyStrategy(httpsDestination)).toBe(ProxyStrategy.INTERNET_PROXY);
+  });
+
+  it('should use PrivateLink proxy if proxy type is Privatelink.', () => {
+    expect(proxyStrategy(privateLinkDestination)).toBe(ProxyStrategy.PRIVATELINK_PROXY);
   });
 
   it('should use the proxy env with the  protocol indicated by the destination.', () => {

--- a/packages/connectivity/src/scp-cf/destination/proxy-util.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/proxy-util.spec.ts
@@ -85,7 +85,9 @@ describe('proxy-util', () => {
   });
 
   it('should use PrivateLink proxy if proxy type is Privatelink.', () => {
-    expect(proxyStrategy(privateLinkDestination)).toBe(ProxyStrategy.PRIVATELINK_PROXY);
+    expect(proxyStrategy(privateLinkDestination)).toBe(
+      ProxyStrategy.PRIVATELINK_PROXY
+    );
   });
 
   it('should use the proxy env with the  protocol indicated by the destination.', () => {

--- a/packages/connectivity/src/scp-cf/destination/proxy-util.ts
+++ b/packages/connectivity/src/scp-cf/destination/proxy-util.ts
@@ -31,9 +31,7 @@ export function proxyStrategy(destination: Destination): ProxyStrategy {
   }
 
   if (destination.proxyType === 'PrivateLink') {
-    logger.info(
-      'PrivateLink destination proxy settings will be used.'
-    );
+    logger.info('PrivateLink destination proxy settings will be used.');
     return ProxyStrategy.PRIVATELINK_PROXY;
   }
 

--- a/packages/connectivity/src/scp-cf/destination/proxy-util.ts
+++ b/packages/connectivity/src/scp-cf/destination/proxy-util.ts
@@ -29,6 +29,14 @@ export function proxyStrategy(destination: Destination): ProxyStrategy {
     );
     return ProxyStrategy.ON_PREMISE_PROXY;
   }
+
+  if (destination.proxyType === 'PrivateLink') {
+    logger.info(
+      'PrivateLink destination proxy settings will be used.'
+    );
+    return ProxyStrategy.PRIVATELINK_PROXY;
+  }
+
   const destinationProtocol = getProtocolOrDefault(destination);
   if (!getProxyEnvValue(destinationProtocol)) {
     logger.info(
@@ -257,5 +265,6 @@ export function proxyAgent(
 export enum ProxyStrategy {
   NO_PROXY,
   ON_PREMISE_PROXY,
-  INTERNET_PROXY
+  INTERNET_PROXY,
+  PRIVATELINK_PROXY
 }

--- a/test-packages/integration-tests/test/auth-flows/auth-flow-util.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow-util.ts
@@ -63,5 +63,6 @@ export interface Systems {
     providerOauth2JWTBearerCommonTokenURL: string;
     providerOauth2UserTokenExchange: string;
     providerOauth2UserTokenExchangeCommonTokenURL: string;
+    providerBasicPrivateLink: string;
   };
 }

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -384,6 +384,13 @@ describe('OAuth flows', () => {
     expect(decoded.scope.length).toBeGreaterThan(0);
   }, 60000);
 
+  xit('PrivateLink: Provider Destination', async () => {
+    const myDestination = await getDestination({
+      destinationName: systems.destination.providerBasicPrivateLink
+    });
+    expect(myDestination?.proxyType).toEqual('PrivateLink');
+  });
+
   xit('IAS + OAuth2ClientCredentials: Provider Destination & Provider Jwt', async () => {
     const iasToken = accessToken.iasProvider;
     const xsuaaConfig = JSON.parse(process.env.VCAP_SERVICES!).xsuaa[0]


### PR DESCRIPTION
This PR introduces support for proxy type PrivateLink.

Relates to SAP/cloud-sdk-backlog#450.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
