### PR TITLE
fix: 1.0 pipeline

### DIFF
--- a/.github/workflows/1.0-build.yml
+++ b/.github/workflows/1.0-build.yml
@@ -1,7 +1,11 @@
-name: 1.0-pr-build
+name: 1.0-build
 
 on:
   pull_request: ~
+  push:
+    branches: ['1.0-main']
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   tests:

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -2,7 +2,7 @@ name: windows-tests
 
 on:
   push:
-    branches: [main]
+    branches: ['1.0-main']
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -1,0 +1,41 @@
+name: windows-tests
+
+  on:
+    push:
+      branches: ['1.0-main']
+      paths-ignore:
+        - 'docs/**'
+
+  jobs:
+    tests:
+      runs-on: ${{ matrix.os }}
+      timeout-minutes: 15
+      strategy:
+        matrix:
+          os: [windows-latest]
+          node-version: [12.x]
+      steps:
+        - uses: actions/checkout@v2
+        - run: git fetch --depth=1
+        - uses: actions/setup-node@v2
+          with:
+            node-version: ${{ matrix.node-version }}
+        - uses: actions/cache@v2
+          id: cache
+          with:
+            path: |
+              node_modules
+              */*/node_modules
+            key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+        - run: yarn install --frozen-lockfile
+        - run: yarn test:unit -- -- --no-bail -- -- -- --json --outputFile=unit-test-output.json
+        - run: yarn test:integration --json --outputFile=int-test-output.json
+          if: always()
+        - run: yarn test:type
+        - name: Archive results
+          uses: actions/upload-artifact@v2
+          if: failure()
+          with:
+            name: windows-test-results
+            path: '*packages/**/*-test-output.json'
+            retention-days: 30

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -1,41 +1,41 @@
 name: windows-tests
 
-  on:
-    push:
-      branches: ['1.0-main']
-      paths-ignore:
-        - 'docs/**'
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
 
-  jobs:
-    tests:
-      runs-on: ${{ matrix.os }}
-      timeout-minutes: 15
-      strategy:
-        matrix:
-          os: [windows-latest]
-          node-version: [12.x]
-      steps:
-        - uses: actions/checkout@v2
-        - run: git fetch --depth=1
-        - uses: actions/setup-node@v2
-          with:
-            node-version: ${{ matrix.node-version }}
-        - uses: actions/cache@v2
-          id: cache
-          with:
-            path: |
-              node_modules
-              */*/node_modules
-            key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
-        - run: yarn install --frozen-lockfile
-        - run: yarn test:unit -- -- --no-bail -- -- -- --json --outputFile=unit-test-output.json
-        - run: yarn test:integration --json --outputFile=int-test-output.json
-          if: always()
-        - run: yarn test:type
-        - name: Archive results
-          uses: actions/upload-artifact@v2
-          if: failure()
-          with:
-            name: windows-test-results
-            path: '*packages/**/*-test-output.json'
-            retention-days: 30
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        os: [windows-latest]
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --depth=1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn test:unit -- -- --no-bail -- -- -- --json --outputFile=unit-test-output.json
+      - run: yarn test:integration --json --outputFile=int-test-output.json
+        if: always()
+      - run: yarn test:type
+      - name: Archive results
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: windows-test-results
+          path: '*packages/**/*-test-output.json'
+          retention-days: 30


### PR DESCRIPTION
It seems the 1.0-main build is only triggered, when the pipeline is shown in it's branch instead of the default one. 