### PR TITLE
Generator fixes

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -48,6 +48,9 @@
   },
   "dependencies": {
     "@sap-cloud-sdk/generator-common": "^1.50.0",
+    "@sap-cloud-sdk/odata-common": "^1.50.0",
+    "@sap-cloud-sdk/odata-v2": "^1.50.0",
+    "@sap-cloud-sdk/odata-v4": "^1.50.0",
     "@sap-cloud-sdk/util": "^1.50.0",
     "@sap/edm-converters": "~1.0.21",
     "@types/fs-extra": "^9.0.1",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -44,11 +44,10 @@
     "wrap-esm": "yarn gen-esm-wrapper ./dist/index ./dist/index.mjs && yarn gen-esm-wrapper ./dist/internal ./dist/internal.mjs",
     "test": "yarn jest",
     "coverage": "yarn jest --coverage",
-    "check:dependencies": "depcheck "
+    "check:dependencies": "depcheck . --ignores='@sap-cloud-sdk/odata-v2,@sap-cloud-sdk/odata-v4'"
   },
   "dependencies": {
     "@sap-cloud-sdk/generator-common": "^1.50.0",
-    "@sap-cloud-sdk/odata-common": "^1.50.0",
     "@sap-cloud-sdk/odata-v2": "^1.50.0",
     "@sap-cloud-sdk/odata-v4": "^1.50.0",
     "@sap-cloud-sdk/util": "^1.50.0",

--- a/packages/generator/src/generator.spec.ts
+++ b/packages/generator/src/generator.spec.ts
@@ -207,7 +207,7 @@ describe('generator', () => {
     );
 
     expect(getInstallODataErrorMessage(project!)).toMatchInlineSnapshot(
-      `"Did you forget to install \\"@sap-cloud-sdk/odata-v2\\"?"`
+      '"Did you forget to install \\"@sap-cloud-sdk/odata-v2\\"?"'
     );
   });
 });

--- a/packages/generator/src/generator.spec.ts
+++ b/packages/generator/src/generator.spec.ts
@@ -10,7 +10,11 @@ import {
   getGeneratedFiles
 } from '../test/test-util/generator';
 import { oDataServiceSpecs } from '../../../test-resources/odata-service-specs';
-import { generate, generateProject } from './generator';
+import {
+  generate,
+  generateProject,
+  getInstallODataErrorMessage
+} from './generator';
 import { GeneratorOptions } from './generator-options';
 import * as csnGeneration from './service/csn';
 
@@ -43,6 +47,7 @@ describe('generator', () => {
       const sourceFiles = await promises.readdir(
         join(outPutPath, 'test-service')
       );
+
       expect(
         sourceFiles.find(file => file === 'some-test-markdown.md')
       ).toBeDefined();
@@ -188,6 +193,22 @@ describe('generator', () => {
         ])
       );
     });
