### PR TITLE
Revert "chore: publish a new next version"

### DIFF
--- a/.github/workflows/v2.yaml
+++ b/.github/workflows/v2.yaml
@@ -100,6 +100,6 @@ jobs:
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
           date=`date +%Y%m%d%H%M%S`
-          yarn lerna publish --canary patch --no-push --no-git-tag-version --dist-tag next --force-publish --preid "beta.1-${date}" -y
+          yarn lerna publish --canary --no-push --no-git-tag-version --dist-tag canary --force-publish --preid ${date} -y
         env:
           NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}


### PR DESCRIPTION
Reverts SAP/cloud-sdk-js#2104

The one time release was done, so revert the changes.