### PR TITLE
feat: Allow specifying the license for generated clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ## Improvements
 
 - [util] Add `sanitizeRecord` function to `cloud-sdk-logger` which replaces potentially sensitive information in a `Record<string, any>` based on a list of sensistive keys.
+- [generator] The new CLI option `licenceInPackageJson` offers the possibility to specify the license property in a generated `package.json`.     
 
 ## Fixed Issues
 

--- a/packages/generator-common/src/file-writer/index.ts
+++ b/packages/generator-common/src/file-writer/index.ts
@@ -1,1 +1,2 @@
 export * from './copy-file';
+export * from './package-json';

--- a/packages/generator-common/src/file-writer/package-json.ts
+++ b/packages/generator-common/src/file-writer/package-json.ts
@@ -1,0 +1,10 @@
+/**
+ * @internal
+ */
+export interface PackageJsonOptions {
+  npmPackageName: string;
+  version: string;
+  sdkVersion: string;
+  description: string;
+  license?: string;
+}

--- a/packages/generator-common/src/file-writer/package-json.ts
+++ b/packages/generator-common/src/file-writer/package-json.ts
@@ -8,3 +8,24 @@ export interface PackageJsonOptions {
   description: string;
   license?: string;
 }
+
+export function packageJsonBase(
+  options: PackageJsonOptions
+): Record<string, any> {
+  return {
+    name: options.npmPackageName,
+    version: options.version,
+    description: options.description,
+    homepage: 'https://sap.github.io/cloud-sdk/docs/js/getting-started',
+    main: './index.js',
+    types: './index.d.ts',
+    ...(options.license ? { license: options.license } : {}),
+    publishConfig: {
+      access: 'public'
+    },
+    repository: {
+      type: 'git',
+      url: ''
+    }
+  };
+}

--- a/packages/generator/src/generator-options.ts
+++ b/packages/generator/src/generator-options.ts
@@ -119,7 +119,7 @@ export const generatorOptionsCli: KeysToOptions = {
   },
   licenseInPackageJson: {
     describe:
-        'License to be used on the generated package.json. Only considered is \'generatePackageJson\' is enabled.',
+      "License to be used on the generated package.json. Only considered is 'generatePackageJson' is enabled.",
     type: 'string',
     requiresArg: false
   },

