### PR TITLE
chore: todo remove includeFactoryName function

### DIFF
--- a/packages/generator/src/edmx-to-vdm/common/action-function-return-types.ts
+++ b/packages/generator/src/edmx-to-vdm/common/action-function-return-types.ts
@@ -24,7 +24,7 @@ import { getApiName } from '../../generator-without-ts-morph/service';
 export function parseFunctionImportReturnTypes(
   returnType: EdmxReturnType | undefined,
   entities: VdmEntity[],
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[],
+  complexTypes: VdmComplexType[],
   extractResponse: ExtractResponse,
   serviceName: string
 ): VdmFunctionImportReturnType {
@@ -42,7 +42,7 @@ export function parseFunctionImportReturnTypes(
 export function parseActionImportReturnTypes(
   returnType: EdmxReturnType | undefined,
   entities: VdmEntity[],
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[],
+  complexTypes: VdmComplexType[],
   extractResponse: ExtractResponse,
   serviceName: string
 ): VdmActionImportReturnType {
@@ -58,7 +58,7 @@ export function parseActionImportReturnTypes(
 function parseReturnTypes(
   returnType: EdmxReturnType | undefined,
   entities: VdmEntity[],
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[],
+  complexTypes: VdmComplexType[],
   extractResponse: ExtractResponse,
   serviceName: string
 ): VdmFunctionImportReturnType | VdmActionImportReturnType {
@@ -114,8 +114,8 @@ function findEntityTypes(
 
 function findComplexType(
   returnType: string,
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[]
-): Omit<VdmComplexType, 'factoryName'> | undefined {
+  complexTypes: VdmComplexType[]
+): VdmComplexType | undefined {
   returnType = parseTypeName(returnType);
   return complexTypes.find(
     e => `${e.namespace}.${e.originalName}` === returnType
@@ -184,7 +184,7 @@ function getEntityReturnType(
 function getComplexReturnType(
   isCollection: boolean,
   isNullable: boolean,
-  complexType: Omit<VdmComplexType, 'factoryName'>
+  complexType: VdmComplexType
 ): VdmFunctionImportReturnType {
   return {
     returnTypeCategory: VdmReturnTypeCategory.COMPLEX_TYPE,

--- a/packages/generator/src/edmx-to-vdm/common/complex-type.ts
+++ b/packages/generator/src/edmx-to-vdm/common/complex-type.ts
@@ -22,21 +22,7 @@ import { EdmxComplexTypeBase } from '../../edmx-parser/common';
 import { applyPrefixOnJsConflictParam } from '../../name-formatting-strategies';
 import { enumTypeForName } from './entity';
 
-// TODO: this should be removed once the deprecated complex type factory is removed
 /* eslint-disable valid-jsdoc */
-
-/**
- * @internal
- */
-export function includeFactoryName(
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[],
-  formatter: ServiceNameFormatter
-): VdmComplexType[] {
-  return complexTypes.map(c => ({
-    ...c,
-    factoryName: formatter.typeNameToFactoryName(c.typeName)
-  }));
-}
 /**
  * @internal
  */
@@ -44,7 +30,7 @@ export function transformComplexTypesBase(
   complexTypes: EdmxComplexTypeBase[],
   enumTypes: VdmEnumType[],
   formatter: ServiceNameFormatter
-): Omit<VdmComplexType, 'factoryName'>[] {
+): VdmComplexType[] {
   const formattedTypes = complexTypes.reduce(
     (formatted, c) => ({
       ...formatted,

--- a/packages/generator/src/edmx-to-vdm/common/entity.ts
+++ b/packages/generator/src/edmx-to-vdm/common/entity.ts
@@ -49,7 +49,7 @@ const logger = createLogger({
 export function transformEntityBase(
   entityMetadata: JoinedEntityMetadata<EdmxEntitySetBase, any>,
   classNames: Record<string, any>,
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[],
+  complexTypes: VdmComplexType[],
   enumTypes: VdmEnumType[],
   formatter: ServiceNameFormatter
 ): Omit<VdmEntity, 'navigationProperties'> {
@@ -85,7 +85,7 @@ function keys(props: VdmProperty[], edmxKeys: EdmxNamed[]): VdmProperty[] {
 
 function properties(
   entity: JoinedEntityMetadata<EdmxEntitySetBase, any>,
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[],
+  complexTypes: VdmComplexType[],
   formatter: ServiceNameFormatter,
   enumTypes: VdmEnumType[]
 ): VdmProperty[] {
@@ -216,7 +216,7 @@ export function createEntityClassNames(
 
 function getTypeMappingEntityProperties(
   typeName: string,
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[],
+  complexTypes: VdmComplexType[],
   enumTypes: VdmEnumType[],
   isComplex: boolean,
   isEnum: boolean
@@ -251,7 +251,7 @@ function getTypeMappingEntityProperties(
 
 function complexTypeFieldForName(
   name: string,
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[]
+  complexTypes: VdmComplexType[]
 ): string {
   const complexType = findComplexType(name, complexTypes);
   if (complexType) {
@@ -269,8 +269,8 @@ const getPostfix = (type: string) => last(type.split('.'));
  */
 export const findComplexType = (
   name: string,
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[]
-): Omit<VdmComplexType, 'factoryName'> | undefined =>
+  complexTypes: VdmComplexType[]
+): VdmComplexType | undefined =>
   complexTypes.find(c => c.originalName === getPostfix(name));
 /**
  * @internal
@@ -285,7 +285,7 @@ export const findEnumType = (
  */
 export function complexTypeForName(
   name: string,
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[]
+  complexTypes: VdmComplexType[]
 ): string {
   const complexType = findComplexType(name, complexTypes);
   if (complexType) {

--- a/packages/generator/src/edmx-to-vdm/edmx-to-vdm-util.ts
+++ b/packages/generator/src/edmx-to-vdm/edmx-to-vdm-util.ts
@@ -88,7 +88,7 @@ export function isComplexTypeOrEnumType(typeName: string): boolean {
  */
 export function isComplexType(
   name: string,
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[]
+  complexTypes: VdmComplexType[]
 ): boolean {
   return isComplexTypeOrEnumType(name)
     ? !!findComplexType(name, complexTypes)
@@ -142,7 +142,7 @@ export function getTypeMappingActionFunction(
 export function typesForCollection(
   typeName: string,
   enumTypes: VdmEnumType[],
-  complexTypes?: Omit<VdmComplexType, 'factoryName'>[],
+  complexTypes?: VdmComplexType[],
   formattedTypes?: Record<string, any>
 ): VdmMappedEdmType {
   const typeInsideCollection = parseCollectionTypeName(typeName);

--- a/packages/generator/src/edmx-to-vdm/v2/complex-type.ts
+++ b/packages/generator/src/edmx-to-vdm/v2/complex-type.ts
@@ -11,7 +11,7 @@ import { ServiceMetadata } from '../../edmx-parser';
 export function generateComplexTypesV2(
   serviceMetadata: ServiceMetadata,
   formatter: ServiceNameFormatter
-): Omit<VdmComplexType, 'factoryName'>[] {
+): VdmComplexType[] {
   return transformComplexTypesBase(
     parseComplexTypesV2(serviceMetadata.edmx.root),
     [],

--- a/packages/generator/src/edmx-to-vdm/v2/entity.ts
+++ b/packages/generator/src/edmx-to-vdm/v2/entity.ts
@@ -34,7 +34,7 @@ import { stripNamespace } from '../edmx-to-vdm-util';
  */
 export function generateEntitiesV2(
   serviceMetadata: ServiceMetadata,
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[],
+  complexTypes: VdmComplexType[],
   formatter: ServiceNameFormatter
 ): VdmEntity[] {
   const entitySets = parseEntitySetsV2(serviceMetadata.edmx.root);

--- a/packages/generator/src/edmx-to-vdm/v2/function-import.ts
+++ b/packages/generator/src/edmx-to-vdm/v2/function-import.ts
@@ -20,7 +20,7 @@ export function generateFunctionImportsV2(
   serviceMetadata: ServiceMetadata,
   serviceName: string,
   entities: VdmEntity[],
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[],
+  complexTypes: VdmComplexType[],
   formatter: ServiceNameFormatter
 ): VdmFunctionImport[] {
   const edmxFunctionImports = parseFunctionImportsV2(serviceMetadata.edmx.root);

--- a/packages/generator/src/edmx-to-vdm/v2/service-entities.ts
+++ b/packages/generator/src/edmx-to-vdm/v2/service-entities.ts
@@ -1,7 +1,6 @@
 import { ServiceMetadata } from '../../edmx-parser';
 import { VdmServiceEntities } from '../../vdm-types';
 import { ServiceNameFormatter } from '../../service-name-formatter';
-import { includeFactoryName } from '../common';
 import { generateFunctionImportsV2 } from './function-import';
 import { generateComplexTypesV2 } from './complex-type';
 import { generateEntitiesV2 } from './entity';
@@ -27,7 +26,7 @@ export function getServiceEntitiesV2(
   );
 
   return {
-    complexTypes: includeFactoryName(complexTypes, formatter),
+    complexTypes,
     enumTypes: [],
     entities,
     functionImports

--- a/packages/generator/src/edmx-to-vdm/v4/action-import.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/action-import.ts
@@ -79,7 +79,7 @@ export function generateActionImportsV4(
   serviceMetadata: ServiceMetadata,
   serviceName: string,
   entities: VdmEntity[],
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[],
+  complexTypes: VdmComplexType[],
   formatter: ServiceNameFormatter
 ): VdmActionImport[] {
   const actions = parseActions(serviceMetadata.edmx.root);

--- a/packages/generator/src/edmx-to-vdm/v4/complex-type.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/complex-type.ts
@@ -12,7 +12,7 @@ export function generateComplexTypesV4(
   serviceMetadata: ServiceMetadata,
   enumTypes: VdmEnumType[],
   formatter: ServiceNameFormatter
-): Omit<VdmComplexType, 'factoryName'>[] {
+): VdmComplexType[] {
   return transformComplexTypesBase(
     parseComplexTypesV4(serviceMetadata.edmx.root),
     enumTypes,

--- a/packages/generator/src/edmx-to-vdm/v4/entity.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/entity.ts
@@ -46,7 +46,7 @@ export function joinEntityTypes<T extends EdmxEntityTypeV4>(
  */
 export function generateEntitiesV4(
   serviceMetadata: ServiceMetadata,
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[],
+  complexTypes: VdmComplexType[],
   enumTypes: VdmEnumType[],
   formatter: ServiceNameFormatter
 ): VdmEntity[] {

--- a/packages/generator/src/edmx-to-vdm/v4/function-import.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/function-import.ts
@@ -79,7 +79,7 @@ export function generateFunctionImportsV4(
   serviceMetadata: ServiceMetadata,
   serviceName: string,
   entities: VdmEntity[],
-  complexTypes: Omit<VdmComplexType, 'factoryName'>[],
+  complexTypes: VdmComplexType[],
   formatter: ServiceNameFormatter
 ): VdmFunctionImport[] {
   const functions = parseFunctions(serviceMetadata.edmx.root);

--- a/packages/generator/src/edmx-to-vdm/v4/service-entities.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/service-entities.ts
@@ -1,7 +1,6 @@
 import { ServiceMetadata } from '../../edmx-parser';
 import { ServiceNameFormatter } from '../../service-name-formatter';
 import { VdmServiceEntities } from '../../vdm-types';
-import { includeFactoryName } from '../common';
 import { generateFunctionImportsV4 } from './function-import';
 import { generateComplexTypesV4 } from './complex-type';
 import { generateEntitiesV4 } from './entity';
@@ -46,7 +45,7 @@ export function getServiceEntitiesV4(
   );
 
   return {
-    complexTypes: includeFactoryName(complexTypes, formatter),
+    complexTypes,
     enumTypes,
     entities,
     functionImports,

--- a/packages/generator/src/service-generator.spec.ts
+++ b/packages/generator/src/service-generator.spec.ts
@@ -255,7 +255,6 @@ describe('service-generator', () => {
         expect(complexTypes.length).toEqual(3);
         expect(complexType.typeName).toEqual('TestComplexType');
         expect(complexType.originalName).toEqual('A_TestComplexType');
-        expect(complexType.factoryName).toEqual('createTestComplexType_1');
         expect(complexType.fieldType).toEqual('TestComplexTypeField');
         expect(complexType.properties.length).toEqual(17);
 
@@ -320,7 +319,6 @@ describe('service-generator', () => {
 
         const complexTypeName = 'TestComplexType';
         const functionImportName = 'createTestComplexType';
-        const factoryName = 'createTestComplexType_1';
         const expectedReturnType = {
           returnTypeCategory: VdmReturnTypeCategory.COMPLEX_TYPE,
           returnType: 'TestComplexType',
@@ -334,7 +332,6 @@ describe('service-generator', () => {
         expect(functionImport.returnType).toEqual(expectedReturnType);
 
         expect(complexType.typeName).toEqual(complexTypeName);
-        expect(complexType.factoryName).toEqual(factoryName);
       });
 
       it('does not clash with reserved JavaScript keywords', () => {

--- a/packages/generator/src/service-name-formatter.ts
+++ b/packages/generator/src/service-name-formatter.ts
@@ -127,11 +127,6 @@ export class ServiceNameFormatter {
     return this.originalToComplexTypeName(str);
   }
 
-  typeNameToFactoryName(str: string): string {
-    const factoryName = `create${str}`;
-    return this.serviceWideNameGenerator.generateAndSaveUniqueName(factoryName);
-  }
-
   originalToNavigationPropertyName(
     entitySetName: string,
     originalPropertyName: string

--- a/packages/generator/src/vdm-types.ts
+++ b/packages/generator/src/vdm-types.ts
@@ -114,7 +114,6 @@ export interface VdmComplexType {
   originalName: string;
   properties: VdmProperty[];
   typeName: string;
-  factoryName: string;
   fieldType: string;
   namespace: string;
 }

--- a/packages/generator/test/test-util/data-model.ts
+++ b/packages/generator/test/test-util/data-model.ts
@@ -118,7 +118,6 @@ export const complexMeal: VdmComplexType = {
   originalName: 'ComplexMealName',
   typeName: 'ComplexMealType',
   fieldType: 'ComplexMealField',
-  factoryName: 'createComplexMeal',
   properties: [
     {
       originalName: 'Complexity',
@@ -152,7 +151,6 @@ export const complexDesert: VdmComplexType = {
   originalName: 'ComplexDesert',
   typeName: 'ComplexDesert',
   fieldType: 'ComplexDesertField',
-  factoryName: 'createComplexDesert',
   properties: [
     {
       originalName: 'Amount',
@@ -186,7 +184,6 @@ export const complexMealWithDesert: VdmComplexType = {
   originalName: 'ComplexMealWithDesertName',
   typeName: 'ComplexMealWithDesertType',
   fieldType: 'ComplexMealWithDesertField',
-  factoryName: 'createComplexMealWithDesert',
   properties: [
     {
       originalName: 'ComplexDesert',


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#521.

This PR removes the `includeFactoryName` method and the `factoryName` property from the `VdmComplexType`

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
