### PR TITLE
chore: disable publishing canary for v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,31 +105,6 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-  canary-release:
-    if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    needs: [tests, checks, e2e-tests]
-    steps:
-      - uses: actions/checkout@v2
-      - run: git fetch --depth=1
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '12.x'
-      - uses: actions/cache@v2
-        id: cache
-        with:
-          path: |
-            node_modules
-            */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install --frozen-lockfile
-      - name: Canary Release
-        run: |
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
-          date=`date +%Y%m%d%H%M%S`
-          yarn lerna publish --canary --no-push --no-git-tag-version --dist-tag canary --force-publish --preid ${date} -y
-        env:
-          NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
   draft-github-release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
