### PR TITLE
chore: remove useless v1 pipelines

### DIFF
--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -3,7 +3,7 @@ name: blackduck-scan
 on:
   pull_request: ~
   push:
-    branches: ['main', '1.0-main']
+    branches: ['main']
 
 jobs:
   tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   pull_request: ~
   push:
-    branches: ['main', '1.0-main']
+    branches: ['main']
     tags: ['v*']
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ name: 'code-ql'
 
 on:
   push:
-    branches: ['main', '1.0-main']
+    branches: ['main']
     tags: ['v*']
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -2,7 +2,7 @@ name: windows-tests
 
 on:
   push:
-    branches: ['main', '1.0-main']
+    branches: ['main']
     paths-ignore:
       - 'docs/**'
 


### PR DESCRIPTION
The removed v1 pipelines should be set up in `1.0-main` branch to make it work.