### PR TITLE
chore: change fetchCsrfToken default value to true

### DIFF
--- a/CHANGELOG-v2.md
+++ b/CHANGELOG-v2.md
@@ -420,6 +420,8 @@
   - `serviceToken` uses jwt instead of userJwt now.
   - `jwtBearerToken` uses jwt instead of userJwt now.
   - `fetchVerificationKeys` merged with `executeFetchVerificationKeys`, now only accepts url as parameter
+- [http-client] changed the following implementations
+  - `executeHttpRequest` fetches CsrfToken for non-GET requests by default.
 
 ## Known Issues
 

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -37,6 +37,7 @@
     "axios": "^0.24.0"
   },
   "devDependencies": {
-    "nock": "^13.0.11"
+    "nock": "^13.0.11",
+    "https-proxy-agent": "^5.0.0"
   }
 }

--- a/packages/http-client/src/http-client-types.ts
+++ b/packages/http-client/src/http-client-types.ts
@@ -84,11 +84,10 @@ export interface HttpResponse extends KnownHttpResponseFields {
 }
 
 export interface HttpRequestOptions {
-  // TODO: 2.0 update docs when default value is changed to true.
   /**
    * A boolean value that indicates whether to fetch the csrf token for a non-get request.
    * For a get request, the csrf token is not fetched and this option is ignored.
-   * By default, the value is `false`.
+   * By default, the value is `true`.
    */
   fetchCsrfToken?: boolean;
 }

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -689,6 +689,7 @@ sap-client:001`);
       );
     });
 
+    // Axios requests are not redirected via proxy
     xit('test axios proxy redirect', () => {
       const proxyConfiguration: ProxyConfiguration = {
         host: 'localhost',

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -689,7 +689,12 @@ sap-client:001`);
       );
     });
 
-    // Axios requests are not redirected via proxy
+    /* eslint-disable no-console */
+    /**
+     * https://github.com/SAP/cloud-sdk-backlog/issues/560.
+     * Actual: request is successfull.
+     * Expected: Axios requests should pass via the proxy and hence result in a redirect loop.
+     * */
     xit('test axios proxy redirect', () => {
       const proxyConfiguration: ProxyConfiguration = {
         host: 'localhost',
@@ -709,10 +714,8 @@ sap-client:001`);
         url: 'https://google.com',
         httpsAgent: new HttpsProxyAgent(proxyConfiguration)
       })
-        .then(r => r.data)
-        .catch(error => {
-          throw new Error(error);
-        });
+        .then(r => console.log(r))
+        .catch(console.error);
     });
   });
 

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -1,8 +1,10 @@
 import https from 'https';
+import http from 'http';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import nock from 'nock';
 import { createLogger } from '@sap-cloud-sdk/util';
 import axios from 'axios';
-import { Destination, Protocol } from '@sap-cloud-sdk/connectivity';
+import { Destination, Protocol, ProxyConfiguration } from '@sap-cloud-sdk/connectivity';
 import {
   connectivityProxyConfigMock,
   defaultDestination
@@ -681,6 +683,27 @@ sap-client:001`);
           method: 'post'
         })
       );
+    });
+
+    xit('test axios proxy redirect', () => {
+      const proxyConfiguration: ProxyConfiguration = {
+        host: 'localhost',
+        port: 8080,
+        protocol: Protocol.HTTP
+      };
+      // A fake proxy server
+      http.createServer(function (req, res) {
+        res.writeHead(302, { location: 'https://example.com' });
+        res.end();
+      }).listen(8080);
+
+      axios({
+        method: 'get',
+        url: 'https://google.com',
+        httpsAgent: new HttpsProxyAgent(proxyConfiguration)
+      })
+      .then((r) => r.data)
+      .catch(console.error);
     });
   });
 

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -4,7 +4,11 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import nock from 'nock';
 import { createLogger } from '@sap-cloud-sdk/util';
 import axios from 'axios';
-import { Destination, Protocol, ProxyConfiguration } from '@sap-cloud-sdk/connectivity';
+import {
+  Destination,
+  Protocol,
+  ProxyConfiguration
+} from '@sap-cloud-sdk/connectivity';
 import {
   connectivityProxyConfigMock,
   defaultDestination
@@ -692,18 +696,24 @@ sap-client:001`);
         protocol: Protocol.HTTP
       };
       // A fake proxy server
-      http.createServer(function (req, res) {
-        res.writeHead(302, { location: 'https://example.com' });
-        res.end();
-      }).listen(8080);
+      http
+        .createServer(function (req, res) {
+          res.writeHead(302, { location: 'https://example.com' });
+          res.end();
+        })
+        .listen(8080);
 
       axios({
         method: 'get',
         url: 'https://google.com',
         httpsAgent: new HttpsProxyAgent(proxyConfiguration)
       })
-      .then((r) => r.data)
-      .catch(console.error);
+        .then(r => r.data)
+        .catch(error => {
+          expect(error.message).toContain(
+            'Maximum number of redirects exceeded'
+          );
+        });
     });
   });
 

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -710,9 +710,7 @@ sap-client:001`);
       })
         .then(r => r.data)
         .catch(error => {
-          expect(error.message).toContain(
-            'Maximum number of redirects exceeded'
-          );
+          throw new Error(error);
         });
     });
   });

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -330,10 +330,13 @@ export function getAxiosConfigWithDefaultsWithoutMethod(): Omit<
   };
 }
 
-function getDefaultHttpRequestOptions(): HttpRequestOptions {
-  // TODO: 2.0 change to true
+// eslint-disable-next-line valid-jsdoc
+/**
+ * @internal
+ */
+export function getDefaultHttpRequestOptions(): HttpRequestOptions {
   return {
-    fetchCsrfToken: false
+    fetchCsrfToken: true
   };
 }
 

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -106,7 +106,6 @@ export class OpenApiRequestBuilder<ResponseT = any> {
         params: this.getParameters(),
         data: this.parameters?.body
       },
-      // TODO: Remove this in v 2.0, when this becomes true becomes the default
       { fetchCsrfToken }
     );
   }


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#524.

Changed the default value of `fetchCsrfToken` to true for the generic http client for non-GET requests.( note: this was already true by default in the odata and openapi clients). The user can still override this by passing false in the `executeHttpRequest` method. 

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
