### PR TITLE
chore: add dependabot automerge for main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,10 +82,33 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - run: yarn test:e2e
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
+    needs: [tests, checks, e2e-tests]
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   canary-release:
     if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [tests, checks]
+    needs: [tests, checks, e2e-tests]
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

This PR adds the dependabot automerge job in the build workflow for the main branch

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