+  });
+
+  it('recommends to install odata packages', async () => {
+    const project = await generateProject(
+      createOptions({
+        inputDir: pathTestService,
+        outputDir: outPutPath,
+        forceOverwrite: true,
+        generateJs: true,
+        additionalFiles: '../../../*.md'
+      })
+    );
+
+    expect(getInstallODataErrorMessage(project!)).toMatchInlineSnapshot(
+      `"Did you forget to install \\"@sap-cloud-sdk/odata-v2\\"?"`
+    );
   });
 });
 

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -98,6 +98,8 @@ export async function generate(options: GeneratorOptions): Promise<void> {
 
 /**
  * @internal
+ * @param projectAndServices - Generated project with services.
+ * @returns An error message with a recommendation to install specific SDK packages.
  */
 export function getInstallODataErrorMessage(
   projectAndServices: ProjectAndServices

--- a/packages/generator/src/service/package-json.spec.ts
+++ b/packages/generator/src/service/package-json.spec.ts
@@ -1,0 +1,104 @@
+import { packageJson } from './package-json';
+
+describe('package-json', () => {
+  it('creates v2 package content', async () => {
+    await expect(
+      packageJson(
+        'my-v2-package',
+        'X.Y.Z-v2',
+        'my v2 package description',
+        false,
+        'v2'
+      )
+    ).resolves.toMatchInlineSnapshot(`
+            "{
+              \\"name\\": \\"my-v2-package\\",
+              \\"version\\": \\"X.Y.Z-v2\\",
+              \\"description\\": \\"my v2 package description\\",
+              \\"homepage\\": \\"https://sap.github.io/cloud-sdk/docs/js/getting-started\\",
+              \\"main\\": \\"./index.js\\",
+              \\"types\\": \\"./index.d.ts\\",
+              \\"publishConfig\\": {
+                \\"access\\": \\"public\\"
+              },
+              \\"files\\": [
+                \\"**/*.js\\",
+                \\"**/*.js.map\\",
+                \\"**/*.d.ts\\",
+                \\"**/d.ts.map\\",
+                \\"**/*-csn.json\\"
+              ],
+              \\"repository\\": {
+                \\"type\\": \\"git\\",
+                \\"url\\": \\"\\"
+              },
+              \\"scripts\\": {
+                \\"compile\\": \\"npx tsc\\"
+              },
+              \\"dependencies\\": {
+                \\"@sap-cloud-sdk/odata-common\\": \\"^1.50.0\\",
+                \\"@sap-cloud-sdk/odata-v2\\": \\"^1.50.0\\"
+              },
+              \\"peerDependencies\\": {
+                \\"@sap-cloud-sdk/odata-common\\": \\"^1.50.0\\",
+                \\"@sap-cloud-sdk/odata-v2\\": \\"^1.50.0\\"
+              },
+              \\"devDependencies\\": {
+                \\"typescript\\": \\"~4.5\\"
+              }
+            }
+            "
+          `);
+  });
+
+  it('creates v4 package content with after version script', async () => {
+    await expect(
+      packageJson(
+        'my-v4-package',
+        'X.Y.Z-v4',
+        'my v4 package description',
+        true,
+        'v4'
+      )
+    ).resolves.toMatchInlineSnapshot(`
+            "{
+              \\"name\\": \\"my-v4-package\\",
+              \\"version\\": \\"X.Y.Z-v4\\",
+              \\"description\\": \\"my v4 package description\\",
+              \\"homepage\\": \\"https://sap.github.io/cloud-sdk/docs/js/getting-started\\",
+              \\"main\\": \\"./index.js\\",
+              \\"types\\": \\"./index.d.ts\\",
+              \\"publishConfig\\": {
+                \\"access\\": \\"public\\"
+              },
+              \\"files\\": [
+                \\"**/*.js\\",
+                \\"**/*.js.map\\",
+                \\"**/*.d.ts\\",
+                \\"**/d.ts.map\\",
+                \\"**/*-csn.json\\"
+              ],
+              \\"repository\\": {
+                \\"type\\": \\"git\\",
+                \\"url\\": \\"\\"
+              },
+              \\"scripts\\": {
+                \\"compile\\": \\"npx tsc\\",
+                \\"version\\": \\"node ../../../after-version-update.js\\"
+              },
+              \\"dependencies\\": {
+                \\"@sap-cloud-sdk/odata-common\\": \\"^1.50.0\\",
+                \\"@sap-cloud-sdk/odata-v4\\": \\"^1.50.0\\"
+              },
+              \\"peerDependencies\\": {
+                \\"@sap-cloud-sdk/odata-common\\": \\"^1.50.0\\",
+                \\"@sap-cloud-sdk/odata-v4\\": \\"^1.50.0\\"
+              },
+              \\"devDependencies\\": {
+                \\"typescript\\": \\"~4.5\\"
+              }
+            }
+            "
+          `);
+  });
+});

--- a/packages/generator/src/service/package-json.ts
+++ b/packages/generator/src/service/package-json.ts
@@ -46,15 +46,15 @@ export async function packageJson(
             : {})
         },
         dependencies: {
-          '@sap-cloud-sdk/odata-common/internal': `^${await getSdkVersion()}`,
+          '@sap-cloud-sdk/odata-common': `^${await getSdkVersion()}`,
           [oDataModule]: `^${await getSdkVersion()}`
         },
         peerDependencies: {
-          '@sap-cloud-sdk/odata-common/internal': `^${await getSdkVersion()}`,
+          '@sap-cloud-sdk/odata-common': `^${await getSdkVersion()}`,
           [oDataModule]: `^${await getSdkVersion()}`
         },
         devDependencies: {
-          typescript: '~4.1.2'
+          typescript: '~4.5'
         }
       },
       null,


### PR DESCRIPTION
Add dependencies to generator + recommendation if the odata package was not installed.
The idea is: This will work for the local generator, but if someone is using a globally installed generator, they must install the odata packages.

I am not too happy about the tests, but I think this is a general problem in the odata generator...

Closes SAP/cloud-sdk-backlog#562.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
