### PR TITLE
fix: move `execa` to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-tsdoc": "^0.2.14",
     "eslint-plugin-unused-imports": "^2.0.0",
+    "execa": "^5.0.0",
     "glob": "^7.1.6",
     "jest": "^27.2.3",
     "jest-junit": "^13.0.0",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -40,7 +40,6 @@
     "@sap/edm-converters": "~1.0.21",
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.2",
-    "execa": "^5.0.0",
     "fast-xml-parser": "^4.0.1",
     "fs-extra": "^10.0.0",
     "glob": "^7.1.6",
@@ -51,6 +50,7 @@
   },
   "devDependencies": {
     "@types/yargs": "^17.0.0",
+    "execa": "^5.0.0",
     "mock-fs": "^5.0.0",
     "jest-extended": "^1.0.0",
     "nock": "^13.0.11"


### PR DESCRIPTION
`execa` is used:
- as dependency in the `generator` package, while only tests are using it.
- in some scripts of the `script` directory, which is for the SDK developers like calling `lerna` or generating readme.

This lib is also related to the ESM issue.
If we don't ship it to the users, even it might be vulnerable in the future, we are still "safe".

This PR will move the `execa` to dev dependency.

### The install size
226 KB
