### PR TITLE
chore: Add support for proxy type privatelink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ## New Functionality
 
--
+- [core] Proxy type `PrivateLink` is now supported
 
 ## Improvements
 

--- a/packages/core/src/connectivity/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
@@ -184,13 +184,10 @@ describe('get destination with PrivateLink proxy type', () => {
     });
     const info = jest.spyOn(logger, 'info');
 
-    await getDestination('PrivateLinkDest',
-      {
-        userJwt: subscriberUserJwt,
-        cacheVerificationKeys: false,
-        iasToXsuaaTokenExchange: false
-      }
-    );
+    await getDestination('PrivateLinkDest', {
+      userJwt: subscriberUserJwt,
+      cacheVerificationKeys: false
+    });
     expect(info).toBeCalledWith(
       'PrivateLink destination proxy settings will be used. This is not supported in local/CI/CD environments.'
     );
@@ -202,11 +199,9 @@ describe('get destination with PrivateLink proxy type', () => {
       'addProxyConfigurationInternet'
     );
 
-    const destinationFromFirstCall = await getDestination({
-      destinationName: 'PrivateLinkDest',
+    const destinationFromFirstCall = await getDestination('PrivateLinkDest', {
       userJwt: subscriberUserJwt,
-      cacheVerificationKeys: false,
-      iasToXsuaaTokenExchange: false
+      cacheVerificationKeys: false
     });
 
     expect(destinationFromFirstCall?.proxyType).toBe('PrivateLink');

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-env.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-env.ts
@@ -85,7 +85,8 @@ export function getDestinationFromEnvByName(name: string): Destination | null {
     );
   }
   const destination = matchingDestinations[0];
-  return proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY || proxyStrategy(destination) === ProxyStrategy.PRIVATELINK_PROXY
+  return proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY ||
+    proxyStrategy(destination) === ProxyStrategy.PRIVATELINK_PROXY
     ? addProxyConfigurationInternet(destination)
     : destination;
 }

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-env.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-env.ts
@@ -85,7 +85,7 @@ export function getDestinationFromEnvByName(name: string): Destination | null {
     );
   }
   const destination = matchingDestinations[0];
-  return proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY
+  return proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY || proxyStrategy(destination) === ProxyStrategy.PRIVATELINK_PROXY
     ? addProxyConfigurationInternet(destination)
     : destination;
 }

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-service.ts
@@ -425,6 +425,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
           this.subscriberToken?.userJwt
         );
       case ProxyStrategy.INTERNET_PROXY:
+      case ProxyStrategy.PRIVATELINK_PROXY:
         return addProxyConfigurationInternet(destination);
       case ProxyStrategy.NO_PROXY:
         return destination;

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-vcap.ts
@@ -31,7 +31,8 @@ export function destinationForServiceBinding(
     : transform(selected);
 
   return destination &&
-    (proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY || proxyStrategy(destination) === ProxyStrategy.PRIVATELINK_PROXY)
+    (proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY ||
+      proxyStrategy(destination) === ProxyStrategy.PRIVATELINK_PROXY)
     ? addProxyConfigurationInternet(destination)
     : destination;
 }

--- a/packages/core/src/connectivity/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-from-vcap.ts
@@ -31,7 +31,7 @@ export function destinationForServiceBinding(
     : transform(selected);
 
   return destination &&
-    proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY
+    (proxyStrategy(destination) === ProxyStrategy.INTERNET_PROXY || proxyStrategy(destination) === ProxyStrategy.PRIVATELINK_PROXY)
     ? addProxyConfigurationInternet(destination)
     : destination;
 }

--- a/packages/core/src/connectivity/scp-cf/destination/destination-service-types.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-service-types.ts
@@ -166,7 +166,7 @@ export interface DestinationAuthToken {
   };
 }
 
