### PR TITLE
feat: Add sanitizeRecord function and sanitize http-client debug log

### DIFF
--- a/packages/connectivity/src/scp-cf/destination/proxy-util.ts
+++ b/packages/connectivity/src/scp-cf/destination/proxy-util.ts
@@ -2,7 +2,7 @@ import { AgentOptions } from 'https';
 import { URL } from 'url';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { HttpsProxyAgent } from 'https-proxy-agent';
-import { createLogger } from '@sap-cloud-sdk/util';
+import { createLogger, sanitizeRecord } from '@sap-cloud-sdk/util';
 import { Protocol } from '../protocol';
 import { ProxyConfiguration } from '../connectivity-service-types';
 import { basicHeader } from '../authorization-header';
@@ -168,10 +168,12 @@ export function parseProxyEnv(
     if (proxyConfig) {
       const loggableConfig = {
         ...proxyConfig,
-        headers: proxyConfig.headers
-          ? 'Authorization header present. Not logged for security reasons.'
-          : 'No authorization header present.'
+        headers: sanitizeRecord(
+          proxyConfig.headers || {},
+          'Authorization header present. Not logged for security reasons.'
+        )
       };
+
       logger.debug(
         `Used Proxy Configuration: ${JSON.stringify(loggableConfig, null, 2)}.`
       );

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -270,7 +270,7 @@ describe('generic http client', () => {
       expect(debugSpy)
         .toHaveBeenCalledWith(`Execute 'GET' request with target: /api/entity.
 The headers of the request are:
-authorization:*******
+authorization:<DATA NOT LOGGED TO PREVENT LEAKING SENSITIVE DATA>
 sap-client:001`);
     });
 

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -4,7 +4,8 @@ import {
   createLogger,
   ErrorWithCause,
   pickIgnoreCase,
-  unixEOL
+  unixEOL,
+  sanitizeRecord
 } from '@sap-cloud-sdk/util';
 import axios from 'axios';
 import {
@@ -218,16 +219,15 @@ function logCustomHeadersWarning(customHeaders?: Record<string, string>) {
 function logRequestInformation(request: HttpRequestConfig) {
   const basicRequestInfo = `Execute '${request.method}' request with target: ${request.url}.`;
   if (request.headers) {
-    const headerText = Object.keys(request.headers).reduce((previous, key) => {
-      if (
-        key.toLowerCase().includes('authentication') ||
-        key.toLowerCase().includes('authorization')
-      ) {
-        return `${previous}${unixEOL}${key}:*******`;
-      }
-      return `${previous}${unixEOL}${key}:${request.headers![key]}`;
-    }, 'The headers of the request are:');
-    logger.debug(`${basicRequestInfo}${unixEOL}${headerText}`);
+    const headerText = Object.entries(sanitizeRecord(request.headers))
+      .map(([key, value]) => `${key}:${value}`)
+      .join(unixEOL);
+
+    logger.debug(
+      `${basicRequestInfo}${unixEOL}The headers of the request are:${unixEOL}${headerText}`
+    );
+  } else {
+    logger.debug(basicRequestInfo);
   }
 }
 

--- a/packages/util/src/logger/cloud-sdk-logger.spec.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.spec.ts
@@ -6,6 +6,7 @@ import {
   getGlobalLogLevel,
   getLogger,
   muteLoggers,
+  sanitizeRecord,
   setGlobalLogLevel,
   setLogLevel,
   unmuteLoggers
@@ -237,6 +238,125 @@ describe('Cloud SDK Logger', () => {
       logger = createLogger(messageContext);
 
       expect(logger.level).toEqual('warn');
+    });
+  });
+
+  describe('sanitize records', () => {
+    it('does not remove any unwanted record properties for common response headers', () => {
+      const responseHeaders = {
+        'Content-Type': 'application/json',
+        'access-control-allow-origin': '*',
+        'content-security-policy':
+          "default-src 'self' http: https: data: blob: 'unsafe-inline'; frame-ancestors 'self';",
+        'cross-origin-embedder-policy': 'require-corp',
+        'cross-origin-opener-policy': 'same-origin',
+        'cross-origin-resource-policy': 'same-origin',
+        date: 'Thu, 10 Feb 2022 14:09:09 GMT',
+        etag: 'W/"134d2-7mWFsXsjM/3aYrrtmSWe4HUcaGE"',
+        'expect-ct': 'max-age=0',
+        'origin-agent-cluster': '?1',
+        'permissions-policy': 'interest-cohort=()',
+        'referrer-policy': 'no-referrer',
+        server: 'nginx',
+        'strict-transport-security': 'max-age=15552000; includeSubDomains',
+        'x-content-type-options': 'nosniff',
+        'x-dns-prefetch-control': 'off',
+        'x-download-options': 'noopen',
+        'x-frame-options': 'SAMEORIGIN',
+        'x-permitted-cross-domain-policies': 'none',
+        'x-xss-protection': '0'
+      };
+      // Should return a copy of the input
+      expect(sanitizeRecord(responseHeaders)).not.toBe(responseHeaders);
+      expect(sanitizeRecord(responseHeaders)).toEqual(responseHeaders);
+    });
+
+    it('does not remove any unwanted record properties for common request headers', () => {
+      const requestHeaders = {
+        ':authority': 'example.com',
+        ':method': 'GET',
+        ':path': '/api/v1',
+        ':scheme': 'https',
+        accept: '*/*',
+        'accept-encoding': 'gzip, deflate, br',
+        'accept-language': 'en-US,en;q=0.9,de;q=0.8',
+        'content-type': 'application/json',
+        cookie: 'USERID=1;SERVERID=2',
+        dnt: '1',
+        'if-none-match': 'W/"134d2-7mWFsXsjM/3aYrrtmSWe4HUcaGE"',
+        referer: 'https://example.com',
+        'sec-ch-ua':
+          '"Not A;Brand";v="99", "Chromium";v="98", "Google Chrome";v="98"',
+        'sec-ch-ua-mobile': '?0',
+        'sec-ch-ua-platform': '"macOS"',
+        'sec-fetch-dest': 'empty',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-site': 'same-origin',
+        'user-agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.80 Safari/537.36'
+      };
+      // Should return a copy of the input
+      expect(sanitizeRecord(requestHeaders)).not.toBe(requestHeaders);
+      expect(sanitizeRecord(requestHeaders)).toEqual(requestHeaders);
+    });
+
+    it('should remove auth headers', () => {
+      const input = {
+        access_token: 'SECRET',
+        my_access_token: 'SECRET',
+        authentication: 'secret',
+        service_authentication: 'secret',
+        authorization: 'secret',
+        Authorization: 'secret',
+        AUTHORIZATION: 'secret',
+        credentials: 'password',
+        'x-xsrf-token': 'secret token',
+        cookie: 'csrfToken=secret'
+      };
+      const output = {
+        access_token: '<DATA NOT LOGGED TO PREVENT LEAKING SENSITIVE DATA>',
+        my_access_token: '<DATA NOT LOGGED TO PREVENT LEAKING SENSITIVE DATA>',
+        authentication: '<DATA NOT LOGGED TO PREVENT LEAKING SENSITIVE DATA>',
+        service_authentication:
+          '<DATA NOT LOGGED TO PREVENT LEAKING SENSITIVE DATA>',
+        authorization: '<DATA NOT LOGGED TO PREVENT LEAKING SENSITIVE DATA>',
+        Authorization: '<DATA NOT LOGGED TO PREVENT LEAKING SENSITIVE DATA>',
+        AUTHORIZATION: '<DATA NOT LOGGED TO PREVENT LEAKING SENSITIVE DATA>',
+        credentials: '<DATA NOT LOGGED TO PREVENT LEAKING SENSITIVE DATA>',
+        'x-xsrf-token': '<DATA NOT LOGGED TO PREVENT LEAKING SENSITIVE DATA>',
+        cookie: '<DATA NOT LOGGED TO PREVENT LEAKING SENSITIVE DATA>'
+      };
+      expect(sanitizeRecord(input)).toEqual(output);
+    });
+
+    it('should replace with correct replacement string', () => {
+      const input = {
+        JTENANT: 'SECRET',
+        password: 'SECRET'
+      };
+      const output = {
+        JTENANT: '****',
+        password: '****'
+      };
+      expect(sanitizeRecord(input, '****')).toEqual(output);
+    });
+
+    it('should replace using custom sensitive keys', () => {
+      const input = {
+        password: 'SECRET',
+        authorization: 'SECRET',
+        lineOfBusiness: 'SECRET',
+        cloudHoster: 'SECRET'
+      };
+      const output = {
+        password: 'SECRET',
+        authorization: 'SECRET',
+        lineOfBusiness: 'SAP',
+        cloudHoster: 'SAP'
+      };
+      expect(
+        sanitizeRecord(input, 'SAP', ['business', 'software', 'cloud'])
+      ).toEqual(output);
     });
   });
 


### PR DESCRIPTION
To prevent accidental leaking of sensitive data, I introduced the `sanitizeRecord` function which is part of the `cloud-sdk-logger`. It searches keys for a number of potentially sensitive keys and replaces the values with a configurable placeholder.

Closes SAP/cloud-sdk-backlog#558.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
