### PR TITLE
chore: support releasing major version

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -29,3 +29,6 @@ jobs:
       - name: Bump patch version
         if: github.event.inputs.bump == 'patch'
         run: yarn lerna version patch --force-publish -y
+      - name: Bump patch version
+        if: github.event.inputs.bump == 'major'
+        run: yarn lerna version major --force-publish -y


### PR DESCRIPTION
This is used for one time major version release, and will be reverted after the release.
Having release in the pipeline/container is much cleaner/saver instead of local.