-export type DestinationProxyType = 'OnPremise' | 'Internet' | null;
+export type DestinationProxyType = 'OnPremise' | 'Internet' | 'PrivateLink' | null;
 
 /**
  * Represents a certificate attached to a destination.

--- a/packages/core/src/connectivity/scp-cf/destination/destination-service-types.ts
+++ b/packages/core/src/connectivity/scp-cf/destination/destination-service-types.ts
@@ -166,7 +166,11 @@ export interface DestinationAuthToken {
   };
 }
 
-export type DestinationProxyType = 'OnPremise' | 'Internet' | 'PrivateLink' | null;
+export type DestinationProxyType =
+  | 'OnPremise'
+  | 'Internet'
+  | 'PrivateLink'
+  | null;
 
 /**
  * Represents a certificate attached to a destination.

--- a/packages/core/src/http-agent/proxy-util.spec.ts
+++ b/packages/core/src/http-agent/proxy-util.spec.ts
@@ -35,6 +35,12 @@ describe('proxy-util', () => {
     url: 'http://example.com'
   };
 
+  const privateLinkDestination: Destination = {
+    name: 'privateLinkDestination',
+    url: 'https://example.com',
+    proxyType: 'PrivateLink'
+  };
+
   it('should use proxy type OnPrem if the destination is onPrem - even if HTTP(S)_PROXY env are present.', () => {
     process.env['https_proxy'] = 'https://some.proxy.com:443';
 
@@ -78,6 +84,12 @@ describe('proxy-util', () => {
 
     process.env['http_proxy'] = 'envIsNowSet';
     expect(proxyStrategy(httpsDestination)).toBe(ProxyStrategy.INTERNET_PROXY);
+  });
+
+  it('should use PrivateLink proxy if proxy type is Privatelink.', () => {
+    expect(proxyStrategy(privateLinkDestination)).toBe(
+      ProxyStrategy.PRIVATELINK_PROXY
+    );
   });
 
   it('should use the proxy env with the  protocol indicated by the destination.', () => {

--- a/packages/core/src/http-agent/proxy-util.ts
+++ b/packages/core/src/http-agent/proxy-util.ts
@@ -28,6 +28,14 @@ export function proxyStrategy(destination: Destination): ProxyStrategy {
     );
     return ProxyStrategy.ON_PREMISE_PROXY;
   }
+
+  if (destination.proxyType === 'PrivateLink') {
+    logger.info(
+      'PrivateLink destination proxy settings will be used. This is not supported in local/CI/CD environments.'
+    );
+    return ProxyStrategy.PRIVATELINK_PROXY;
+  }
+
   const destinationProtocol = getProtocolOrDefault(destination);
   if (!getProxyEnvValue(destinationProtocol)) {
     logger.info(
@@ -253,5 +261,6 @@ export function proxyAgent(
 export enum ProxyStrategy {
   NO_PROXY,
   ON_PREMISE_PROXY,
-  INTERNET_PROXY
+  INTERNET_PROXY,
+  PRIVATELINK_PROXY
 }

--- a/test-packages/integration-tests/test/auth-flows/auth-flow-util.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow-util.ts
@@ -60,5 +60,6 @@ export interface Systems {
     providerOauth2JWTBearerCommonTokenURL: string;
     providerOauth2UserTokenExchange: string;
     providerOauth2UserTokenExchangeCommonTokenURL: string;
+    providerBasicPrivateLink: string;
   };
 }

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -342,6 +342,13 @@ describe('OAuth flows', () => {
       ]
     ).toBeDefined();
   }, 60000);
+
+  xit('PrivateLink: Provider Destination', async () => {
+    const myDestination = await getDestination(
+      systems.destination.providerBasicPrivateLink
+    );
+    expect(myDestination?.proxyType).toEqual('PrivateLink');
+  });
 });
 
 function assertCommenTokenUrl(destination: Destination) {


### PR DESCRIPTION
This PR is a copy of #2026 

Some adaptions were made to support main (e.g. different getDestination call, different imports)

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
