### PR TITLE
fix: re-export `DestinationSelectionStrategies`

### DIFF
--- a/packages/connectivity/src/index.ts
+++ b/packages/connectivity/src/index.ts
@@ -20,6 +20,7 @@ export {
   Destination,
   DestinationFetchOptions,
   DestinationAccessorOptions,
+  DestinationSelectionStrategies,
   JwtPayload,
   ProxyConfiguration,
   ProxyConfigurationHeaders,

--- a/packages/connectivity/src/scp-cf/destination/destination-selection-strategies.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-selection-strategies.ts
@@ -64,7 +64,6 @@ export function subscriberFirst(
 
 /**
  * Selector of destination selection strategies. See [[alwaysProvider]], [[alwaysSubscriber]] and [[subscriberFirst]] for more information available selection strategies.
- * @internal
  */
 export const DestinationSelectionStrategies = {
   alwaysProvider,


### PR DESCRIPTION
The `DestinationSelectionStrategies` is used by CAP.