### PR TITLE
fix: generator compilation error

### DIFF
--- a/packages/connectivity/src/scp-cf/resilience-options.spec.ts
+++ b/packages/connectivity/src/scp-cf/resilience-options.spec.ts
@@ -1,0 +1,16 @@
+import CircuitBreaker from 'opossum';
+import { CircuitBreakerOptions } from './resilience-options';
+
+describe('resilience-options', () => {
+  // when compiling a generated client the compiler fails, because the CircuitBreaker.Options from @types/opssum are not present (long import chain)
+  // since these types contain the @types/node they are 1.8MB in size and we do not want to include this as a prod dependency of the connectivity module.
+  // Hence we copied the CircuitBreaker options and added this test to ensure type compatability.
+  it('ensure type compatability to opssum', () => {
+    type keysOpossum = keyof CircuitBreaker.Options;
+    type keysSDK = keyof CircuitBreakerOptions;
+    let a: keysOpossum = '' as any;
+    const b: keysSDK = '' as any;
+    // is assignment works they are compatible
+    a = b;
+  });
+});

--- a/packages/connectivity/src/scp-cf/resilience-options.spec.ts
+++ b/packages/connectivity/src/scp-cf/resilience-options.spec.ts
@@ -4,8 +4,8 @@ import { CircuitBreakerOptions } from './resilience-options';
 describe('resilience-options', () => {
   // when compiling a generated client the compiler fails, because the CircuitBreaker.Options from @types/opssum are not present (long import chain)
   // since these types contain the @types/node they are 1.8MB in size and we do not want to include this as a prod dependency of the connectivity module.
-  // Hence we copied the CircuitBreaker options and added this test to ensure type compatability.
-  it('ensure type compatability to opssum', () => {
+  // Hence we copied the CircuitBreaker options and added this test to ensure type compatibility.
+  it('ensure type compatibility to opossum', () => {
     type keysOpossum = keyof CircuitBreaker.Options;
     type keysSDK = keyof CircuitBreakerOptions;
     let a: keysOpossum = '' as any;

--- a/packages/connectivity/src/scp-cf/resilience-options.spec.ts
+++ b/packages/connectivity/src/scp-cf/resilience-options.spec.ts
@@ -2,7 +2,7 @@ import CircuitBreaker from 'opossum';
 import { CircuitBreakerOptions } from './resilience-options';
 
 describe('resilience-options', () => {
-  // when compiling a generated client the compiler fails, because the CircuitBreaker.Options from @types/opssum are not present (long import chain)
+  // when compiling a generated client the compiler fails, because the CircuitBreaker.Options from @types/opossum are not present (long import chain)
   // since these types contain the @types/node they are 1.8MB in size and we do not want to include this as a prod dependency of the connectivity module.
   // Hence we copied the CircuitBreaker options and added this test to ensure type compatibility.
   it('ensure type compatibility to opossum', () => {

--- a/packages/connectivity/src/scp-cf/resilience-options.ts
+++ b/packages/connectivity/src/scp-cf/resilience-options.ts
@@ -46,8 +46,9 @@ export function timeoutPromise<T>(timeout: number): Promise<T> {
 
 /**
  * This is partially copied from CircuitBreaker.Options of `@types/opossum`.
+ * @internal
  */
-interface CircuitBreakerOptions {
+export interface CircuitBreakerOptions {
   timeout?: number | false | undefined;
   errorThresholdPercentage?: number | undefined;
   volumeThreshold?: number | undefined;

--- a/packages/connectivity/src/scp-cf/resilience-options.ts
+++ b/packages/connectivity/src/scp-cf/resilience-options.ts
@@ -1,5 +1,3 @@
-import CircuitBreaker from 'opossum';
-
 export interface ResilienceOptions {
   /**
    * A boolean value that indicates whether to execute request to SCP-CF services using circuit breaker.
@@ -24,7 +22,7 @@ export const defaultResilienceBTPServices: Required<ResilienceOptions> = {
 /**
  * @internal
  */
-export const circuitBreakerDefaultOptions: CircuitBreaker.Options = {
+export const circuitBreakerDefaultOptions: CircuitBreakerOptions = {
   timeout: false,
   errorThresholdPercentage: 50,
   volumeThreshold: 10,
@@ -44,4 +42,14 @@ export function timeoutPromise<T>(timeout: number): Promise<T> {
       timeout
     )
   );
+}
+
+/**
+ * This is partially copied from CircuitBreaker.Options of `@types/opossum`.
+ */
+interface CircuitBreakerOptions {
+  timeout?: number | false | undefined;
+  errorThresholdPercentage?: number | undefined;
+  volumeThreshold?: number | undefined;
+  resetTimeout?: number | undefined;
 }


### PR DESCRIPTION
E2E generator tests failed due to the error below, because we use `@types/opossum` code in the `d.ts` file, while the dependency is a dev dependency.

```
[2022-03-21T16:59:39.858Z] ERROR    (generator-cli): ErrorWithCause: Generation of services failed.
    at /.../node_modules/@sap-cloud-sdk/generator/dist/generator-cli.js:22:18
Caused by:
Error: Compilation Errors:
/.../node_modules/@sap-cloud-sdk/connectivity/dist/scp-cf/resilience-options.d.ts:1:27 - error TS7016: [object Object]
    at transpileDirectory (/.../node_modules/@sap-cloud-sdk/generator-common/dist/compiler.js:35:15)
    at async Promise.all (index 0)
    at async generate (/.../node_modules/@sap-cloud-sdk/generator/dist/generator.js:52:13)
Waiting for the debugger to disconnect...
npm ERR! code ELIFECYCLE

```

This PR removes the type usage.

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
