### PR TITLE
fix: Blackduck performance threshold

### DIFF
--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -42,21 +42,3 @@ jobs:
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}
-      - name: Sleep on retry
-        if: ${{ failure() }}
-        run: sleep 60
-      - name: Blackduck Scan Retry
-        uses: SAP/project-piper-action@de2106c218782b7caa3989c7a8af8f3b9d5fa36b
-        if: ${{ failure() }}
-        with:
-          command: detectExecuteScan
-          flags: \
-            --version=$PROJECT_VERSION \
-            --scanProperties="\
-            --detect.yarn.prod.only=true \
-            --blackduck.signature.scanner.memory=4096 \
-            --detect.timeout=6000 \
-            --blackduck.trust.cert=true"
-        env:
-          PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
-          PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -1,6 +1,7 @@
 name: blackduck-scan
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: 0 23 * * *
 

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -1,9 +1,8 @@
 name: blackduck-scan
 
 on:
-  pull_request: ~
-  push:
-    branches: ['main']
+  schedule:
+    - cron: 0 23 * * *
 
 jobs:
   tests:
@@ -28,7 +27,7 @@ jobs:
           key: ${{ matrix.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - run: sudo apt-get install jq
-      - run: echo "project_version=$(lerna ls -l --json | jq '.[0].version' | tr -d '"')-${GITHUB_REF_NAME}" >> $GITHUB_ENV
+      - run: echo "project_version=$(lerna ls -l --json | jq '.[0].version' | tr -d '"')" >> $GITHUB_ENV
       - name: Blackduck Scan
         uses: SAP/project-piper-action@de2106c218782b7caa3989c7a8af8f3b9d5fa36b
         with:


### PR DESCRIPTION
This PR switches our Blackduck scans from a per-branch scan to nightly scans, to avoid hitting the performance threshold.

Closes SAP/cloud-sdk-backlog#574.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