--- a/packages/generator/src/generator-options.ts
+++ b/packages/generator/src/generator-options.ts
@@ -14,6 +14,7 @@ export interface GeneratorOptions {
   generateNpmrc: boolean;
   generatePackageJson: boolean;
   versionInPackageJson?: string;
+  licenseInPackageJson?: string;
   generateJs: boolean;
   generateSdkMetadata?: boolean;
   processesJsGeneration?: number;
@@ -115,6 +116,12 @@ export const generatorOptionsCli: KeysToOptions = {
     describe:
       'By default, when generating package.json file, the generator will set a version by using the generator version. It can also be set to a specific version.',
     type: 'string'
+  },
+  licenseInPackageJson: {
+    describe:
+        'License to be used on the generated package.json. Only considered is \'generatePackageJson\' is enabled.',
+    type: 'string',
+    requiresArg: false
   },
   generateJs: {
     describe:

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -256,11 +256,8 @@ export async function generateSourcesForService(
       serviceDir,
       'package.json',
       await packageJson(
-        service.npmPackageName,
-        await getVersionForClient(options.versionInPackageJson),
-        getServiceDescription(service, options),
-        options.sdkAfterVersionScript,
-        service.oDataVersion
+        service,
+          options
       ),
       options.forceOverwrite
     );

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -23,7 +23,8 @@ import {
   sdkMetadataHeader,
   transpileDirectory,
   readCompilerOptions,
-  copyFiles
+  copyFiles,
+  getSdkVersion
 } from '@sap-cloud-sdk/generator-common/internal';
 import { batchSourceFile } from './batch/file';
 import { complexTypeSourceFile } from './complex-type/file';
@@ -255,10 +256,15 @@ export async function generateSourcesForService(
     otherFile(
       serviceDir,
       'package.json',
-      await packageJson(
-        service,
-          options
-      ),
+      await packageJson({
+        npmPackageName: service.npmPackageName,
+        version: await getVersionForClient(options.versionInPackageJson),
+        sdkVersion: await getSdkVersion(),
+        description: getServiceDescription(service, options),
+        sdkAfterVersionScript: options.sdkAfterVersionScript,
+        oDataVersion: service.oDataVersion,
+        license: options.licenseInPackageJson
+      }),
       options.forceOverwrite
     );
   }

--- a/packages/generator/src/service/package-json.spec.ts
+++ b/packages/generator/src/service/package-json.spec.ts
@@ -1,14 +1,15 @@
-import { packageJson } from './package-json';
-import {GeneratorOptions} from "../generator-options";
-import {VdmServiceMetadata} from "../vdm-types";
+import { ODataVersion } from '@sap-cloud-sdk/util';
+import { packageJson, PackageJsonOptions } from './package-json';
 describe('package-json', () => {
-  const semverRegex = /\^\d+\.\d+\.\d+/;
   const packageJsonStatic = {
     homepage: 'https://sap.github.io/cloud-sdk/docs/js/getting-started',
     main: './index.js',
     types: './index.d.ts',
     publishConfig: {
       access: 'public'
+    },
+    scripts: {
+      compile: 'npx tsc'
     },
     files: [
       '**/*.js',
@@ -18,83 +19,78 @@ describe('package-json', () => {
       '**/*-csn.json'
     ],
     repository: {
-      'type': 'git',
-      'url': ''
+      type: 'git',
+      url: ''
     },
     devDependencies: {
-      'typescript': '~4.5'
+      typescript: '~4.5'
     }
   };
 
+  function packageJsonOptions(oDataVersion: ODataVersion): PackageJsonOptions {
+    return {
+      npmPackageName: `my-${oDataVersion}-package`,
+      version: `X.Y.Z-${oDataVersion}`,
+      description: `my ${oDataVersion} package description`,
+      sdkAfterVersionScript: false,
+      oDataVersion,
+      sdkVersion: '1.2.3'
+    };
+  }
+
   it('creates v2 package content', async () => {
-    const jsonString
-        = await
-      packageJson({npmPackageName:'my-v2-package',oDataVersion:"v2"}as VdmServiceMetadata,{versionInPackageJson: 'X.Y.Z-v2'} as GeneratorOptions
-
-      );
-
-    /*
-
-     */
+    const jsonString = await packageJson(packageJsonOptions('v2'));
 
     expect(JSON.parse(jsonString)).toEqual({
       name: 'my-v2-package',
       version: 'X.Y.Z-v2',
       description: 'my v2 package description',
       ...packageJsonStatic,
-      scripts: {
-        'compile': 'npx tsc'
-      },
       dependencies: {
-        '@sap-cloud-sdk/odata-common': expect.stringMatching(semverRegex),
-        '@sap-cloud-sdk/odata-v2': expect.stringMatching(semverRegex)
+        '@sap-cloud-sdk/odata-common': '^1.2.3',
+        '@sap-cloud-sdk/odata-v2': '^1.2.3'
       },
       peerDependencies: {
-        '@sap-cloud-sdk/odata-common': expect.stringMatching(semverRegex),
-        '@sap-cloud-sdk/odata-v2': expect.stringMatching(semverRegex)
+        '@sap-cloud-sdk/odata-common': '^1.2.3',
+        '@sap-cloud-sdk/odata-v2': '^1.2.3'
       }
     });
   });
 
-  it('adds the license information',async ()=> {
-    const jsonString = await
-        packageJson({}as VdmServiceMetadata,{}as GeneratorOptions
-            // 'my-v4-package',
-            // 'X.Y.Z-v4',
-            // 'my v4 package description',
-            // true,
-            // 'v4',
-            // 'my licence value'
-        );
-    expect(JSON.parse(jsonString).license).toEqual('my licence value');
+  it('includes after version script', async () => {
+    const jsonString = await packageJson({
+      ...packageJsonOptions('v2'),
+      sdkAfterVersionScript: true
+    });
+
+    expect(JSON.parse(jsonString).scripts.version).toEqual(
+      'node ../../../after-version-update.js'
+    );
+  });
+
+  it('adds the license information', async () => {
+    const jsonString = await packageJson({
+      ...packageJsonOptions('v2'),
+      license: 'my license value'
+    });
+    expect(JSON.parse(jsonString).license).toEqual('my license value');
   });
 
   it('creates v4 package content with after version script', async () => {
-    const jsonString = await
-      packageJson(
-          {}as VdmServiceMetadata,{}as GeneratorOptions
-        // 'my-v4-package',
-        // 'X.Y.Z-v4',
-        // 'my v4 package description',
-        // true,
-        // 'v4'
-      );
+    const jsonString = await packageJson(packageJsonOptions('v4'));
+
     expect(JSON.parse(jsonString)).toEqual({
       name: 'my-v4-package',
       version: 'X.Y.Z-v4',
       description: 'my v4 package description',
-      scripts: {
-        'compile': 'npx tsc',
-        'version': 'node ../../../after-version-update.js'
-      },
       ...packageJsonStatic,
       dependencies: {
-        '@sap-cloud-sdk/odata-common': expect.stringMatching(semverRegex),
-        '@sap-cloud-sdk/odata-v4': expect.stringMatching(semverRegex)
+        '@sap-cloud-sdk/odata-common': '^1.2.3',
+        '@sap-cloud-sdk/odata-v4': '^1.2.3'
       },
       peerDependencies: {
-        '@sap-cloud-sdk/odata-common': expect.stringMatching(semverRegex),
-        '@sap-cloud-sdk/odata-v4': expect.stringMatching(semverRegex)
+        '@sap-cloud-sdk/odata-common': '^1.2.3',
+        '@sap-cloud-sdk/odata-v4': '^1.2.3'
       }
     });
   });

--- a/packages/generator/src/service/package-json.spec.ts
+++ b/packages/generator/src/service/package-json.spec.ts
@@ -1,104 +1,101 @@
 import { packageJson } from './package-json';
-// TODO: fix the test, as this will fail after a version bump. Search for "^1.50.0", which should not be hard coded.
-xdescribe('package-json', () => {
+import {GeneratorOptions} from "../generator-options";
+import {VdmServiceMetadata} from "../vdm-types";
+describe('package-json', () => {
+  const semverRegex = /\^\d+\.\d+\.\d+/;
+  const packageJsonStatic = {
+    homepage: 'https://sap.github.io/cloud-sdk/docs/js/getting-started',
+    main: './index.js',
+    types: './index.d.ts',
+    publishConfig: {
+      access: 'public'
+    },
+    files: [
+      '**/*.js',
+      '**/*.js.map',
+      '**/*.d.ts',
+      '**/d.ts.map',
+      '**/*-csn.json'
+    ],
+    repository: {
+      'type': 'git',
+      'url': ''
+    },
+    devDependencies: {
+      'typescript': '~4.5'
+    }
+  };
+
   it('creates v2 package content', async () => {
-    await expect(
-      packageJson(
-        'my-v2-package',
-        'X.Y.Z-v2',
-        'my v2 package description',
-        false,
-        'v2'
-      )
-    ).resolves.toMatchInlineSnapshot(`
-            "{
-              \\"name\\": \\"my-v2-package\\",
-              \\"version\\": \\"X.Y.Z-v2\\",
-              \\"description\\": \\"my v2 package description\\",
-              \\"homepage\\": \\"https://sap.github.io/cloud-sdk/docs/js/getting-started\\",
-              \\"main\\": \\"./index.js\\",
-              \\"types\\": \\"./index.d.ts\\",
-              \\"publishConfig\\": {
-                \\"access\\": \\"public\\"
-              },
-              \\"files\\": [
-                \\"**/*.js\\",
-                \\"**/*.js.map\\",
-                \\"**/*.d.ts\\",
-                \\"**/d.ts.map\\",
-                \\"**/*-csn.json\\"
-              ],
-              \\"repository\\": {
-                \\"type\\": \\"git\\",
-                \\"url\\": \\"\\"
-              },
-              \\"scripts\\": {
-                \\"compile\\": \\"npx tsc\\"
-              },
-              \\"dependencies\\": {
-                \\"@sap-cloud-sdk/odata-common\\": \\"^1.50.0\\",
-                \\"@sap-cloud-sdk/odata-v2\\": \\"^1.50.0\\"
-              },
-              \\"peerDependencies\\": {
-                \\"@sap-cloud-sdk/odata-common\\": \\"^1.50.0\\",
-                \\"@sap-cloud-sdk/odata-v2\\": \\"^1.50.0\\"
-              },
-              \\"devDependencies\\": {
-                \\"typescript\\": \\"~4.5\\"
-              }
-            }
-            "
-          `);
+    const jsonString
+        = await
+      packageJson({npmPackageName:'my-v2-package',oDataVersion:"v2"}as VdmServiceMetadata,{versionInPackageJson: 'X.Y.Z-v2'} as GeneratorOptions
+
+      );
+
+    /*
+
+     */
+
+    expect(JSON.parse(jsonString)).toEqual({
+      name: 'my-v2-package',
+      version: 'X.Y.Z-v2',
+      description: 'my v2 package description',
+      ...packageJsonStatic,
+      scripts: {
+        'compile': 'npx tsc'
+      },
+      dependencies: {
+        '@sap-cloud-sdk/odata-common': expect.stringMatching(semverRegex),
+        '@sap-cloud-sdk/odata-v2': expect.stringMatching(semverRegex)
+      },
+      peerDependencies: {
+        '@sap-cloud-sdk/odata-common': expect.stringMatching(semverRegex),
+        '@sap-cloud-sdk/odata-v2': expect.stringMatching(semverRegex)
+      }
+    });
+  });
+
+  it('adds the license information',async ()=> {
+    const jsonString = await
+        packageJson({}as VdmServiceMetadata,{}as GeneratorOptions
+            // 'my-v4-package',
+            // 'X.Y.Z-v4',
+            // 'my v4 package description',
+            // true,
+            // 'v4',
+            // 'my licence value'
+        );
+    expect(JSON.parse(jsonString).license).toEqual('my licence value');
   });
 
   it('creates v4 package content with after version script', async () => {
-    await expect(
+    const jsonString = await
       packageJson(
-        'my-v4-package',
-        'X.Y.Z-v4',
-        'my v4 package description',
-        true,
-        'v4'
-      )
-    ).resolves.toMatchInlineSnapshot(`
-            "{
-              \\"name\\": \\"my-v4-package\\",
-              \\"version\\": \\"X.Y.Z-v4\\",
-              \\"description\\": \\"my v4 package description\\",
-              \\"homepage\\": \\"https://sap.github.io/cloud-sdk/docs/js/getting-started\\",
-              \\"main\\": \\"./index.js\\",
-              \\"types\\": \\"./index.d.ts\\",
-              \\"publishConfig\\": {
-                \\"access\\": \\"public\\"
-              },
-              \\"files\\": [
-                \\"**/*.js\\",
-                \\"**/*.js.map\\",
-                \\"**/*.d.ts\\",
-                \\"**/d.ts.map\\",
-                \\"**/*-csn.json\\"
-              ],
-              \\"repository\\": {
-                \\"type\\": \\"git\\",
-                \\"url\\": \\"\\"
-              },
-              \\"scripts\\": {
-                \\"compile\\": \\"npx tsc\\",
-                \\"version\\": \\"node ../../../after-version-update.js\\"
-              },
-              \\"dependencies\\": {
-                \\"@sap-cloud-sdk/odata-common\\": \\"^1.50.0\\",
-                \\"@sap-cloud-sdk/odata-v4\\": \\"^1.50.0\\"
-              },
-              \\"peerDependencies\\": {
-                \\"@sap-cloud-sdk/odata-common\\": \\"^1.50.0\\",
-                \\"@sap-cloud-sdk/odata-v4\\": \\"^1.50.0\\"
-              },
-              \\"devDependencies\\": {
-                \\"typescript\\": \\"~4.5\\"
-              }
-            }
-            "
-          `);
+          {}as VdmServiceMetadata,{}as GeneratorOptions
+        // 'my-v4-package',
+        // 'X.Y.Z-v4',
+        // 'my v4 package description',
+        // true,
+        // 'v4'
+      );
+    expect(JSON.parse(jsonString)).toEqual({
+      name: 'my-v4-package',
+      version: 'X.Y.Z-v4',
+      description: 'my v4 package description',
+      scripts: {
+        'compile': 'npx tsc',
+        'version': 'node ../../../after-version-update.js'
+      },
+      ...packageJsonStatic,
+      dependencies: {
+        '@sap-cloud-sdk/odata-common': expect.stringMatching(semverRegex),
+        '@sap-cloud-sdk/odata-v4': expect.stringMatching(semverRegex)
+      },
+      peerDependencies: {
+        '@sap-cloud-sdk/odata-common': expect.stringMatching(semverRegex),
+        '@sap-cloud-sdk/odata-v4': expect.stringMatching(semverRegex)
+      }
+    });
   });
 });

--- a/packages/generator/src/service/package-json.ts
+++ b/packages/generator/src/service/package-json.ts
@@ -1,32 +1,34 @@
 import { ODataVersion, unixEOL } from '@sap-cloud-sdk/util';
-import {getSdkVersion, getVersionForClient} from '@sap-cloud-sdk/generator-common/internal';
-import {VdmServiceMetadata} from "../vdm-types";
-import {Project} from "ts-morph";
-import {GeneratorOptions} from "../generator-options";
-import {getServiceDescription} from "../sdk-metadata";
+import { PackageJsonOptions as PackageJsonOptionsBase } from '@sap-cloud-sdk/generator-common/internal';
 
-// eslint-disable-next-line valid-jsdoc
+export interface PackageJsonOptions extends PackageJsonOptionsBase {
+  sdkAfterVersionScript: boolean;
+  oDataVersion: ODataVersion;
+}
+
 /**
+ * Generate the package.json for an odata client so it can be released as an npm module.
+ * @param options - Options to generate the package.json
+ * @returns The package.json contents.
  * @internal
  */
 export async function packageJson(
-    service: VdmServiceMetadata,
-    options: GeneratorOptions
+  options: PackageJsonOptions
 ): Promise<string> {
   const oDataModule =
-    service.oDataVersion === 'v2'
+    options.oDataVersion === 'v2'
       ? '@sap-cloud-sdk/odata-v2'
       : '@sap-cloud-sdk/odata-v4';
   return (
     JSON.stringify(
       {
-        name: service.npmPackageName,
-        version:  await getVersionForClient(options.versionInPackageJson),
-        description: getServiceDescription(service, options),
+        name: options.npmPackageName,
+        version: options.version,
+        description: options.description,
         homepage: 'https://sap.github.io/cloud-sdk/docs/js/getting-started',
         main: './index.js',
         types: './index.d.ts',
-        ...(options.licenseInPackageJson ? { license: options.licenseInPackageJson }:{}),
+        ...(options.license ? { license: options.license } : {}),
         publishConfig: {
           access: 'public'
         },
@@ -48,12 +50,12 @@ export async function packageJson(
             : {})
         },
         dependencies: {
-          '@sap-cloud-sdk/odata-common': `^${await getSdkVersion()}`,
-          [oDataModule]: `^${await getSdkVersion()}`
+          '@sap-cloud-sdk/odata-common': `^${options.sdkVersion}`,
+          [oDataModule]: `^${options.sdkVersion}`
         },
         peerDependencies: {
-          '@sap-cloud-sdk/odata-common': `^${await getSdkVersion()}`,
-          [oDataModule]: `^${await getSdkVersion()}`
+          '@sap-cloud-sdk/odata-common': `^${options.sdkVersion}`,
+          [oDataModule]: `^${options.sdkVersion}`
         },
         devDependencies: {
           typescript: '~4.5'

--- a/packages/generator/src/service/package-json.ts
+++ b/packages/generator/src/service/package-json.ts
@@ -1,5 +1,8 @@
 import { ODataVersion, unixEOL } from '@sap-cloud-sdk/util';
-import { PackageJsonOptions as PackageJsonOptionsBase } from '@sap-cloud-sdk/generator-common/internal';
+import {
+  packageJsonBase,
+  PackageJsonOptions as PackageJsonOptionsBase
+} from '@sap-cloud-sdk/generator-common/internal';
 
 export interface PackageJsonOptions extends PackageJsonOptionsBase {
   sdkAfterVersionScript: boolean;
@@ -22,16 +25,7 @@ export async function packageJson(
   return (
     JSON.stringify(
       {
-        name: options.npmPackageName,
-        version: options.version,
-        description: options.description,
-        homepage: 'https://sap.github.io/cloud-sdk/docs/js/getting-started',
-        main: './index.js',
-        types: './index.d.ts',
-        ...(options.license ? { license: options.license } : {}),
-        publishConfig: {
-          access: 'public'
-        },
+        ...packageJsonBase(options),
         files: [
           '**/*.js',
           '**/*.js.map',
@@ -39,10 +33,6 @@ export async function packageJson(
           '**/d.ts.map',
           '**/*-csn.json'
         ],
-        repository: {
-          type: 'git',
-          url: ''
-        },
         scripts: {
           compile: 'npx tsc',
           ...(options.sdkAfterVersionScript

--- a/packages/generator/src/service/package-json.ts
+++ b/packages/generator/src/service/package-json.ts
@@ -1,30 +1,32 @@
 import { ODataVersion, unixEOL } from '@sap-cloud-sdk/util';
-import { getSdkVersion } from '@sap-cloud-sdk/generator-common/internal';
+import {getSdkVersion, getVersionForClient} from '@sap-cloud-sdk/generator-common/internal';
+import {VdmServiceMetadata} from "../vdm-types";
+import {Project} from "ts-morph";
+import {GeneratorOptions} from "../generator-options";
+import {getServiceDescription} from "../sdk-metadata";
 
 // eslint-disable-next-line valid-jsdoc
 /**
  * @internal
  */
 export async function packageJson(
-  npmPackageName: string,
-  version: string,
-  description: string,
-  sdkAfterVersionScript: boolean,
-  oDataVersion: ODataVersion
+    service: VdmServiceMetadata,
+    options: GeneratorOptions
 ): Promise<string> {
   const oDataModule =
-    oDataVersion === 'v2'
+    service.oDataVersion === 'v2'
       ? '@sap-cloud-sdk/odata-v2'
       : '@sap-cloud-sdk/odata-v4';
   return (
     JSON.stringify(
       {
-        name: npmPackageName,
-        version,
-        description,
+        name: service.npmPackageName,
+        version:  await getVersionForClient(options.versionInPackageJson),
+        description: getServiceDescription(service, options),
         homepage: 'https://sap.github.io/cloud-sdk/docs/js/getting-started',
         main: './index.js',
         types: './index.d.ts',
+        ...(options.licenseInPackageJson ? { license: options.licenseInPackageJson }:{}),
         publishConfig: {
           access: 'public'
         },
@@ -41,7 +43,7 @@ export async function packageJson(
         },
         scripts: {
           compile: 'npx tsc',
-          ...(sdkAfterVersionScript
+          ...(options.sdkAfterVersionScript
             ? { version: 'node ../../../after-version-update.js' }
             : {})
         },

--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -36,66 +36,71 @@ Generate OpenAPI client(s), that use the connectivity features of the SAP Cloud 
 Usage: openapi-generator --input <input> --outputDir <outputDirectory>
 
 Options:
-      --help               Show help                                   [boolean]
-      --version            Show version number                         [boolean]
-  -i, --input              Specify the path to the directory or file containing
-                           the OpenAPI service definition(s) to generate clients
-                           for. Accepts Swagger and OpenAPI definitions as YAML
-                           and JSON files. Throws an error if the path does not
-                           exist.                            [string] [required]
-  -o, --outputDir          Specify the path to the directory to generate the
-                           client(s) in. Each client is generated into a
-                           subdirectory within the given output directory.
-                           Creates the directory if it does not exist. Customize
-                           subdirectory naming through `--optionsPerService`.
+      --help                  Show help                                [boolean]
+      --version               Show version number                      [boolean]
+  -i, --input                 Specify the path to the directory or file
+                              containing the OpenAPI service definition(s) to
+                              generate clients for. Accepts Swagger and OpenAPI
+                              definitions as YAML and JSON files. Throws an
+                              error if the path does not exist.
                                                              [string] [required]
-  -t, --transpile          Transpile the generated TypeScript code. When enabled
-                           a default `tsconfig.json` will be generated and used.
-                           It emits `.js`, `.js.map`, `.d.ts` and `.d.ts.map`
-                           files. To configure transpilation set `--tsconfig`.
+  -o, --outputDir             Specify the path to the directory to generate the
+                              client(s) in. Each client is generated into a
+                              subdirectory within the given output directory.
+                              Creates the directory if it does not exist.
+                              Customize subdirectory naming through
+                              `--optionsPerService`.         [string] [required]
+  -t, --transpile             Transpile the generated TypeScript code. When
+                              enabled a default `tsconfig.json` will be
+                              generated and used. It emits `.js`, `.js.map`,
+                              `.d.ts` and `.d.ts.map` files. To configure
+                              transpilation set `--tsconfig`.
                                                       [boolean] [default: false]
-      --include            Include files matching the given glob into the root
-                           of each generated client directory.          [string]
-      --overwrite          Allow to overwrite files, that already exist. This is
-                           useful, when running the generation regularly.
+      --include               Include files matching the given glob into the
+                              root of each generated client directory.  [string]
+      --overwrite             Allow to overwrite files, that already exist. This
+                              is useful, when running the generation regularly.
                                                       [boolean] [default: false]
-      --clearOutputDir     Remove all files in the output directory before
-                           generation. Be cautious when using this option, as it
-                           really removes EVERYTHING in the output directory.
+      --clearOutputDir        Remove all files in the output directory before
+                              generation. Be cautious when using this option, as
+                              it really removes EVERYTHING in the output
+                              directory.              [boolean] [default: false]
+      --skipValidation        By default, the generation fails, when there are
+                              duplicate or invalid names for operations and/or
+                              path parameters after transforming them to camel
+                              case. Set this to true to enable unique and valid
+                              name generation. The names will then be generated
+                              by appending numbers and prepending prefixes.
                                                       [boolean] [default: false]
-      --skipValidation     By default, the generation fails, when there are
-                           duplicate or invalid names for operations and/or path
-                           parameters after transforming them to camel case. Set
-                           this to true to enable unique and valid name
-                           generation. The names will then be generated by
-                           appending numbers and prepending prefixes.
+      --tsConfig              Replace the default `tsconfig.json` by passing a
+                              path to a custom config. By default, a
+                              `tsconfig.json` is only generated, when
+                              transpilation is enabled (`--transpile`). If a
+                              directory is passed, a `tsconfig.json` file is
+                              read from this directory.                 [string]
+      --packageJson           When enabled, a `package.json`, that specifies
+                              dependencies and scripts for transpilation and
+                              documentation generation is generated.
                                                       [boolean] [default: false]
-      --tsConfig           Replace the default `tsconfig.json` by passing a path
-                           to a custom config. By default, a `tsconfig.json` is
-                           only generated, when transpilation is enabled
-                           (`--transpile`). If a directory is passed, a
-                           `tsconfig.json` file is read from this directory.
+      --licenseInPackageJson  License to be used on the generated package.json.
+                              Only considered is 'packageJson' is enabled.
                                                                         [string]
-      --packageJson        When enabled, a `package.json`, that specifies
-                           dependencies and scripts for transpilation and
-                           documentation generation is generated.
-                                                      [boolean] [default: false]
-  -v, --verbose            Turn on verbose logging.   [boolean] [default: false]
-      --optionsPerService  Set the path to a file containing the options per
-                           service. The configuration allows to set a
-                           `directoryName` and `packageName` for every service,
-                           identified by the path to the original file. It also
-                           makes sure that names do not change between generator
-                           runs. If a directory is passed, a
-                           `options-per-service.json` file is read/created in
-                           this directory.                              [string]
-  -c, --config             Set the path to a file containing the options for
-                           generation instead of setting the options on the
-                           command line. When combining the `config` option with
-                           other options on the command line, the command line
-                           options take precedence. If a directory is passed, a
-                           `config.json` file is read from this directory.
-                                                                        [string]
+  -v, --verbose               Turn on verbose logging.[boolean] [default: false]
+      --optionsPerService     Set the path to a file containing the options per
+                              service. The configuration allows to set a
+                              `directoryName` and `packageName` for every
+                              service, identified by the path to the original
+                              file. It also makes sure that names do not change
+                              between generator runs. If a directory is passed,
+                              a `options-per-service.json` file is read/created
+                              in this directory.                        [string]
+  -c, --config                Set the path to a file containing the options for
+                              generation instead of setting the options on the
+                              command line. When combining the `config` option
+                              with other options on the command line, the
+                              command line options take precedence. If a
+                              directory is passed, a `config.json` file is read
+                              from this directory.                      [string]
 ```
 <!-- commandsstop -->
 

--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -83,7 +83,7 @@ Options:
                               documentation generation is generated.
                                                       [boolean] [default: false]
       --licenseInPackageJson  License to be used on the generated package.json.
-                              Only considered is 'packageJson' is enabled.
+                              Only considered if 'packageJson' is enabled.
                                                                         [string]
   -v, --verbose               Turn on verbose logging.[boolean] [default: false]
       --optionsPerService     Set the path to a file containing the options per

--- a/packages/openapi-generator/src/file-serializer/__snapshots__/package-json.spec.ts.snap
+++ b/packages/openapi-generator/src/file-serializer/__snapshots__/package-json.spec.ts.snap
@@ -11,16 +11,16 @@ exports[`packageJson returns the package.json content 1`] = `
   \\"publishConfig\\": {
     \\"access\\": \\"public\\"
   },
+  \\"repository\\": {
+    \\"type\\": \\"git\\",
+    \\"url\\": \\"\\"
+  },
   \\"files\\": [
     \\"**/*.js\\",
     \\"**/*.js.map\\",
     \\"**/*.d.ts\\",
     \\"**/d.ts.map\\"
   ],
-  \\"repository\\": {
-    \\"type\\": \\"git\\",
-    \\"url\\": \\"\\"
-  },
   \\"scripts\\": {
     \\"compile\\": \\"npx tsc\\"
   },

--- a/packages/openapi-generator/src/file-serializer/package-json.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/package-json.spec.ts
@@ -6,4 +6,11 @@ describe('packageJson', () => {
       packageJson('workflow-service', 'description', '1.35.0', '1.23.1')
     ).toMatchSnapshot();
   });
+
+  it('includes the license', () => {
+    const parsed = JSON.parse(packageJson('workflow-service', 'description', '1.35.0', '1.23.1','my license information'));
+    expect(
+        parsed.license
+    ).toBe('my license information');
+  });
 });

--- a/packages/openapi-generator/src/file-serializer/package-json.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/package-json.spec.ts
@@ -3,19 +3,24 @@ import { packageJson } from './package-json';
 describe('packageJson', () => {
   it('returns the package.json content', () => {
     expect(
-      packageJson('workflow-service', 'description', '1.35.0', '1.23.1')
+      packageJson({
+        npmPackageName: 'workflow-service',
+        description: 'description',
+        sdkVersion: '1.35.0',
+        version: '1.23.1'
+      })
     ).toMatchSnapshot();
   });
 
   it('includes the license', () => {
     const parsed = JSON.parse(
-      packageJson(
-        'workflow-service',
-        'description',
-        '1.35.0',
-        '1.23.1',
-        'my license information'
-      )
+      packageJson({
+        npmPackageName: 'workflow-service',
+        description: 'description',
+        sdkVersion: '1.35.0',
+        version: '1.23.1',
+        license: 'my license information'
+      })
     );
     expect(parsed.license).toBe('my license information');
   });

--- a/packages/openapi-generator/src/file-serializer/package-json.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/package-json.spec.ts
@@ -8,9 +8,15 @@ describe('packageJson', () => {
   });
 
   it('includes the license', () => {
-    const parsed = JSON.parse(packageJson('workflow-service', 'description', '1.35.0', '1.23.1','my license information'));
-    expect(
-        parsed.license
-    ).toBe('my license information');
+    const parsed = JSON.parse(
+      packageJson(
+        'workflow-service',
+        'description',
+        '1.35.0',
+        '1.23.1',
+        'my license information'
+      )
+    );
+    expect(parsed.license).toBe('my license information');
   });
 });

--- a/packages/openapi-generator/src/file-serializer/package-json.ts
+++ b/packages/openapi-generator/src/file-serializer/package-json.ts
@@ -1,34 +1,23 @@
 import { unixEOL } from '@sap-cloud-sdk/util';
-import {GeneratorOptions} from "../options";
+import { PackageJsonOptions } from '@sap-cloud-sdk/generator-common/internal';
 
 /**
  * Generate the package.json for an openapi client so it can be released as an npm module.
- * @param packageName - The name of the npm package.
- * @param description - The description of the  npm package.
- * @param sdkVersion - The version of the SAP Cloud SDK used.
- * @param packageVersion - The version of the npm package.
- * @param license - The version of the npm package.
+ * @param options - Options to generate the package.json
  * @returns The package.json contents.
  * @internal
  */
-export function packageJson(
-    options: Pick<GeneratorOptions,'packageVersion'|'licenseInPackageJson'>
-  // packageName: string,
-  // description: string,
-  // sdkVersion: string,
-  // packageVersion: string,
-  // license?: string
-): string {
+export function packageJson(options: PackageJsonOptions): string {
   return (
     JSON.stringify(
       {
-        name: packageName,
-        version: packageVersion,
-        description,
+        name: options.npmPackageName,
+        version: options.version,
+        description: options.description,
         homepage: 'https://sap.github.io/cloud-sdk/docs/js/getting-started',
         main: './index.js',
         types: './index.d.ts',
-      ...(license ? { license }:{}),
+        ...(options.license ? { license: options.license } : {}),
         publishConfig: {
           access: 'public'
         },
@@ -41,10 +30,10 @@ export function packageJson(
           compile: 'npx tsc'
         },
         dependencies: {
-          '@sap-cloud-sdk/openapi': `^${sdkVersion}`
+          '@sap-cloud-sdk/openapi': `^${options.sdkVersion}`
         },
         peerDependencies: {
-          '@sap-cloud-sdk/openapi': `^${sdkVersion}`
+          '@sap-cloud-sdk/openapi': `^${options.sdkVersion}`
         },
         devDependencies: {
           typescript: '~4.1.2'

--- a/packages/openapi-generator/src/file-serializer/package-json.ts
+++ b/packages/openapi-generator/src/file-serializer/package-json.ts
@@ -1,4 +1,5 @@
 import { unixEOL } from '@sap-cloud-sdk/util';
+import {GeneratorOptions} from "../options";
 
 /**
  * Generate the package.json for an openapi client so it can be released as an npm module.
@@ -6,14 +7,17 @@ import { unixEOL } from '@sap-cloud-sdk/util';
  * @param description - The description of the  npm package.
  * @param sdkVersion - The version of the SAP Cloud SDK used.
  * @param packageVersion - The version of the npm package.
+ * @param license - The version of the npm package.
  * @returns The package.json contents.
  * @internal
  */
 export function packageJson(
-  packageName: string,
-  description: string,
-  sdkVersion: string,
-  packageVersion: string
+    options: Pick<GeneratorOptions,'packageVersion'|'licenseInPackageJson'>
+  // packageName: string,
+  // description: string,
+  // sdkVersion: string,
+  // packageVersion: string,
+  // license?: string
 ): string {
   return (
     JSON.stringify(
@@ -24,6 +28,7 @@ export function packageJson(
         homepage: 'https://sap.github.io/cloud-sdk/docs/js/getting-started',
         main: './index.js',
         types: './index.d.ts',
+      ...(license ? { license }:{}),
         publishConfig: {
           access: 'public'
         },

--- a/packages/openapi-generator/src/file-serializer/package-json.ts
+++ b/packages/openapi-generator/src/file-serializer/package-json.ts
@@ -1,5 +1,8 @@
 import { unixEOL } from '@sap-cloud-sdk/util';
-import { PackageJsonOptions } from '@sap-cloud-sdk/generator-common/internal';
+import {
+  PackageJsonOptions,
+  packageJsonBase
+} from '@sap-cloud-sdk/generator-common/internal';
 
 /**
  * Generate the package.json for an openapi client so it can be released as an npm module.
@@ -11,21 +14,9 @@ export function packageJson(options: PackageJsonOptions): string {
   return (
     JSON.stringify(
       {
-        name: options.npmPackageName,
-        version: options.version,
-        description: options.description,
-        homepage: 'https://sap.github.io/cloud-sdk/docs/js/getting-started',
-        main: './index.js',
-        types: './index.d.ts',
-        ...(options.license ? { license: options.license } : {}),
-        publishConfig: {
-          access: 'public'
-        },
+        ...packageJsonBase(options),
         files: ['**/*.js', '**/*.js.map', '**/*.d.ts', '**/d.ts.map'],
-        repository: {
-          type: 'git',
-          url: ''
-        },
+
         scripts: {
           compile: 'npx tsc'
         },

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -340,7 +340,7 @@ async function generateMetadata(
 async function generatePackageJson(
   serviceDir: string,
   { packageName, directoryName }: ServiceOptions,
-  { packageVersion, overwrite }: ParsedGeneratorOptions
+  { packageVersion, overwrite,licenseInPackageJson }: ParsedGeneratorOptions
 ) {
   logger.verbose(`Generating package.json in ${serviceDir}.`);
 
@@ -351,7 +351,8 @@ async function generatePackageJson(
       packageName,
       genericDescription(directoryName),
       await getSdkVersion(),
-      packageVersion
+      packageVersion,
+      licenseInPackageJson
     ),
     overwrite,
     false

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -340,20 +340,20 @@ async function generateMetadata(
 async function generatePackageJson(
   serviceDir: string,
   { packageName, directoryName }: ServiceOptions,
-  { packageVersion, overwrite,licenseInPackageJson }: ParsedGeneratorOptions
+  { packageVersion, overwrite, licenseInPackageJson }: ParsedGeneratorOptions
 ) {
   logger.verbose(`Generating package.json in ${serviceDir}.`);
 
   await createFile(
     serviceDir,
     'package.json',
-    packageJson(
-      packageName,
-      genericDescription(directoryName),
-      await getSdkVersion(),
-      packageVersion,
-      licenseInPackageJson
-    ),
+    packageJson({
+      npmPackageName: packageName,
+      description: genericDescription(directoryName),
+      sdkVersion: await getSdkVersion(),
+      version: packageVersion,
+      license: licenseInPackageJson
+    }),
     overwrite,
     false
   );

--- a/packages/openapi-generator/src/options/generator-options.ts
+++ b/packages/openapi-generator/src/options/generator-options.ts
@@ -21,6 +21,7 @@ export interface GeneratorOptions {
   skipValidation?: boolean;
   tsConfig?: string;
   packageJson?: boolean;
+  licenseInPackageJson?: string;
   verbose?: boolean;
   optionsPerService?: string;
   packageVersion?: string;
@@ -43,6 +44,7 @@ export interface ParsedGeneratorOptions {
   skipValidation: boolean;
   tsConfig?: string;
   packageJson: boolean;
+  licenseInPackageJson?: string;
   verbose: boolean;
   optionsPerService?: string;
   packageVersion: string;

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -89,6 +89,13 @@ export const generatorOptions = {
       'When enabled, a `package.json`, that specifies dependencies and scripts for transpilation and documentation generation is generated.',
     default: false
   },
+  licenseInPackageJson: {
+    string: true,
+    description:
+        'License to be used on the generated package.json. Only considered is \'packageJson\' is enabled.',
+    coerce: (input?: string): string | undefined =>
+        typeof input !== 'undefined' ? input : undefined
+  },
   verbose: {
     boolean: true,
     alias: 'v',

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -92,7 +92,7 @@ export const generatorOptions = {
   licenseInPackageJson: {
     string: true,
     description:
-      "License to be used on the generated package.json. Only considered is 'packageJson' is enabled.",
+      "License to be used on the generated package.json. Only considered if 'packageJson' is enabled.",
     coerce: (input?: string): string | undefined =>
       typeof input !== 'undefined' ? input : undefined
   },

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -92,9 +92,9 @@ export const generatorOptions = {
   licenseInPackageJson: {
     string: true,
     description:
-        'License to be used on the generated package.json. Only considered is \'packageJson\' is enabled.',
+      "License to be used on the generated package.json. Only considered is 'packageJson' is enabled.",
     coerce: (input?: string): string | undefined =>
-        typeof input !== 'undefined' ? input : undefined
+      typeof input !== 'undefined' ? input : undefined
   },
   verbose: {
     boolean: true,

--- a/test-packages/test-services/openapi/no-schema-service/package.json
+++ b/test-packages/test-services/openapi/no-schema-service/package.json
@@ -8,16 +8,16 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": ""
+  },
   "files": [
     "**/*.js",
     "**/*.js.map",
     "**/*.d.ts",
     "**/d.ts.map"
   ],
-  "repository": {
-    "type": "git",
-    "url": ""
-  },
   "scripts": {
     "compile": "npx tsc"
   },

--- a/test-packages/test-services/openapi/swagger-yaml-service/package.json
+++ b/test-packages/test-services/openapi/swagger-yaml-service/package.json
@@ -8,16 +8,16 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": ""
+  },
   "files": [
     "**/*.js",
     "**/*.js.map",
     "**/*.d.ts",
     "**/d.ts.map"
   ],
-  "repository": {
-    "type": "git",
-    "url": ""
-  },
   "scripts": {
     "compile": "npx tsc"
   },

--- a/test-packages/test-services/openapi/test-service/package.json
+++ b/test-packages/test-services/openapi/test-service/package.json
@@ -8,16 +8,16 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": ""
+  },
   "files": [
     "**/*.js",
     "**/*.js.map",
     "**/*.d.ts",
     "**/d.ts.map"
   ],
-  "repository": {
-    "type": "git",
-    "url": ""
-  },
   "scripts": {
     "compile": "npx tsc"
   },


### PR DESCRIPTION
Relates SAP/cloud-sdk-backlog#583.

we need an option to set the license for our generated clients. This PR adds the CLI option to set the license propert in the generate `package.json`.