### PR TITLE
chore: publish a new next version

### DIFF
--- a/.github/workflows/v2.yaml
+++ b/.github/workflows/v2.yaml
@@ -100,6 +100,6 @@ jobs:
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
           date=`date +%Y%m%d%H%M%S`
-          yarn lerna publish --canary --no-push --no-git-tag-version --dist-tag canary --force-publish --preid ${date} -y
+          yarn lerna publish --canary patch --no-push --no-git-tag-version --dist-tag next --force-publish --preid "beta.1-${date}" -y
         env:
           NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}


### PR DESCRIPTION
After releasing 2.0.0, new `next` versions are released with `3.0.0...` prefixes.
These versions might be risky when developing 3.0, as dynamic versioning can cause unexpected logics.
It's possible to `unpublish` them within 72 hours as long as no packages depend on them.
I successfully deleted test-util, but not for connectivity.
The idea is to publish new `next` versions, so potentially `3.0.0...` versions are free.