### PR TITLE
fix: Add OpenAPI dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- [openapi-generator] Add `@sap-cloud-sdk/openapi` as a dependency to the OpenAPI generator to fix errors during generation with `--transpile` enabled.
 
 # 2.0.0
 

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -31,7 +31,7 @@
     "readme": "npx ts-node generate-readme.ts",
     "test": "yarn jest",
     "coverage": "yarn jest --coverage",
-    "check:dependencies": "depcheck ."
+    "check:dependencies": "depcheck . --ignores='@sap-cloud-sdk/openapi'"
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.3",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.0.3",
     "@sap-cloud-sdk/generator-common": "^2.0.0",
+    "@sap-cloud-sdk/openapi": "^2.0.0",
     "@sap-cloud-sdk/util": "^2.0.0",
     "glob": "^7.1.6",
     "js-yaml": "^4.0.0",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -20,7 +20,6 @@
   },
   "files": [
     "dist",
-    "bin/openapi-jar",
     "internal.d.ts",
     "internal.js"
   ],

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -5,7 +5,8 @@ import {
   kebabCase,
   finishAll,
   setLogLevel,
-  formatJson
+  formatJson,
+  ErrorWithCause
 } from '@sap-cloud-sdk/util';
 import {
   getSdkMetadataFileNames,
@@ -91,6 +92,14 @@ export async function generateWithParsedOptions(
         ? 'Some clients could not be generated.'
         : 'Could not generate client.';
     await finishAll(promises, errorMessage);
+  } catch (err) {
+    if (err.message?.includes('error TS2307')) {
+      throw new ErrorWithCause(
+        'Did you forget to install "@sap-cloud-sdk/openapi"?',
+        err
+      );
+    }
+    throw err;
   } finally {
     if (options.optionsPerService) {
       await generateOptionsPerService(


### PR DESCRIPTION
Fix transpilation errors during generation.

Closes SAP/cloud-sdk-backlog#578.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
