### PR TITLE
chore:remove mjs config

### DIFF
--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -17,11 +17,9 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./internal": {
-      "import": "./dist/internal.mjs",
       "require": "./dist/internal.js"
     }
   },

--- a/packages/generator-common/package.json
+++ b/packages/generator-common/package.json
@@ -17,11 +17,9 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./internal": {
-      "import": "./dist/internal.mjs",
       "require": "./dist/internal.js"
     }
   },

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@types/yargs": "^17.0.0",
-    "execa": "^6.0.0",
+    "execa": "^5.0.0",
     "mock-fs": "^5.0.0",
     "jest-extended": "^2.0.0",
     "nock": "^13.0.11"

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -20,11 +20,9 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./internal": {
-      "import": "./dist/internal.mjs",
       "require": "./dist/internal.js"
     }
   },
@@ -62,7 +60,7 @@
   },
   "devDependencies": {
     "@types/yargs": "^17.0.0",
-    "execa": "^5.0.0",
+    "execa": "^6.0.0",
     "mock-fs": "^5.0.0",
     "jest-extended": "^2.0.0",
     "nock": "^13.0.11"

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -17,11 +17,9 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./internal": {
-      "import": "./dist/internal.mjs",
       "require": "./dist/internal.js"
     }
   },

--- a/packages/odata-common/package.json
+++ b/packages/odata-common/package.json
@@ -17,11 +17,9 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./internal": {
-      "import": "./dist/internal.mjs",
       "require": "./dist/internal.js"
     }
   },

--- a/packages/odata-v2/package.json
+++ b/packages/odata-v2/package.json
@@ -17,11 +17,9 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./internal": {
-      "import": "./dist/internal.mjs",
       "require": "./dist/internal.js"
     }
   },

--- a/packages/odata-v4/package.json
+++ b/packages/odata-v4/package.json
@@ -17,11 +17,9 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./internal": {
-      "import": "./dist/internal.mjs",
       "require": "./dist/internal.js"
     }
   },

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -20,11 +20,9 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./internal": {
-      "import": "./dist/internal.mjs",
       "require": "./dist/internal.js"
     }
   },

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -17,11 +17,9 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./internal": {
-      "import": "./dist/internal.mjs",
       "require": "./dist/internal.js"
     }
   },

--- a/packages/temporal-de-serializers/package.json
+++ b/packages/temporal-de-serializers/package.json
@@ -17,11 +17,9 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./internal": {
-      "import": "./dist/internal.mjs",
       "require": "./dist/internal.js"
     }
   },


### PR DESCRIPTION
This PR 
- keeps the hybrid mode introduced here: #2079 
- removes the `.mjs` related config

so it still have the flexibility to add `.mjs` support (non-breaking) in the future with minimal risks/changes.

The rest of the config should still be considered as breaking, that's why having it before 2.0 is necessary (or wait until 3.0)
```
  "exports": {
    ".": {
      "require": "./dist/index.js"
    },
    "./internal": {
      "require": "./dist/internal.js"
    }
  },
```

### Test coverage
- PoC local unit tests
- Internal vdm e2e tests

### Reference doc
- https://nodejs.org/api/packages.html#package-entry-points