### PR TITLE
Support custom request config for method in OData and OpenAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 ## New Functionality
 
 - [http-client] Introduce the `parameterEncoder` option to the request config of the `http-client` to allow custom parameter encoding.  
+- [http-client] Remove `method` from `defaultDisallowedKeys` to not filter out custom http method when using `filterCustomRequestConfig`.
+- [odata-common] Support adding custom http method in `addCustomRequestConfiguration` to overwrite the default http method.
+- [openapi] Support adding custom http method in `addCustomRequestConfiguration` to overwrite the default http method.
 
 ## Improvements
 

--- a/packages/http-client/src/http-request-config.spec.ts
+++ b/packages/http-client/src/http-request-config.spec.ts
@@ -24,7 +24,7 @@ describe('filterCustomRequestConfig', () => {
     const filtered = filterCustomRequestConfig(customRequestConfig);
     expect(filtered).toEqual({ responseType: 'arraybuffer' });
     expect(warnSpy).toBeCalledWith(
-      'The following keys are found in the custom request config that will be removed: method, url'
+      'The following keys are found in the custom request config that will be removed: url'
     );
   });
 });

--- a/packages/http-client/src/http-request-config.spec.ts
+++ b/packages/http-client/src/http-request-config.spec.ts
@@ -22,9 +22,9 @@ describe('filterCustomRequestConfig', () => {
       url: 'www.example.com'
     };
     const filtered = filterCustomRequestConfig(customRequestConfig);
-    expect(filtered).toEqual({ 
-      responseType: 'arraybuffer', 
-      method: 'delete' 
+    expect(filtered).toEqual({
+      responseType: 'arraybuffer',
+      method: 'delete'
     });
     expect(warnSpy).toBeCalledWith(
       'The following keys are found in the custom request config that will be removed: url'

--- a/packages/http-client/src/http-request-config.spec.ts
+++ b/packages/http-client/src/http-request-config.spec.ts
@@ -22,7 +22,10 @@ describe('filterCustomRequestConfig', () => {
       url: 'www.example.com'
     };
     const filtered = filterCustomRequestConfig(customRequestConfig);
-    expect(filtered).toEqual({ responseType: 'arraybuffer' });
+    expect(filtered).toEqual({ 
+      responseType: 'arraybuffer', 
+      method: 'delete' 
+    });
     expect(warnSpy).toBeCalledWith(
       'The following keys are found in the custom request config that will be removed: url'
     );

--- a/packages/http-client/src/http-request-config.ts
+++ b/packages/http-client/src/http-request-config.ts
@@ -33,13 +33,7 @@ export function filterCustomRequestConfig(
 /**
  * A list of request config keys that are not allowed to be customized by default.
  */
-const defaultDisallowedKeys = [
-  'url',
-  'baseURL',
-  'data',
-  'headers',
-  'params'
-];
+const defaultDisallowedKeys = ['url', 'baseURL', 'data', 'headers', 'params'];
 
 /**
  * Merge options from a given [[OriginOptions]]. When reaching conflicts, values with higher priorities are chosen.

--- a/packages/http-client/src/http-request-config.ts
+++ b/packages/http-client/src/http-request-config.ts
@@ -34,7 +34,6 @@ export function filterCustomRequestConfig(
  * A list of request config keys that are not allowed to be customized by default.
  */
 const defaultDisallowedKeys = [
-  'method',
   'url',
   'baseURL',
   'data',

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -121,12 +121,13 @@ describe('OData Request', () => {
   });
 
   describe('requestConfig', () => {
-    it('should overwrite default request config with filtered custom request config', () => {
+    it('should overwrite default request config with filtered custom request config', async () => {
       const request = createRequest(ODataGetAllRequestConfig);
       request.config.customRequestConfiguration = {
         method: 'merge'
       }
-      expect(request.requestConfig()['method']).toBe('merge');
+      const config = await request.requestConfig();
+      expect(config['method']).toBe('merge');
     });
   });
 });

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -125,7 +125,7 @@ describe('OData Request', () => {
       const request = createRequest(ODataGetAllRequestConfig);
       request.config.customRequestConfiguration = {
         method: 'merge'
-      }
+      };
       const config = await request.requestConfig();
       expect(config['method']).toBe('merge');
     });

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -119,6 +119,16 @@ describe('OData Request', () => {
       })
     );
   });
+
+  describe('requestConfig', () => {
+    it('should overwrite default request config with filtered custom request config', () => {
+      const request = createRequest(ODataGetAllRequestConfig);
+      request.config.customRequestConfiguration = {
+        method: 'merge'
+      }
+      expect(request.requestConfig()['method']).toBe('merge');
+    });
+  });
 });
 
 function createRequest(

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -126,7 +126,7 @@ describe('OData Request', () => {
       request.config.customRequestConfiguration = {
         method: 'merge'
       };
-      const config = await request.requestConfig();
+      const config = await request['requestConfig']();
       expect(config['method']).toBe('merge');
     });
   });

--- a/packages/odata-common/src/request/odata-request.ts
+++ b/packages/odata-common/src/request/odata-request.ts
@@ -218,6 +218,23 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
   }
 
   /**
+   * Execute the given request and return the according promise.
+   * @returns Promise resolving to the requested data.
+   */
+  async execute(): Promise<HttpResponse> {
+    const destination = this.destination;
+    if (!destination) {
+      throw Error('The destination cannot be undefined.');
+    }
+
+    return executeHttpRequest(destination, await this.requestConfig(), {
+      fetchCsrfToken: this.config.fetchCsrfToken
+    }).catch(error => {
+      throw constructError(error, this.config.method, this.serviceUrl());
+    });
+  }
+
+  /**
    * Get http request config.
    * @returns Promise of http request config with origin.
    */
@@ -235,23 +252,6 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
       ...defaultConfig,
       ...filterCustomRequestConfig(this.config.customRequestConfiguration)
     };
-  }
-
-  /**
-   * Execute the given request and return the according promise.
-   * @returns Promise resolving to the requested data.
-   */
-  async execute(): Promise<HttpResponse> {
-    const destination = this.destination;
-    if (!destination) {
-      throw Error('The destination cannot be undefined.');
-    }
-
-    return executeHttpRequest(destination, await this.requestConfig(), {
-      fetchCsrfToken: this.config.fetchCsrfToken
-    }).catch(error => {
-      throw constructError(error, this.config.method, this.serviceUrl());
-    });
   }
 
   private getAdditionalHeadersForKeys(...keys: string[]): Record<string, any> {

--- a/packages/odata-common/src/request/odata-request.ts
+++ b/packages/odata-common/src/request/odata-request.ts
@@ -218,7 +218,7 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
   }
 
   /**
-   * Get http request config .
+   * Get http request config.
    * @returns Promise of http request config with origin.
    */
   async requestConfig(): Promise<HttpRequestConfigWithOrigin> {

--- a/packages/odata-common/src/request/odata-request.ts
+++ b/packages/odata-common/src/request/odata-request.ts
@@ -221,7 +221,7 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
    * Get http request config.
    * @returns Promise of http request config with origin.
    */
-  async requestConfig(): Promise<HttpRequestConfigWithOrigin> {
+  private async requestConfig(): Promise<HttpRequestConfigWithOrigin> {
     const defaultConfig = {
       headers: await this.headers(),
       params: this.queryParameters(),

--- a/packages/odata-common/src/request/odata-request.ts
+++ b/packages/odata-common/src/request/odata-request.ts
@@ -218,12 +218,10 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
   }
 
   /**
-   * Get http request config 
-   * @returns Promise of http request config with origin
+   * Get http request config .
+   * @returns Promise of http request config with origin.
    */
-  async requestConfig(): Promise<
-    HttpRequestConfigWithOrigin
-  > {
+  async requestConfig(): Promise<HttpRequestConfigWithOrigin> {
     const defaultConfig = {
       headers: await this.headers(),
       params: this.queryParameters(),
@@ -236,7 +234,7 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
     return {
       ...defaultConfig,
       ...filterCustomRequestConfig(this.config.customRequestConfiguration)
-    }
+    };
   }
 
   /**
@@ -249,11 +247,9 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
       throw Error('The destination cannot be undefined.');
     }
 
-    return executeHttpRequest(
-      destination,
-      await this.requestConfig(),
-      { fetchCsrfToken: this.config.fetchCsrfToken }
-    ).catch(error => {
+    return executeHttpRequest(destination, await this.requestConfig(), {
+      fetchCsrfToken: this.config.fetchCsrfToken
+    }).catch(error => {
       throw constructError(error, this.config.method, this.serviceUrl());
     });
   }

--- a/packages/openapi/src/openapi-request-builder.spec.ts
+++ b/packages/openapi/src/openapi-request-builder.spec.ts
@@ -258,12 +258,13 @@ describe('openapi-request-builder', () => {
   });
 
   describe('requestConfig', () => {
-    it('should overwrite default request config with filtered custom request config', () => {
+    it('should overwrite default request config with filtered custom request config', async () => {
       const requestBuilder = new OpenApiRequestBuilder('get', '/test');
       requestBuilder.addCustomRequestConfiguration({
         method: 'merge'
       });
-      expect(requestBuilder.requestConfig()['method']).toBe('merge');
+      const reqeustConfig = await requestBuilder.requestConfig();
+      expect(reqeustConfig['method']).toBe('merge');
     });
   });
 });

--- a/packages/openapi/src/openapi-request-builder.spec.ts
+++ b/packages/openapi/src/openapi-request-builder.spec.ts
@@ -256,4 +256,14 @@ describe('openapi-request-builder', () => {
       { fetchCsrfToken: false }
     );
   });
+
+  describe('requestConfig', () => {
+    it('should overwrite default request config with filtered custom request config', () => {
+      const requestBuilder = new OpenApiRequestBuilder('get', '/test');
+      requestBuilder.addCustomRequestConfiguration({
+        method: 'merge'
+      });
+      expect(requestBuilder.requestConfig()['method']).toBe('merge');
+    });
+  });
 });

--- a/packages/openapi/src/openapi-request-builder.spec.ts
+++ b/packages/openapi/src/openapi-request-builder.spec.ts
@@ -263,7 +263,7 @@ describe('openapi-request-builder', () => {
       requestBuilder.addCustomRequestConfiguration({
         method: 'merge'
       });
-      const reqeustConfig = await requestBuilder.requestConfig();
+      const reqeustConfig = await requestBuilder['requestConfig']();
       expect(reqeustConfig['method']).toBe('merge');
     });
   });

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -10,6 +10,7 @@ import {
 import {
   Method,
   HttpResponse,
+  HttpRequestConfigWithOrigin,
   executeHttpRequest
 } from '@sap-cloud-sdk/http-client';
 import {
@@ -91,6 +92,28 @@ export class OpenApiRequestBuilder<ResponseT = any> {
   }
 
   /**
+   * Get http request config 
+   * @returns Promise of http request config with origin
+   */
+  async requestConfig(): Promise<
+    HttpRequestConfigWithOrigin
+  > {
+    const defaultConfig = {
+      method: this.method,
+      url: this.getPath(),
+      headers: this.getHeaders(),
+      params: this.getParameters(),
+      timeout: this._timeout,
+      parameterEncoder: encodeTypedClientRequest,
+      data: this.parameters?.body
+    };
+    return {
+      ...defaultConfig,
+      ...filterCustomRequestConfig(this.customRequestConfiguration)
+    }
+  }
+
+  /**
    * Execute request and get a raw HttpResponse, including all information about the HTTP response.
    * This especially comes in handy, when you need to access the headers or status code of the response.
    * @param destination - Destination or DestinationFetchOptions to execute the request against.
@@ -107,18 +130,10 @@ export class OpenApiRequestBuilder<ResponseT = any> {
     if (isNullish(destination)) {
       throw Error(noDestinationErrorMessage(destination));
     }
+    
     return executeHttpRequest(
       resolvedDestination as Destination,
-      {
-        ...filterCustomRequestConfig(this.customRequestConfiguration),
-        method: this.method,
-        url: this.getPath(),
-        headers: this.getHeaders(),
-        params: this.getParameters(),
-        timeout: this._timeout,
-        parameterEncoder: encodeTypedClientRequest,
-        data: this.parameters?.body
-      },
+      await this.requestConfig(),
       { fetchCsrfToken }
     );
   }

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -92,7 +92,7 @@ export class OpenApiRequestBuilder<ResponseT = any> {
   }
 
   /**
-   * Get http request config .
+   * Get http request config.
    * @returns Promise of http request config with origin.
    */
   async requestConfig(): Promise<HttpRequestConfigWithOrigin> {

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -95,7 +95,7 @@ export class OpenApiRequestBuilder<ResponseT = any> {
    * Get http request config.
    * @returns Promise of http request config with origin.
    */
-  async requestConfig(): Promise<HttpRequestConfigWithOrigin> {
+  private async requestConfig(): Promise<HttpRequestConfigWithOrigin> {
     const defaultConfig = {
       method: this.method,
       url: this.getPath(),

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -92,12 +92,10 @@ export class OpenApiRequestBuilder<ResponseT = any> {
   }
 
   /**
-   * Get http request config 
-   * @returns Promise of http request config with origin
+   * Get http request config .
+   * @returns Promise of http request config with origin.
    */
-  async requestConfig(): Promise<
-    HttpRequestConfigWithOrigin
-  > {
+  async requestConfig(): Promise<HttpRequestConfigWithOrigin> {
     const defaultConfig = {
       method: this.method,
       url: this.getPath(),
@@ -110,7 +108,7 @@ export class OpenApiRequestBuilder<ResponseT = any> {
     return {
       ...defaultConfig,
       ...filterCustomRequestConfig(this.customRequestConfiguration)
-    }
+    };
   }
 
   /**
@@ -130,7 +128,7 @@ export class OpenApiRequestBuilder<ResponseT = any> {
     if (isNullish(destination)) {
       throw Error(noDestinationErrorMessage(destination));
     }
-    
+
     return executeHttpRequest(
       resolvedDestination as Destination,
       await this.requestConfig(),

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -92,26 +92,6 @@ export class OpenApiRequestBuilder<ResponseT = any> {
   }
 
   /**
-   * Get http request config.
-   * @returns Promise of http request config with origin.
-   */
-  private async requestConfig(): Promise<HttpRequestConfigWithOrigin> {
-    const defaultConfig = {
-      method: this.method,
-      url: this.getPath(),
-      headers: this.getHeaders(),
-      params: this.getParameters(),
-      timeout: this._timeout,
-      parameterEncoder: encodeTypedClientRequest,
-      data: this.parameters?.body
-    };
-    return {
-      ...defaultConfig,
-      ...filterCustomRequestConfig(this.customRequestConfiguration)
-    };
-  }
-
-  /**
    * Execute request and get a raw HttpResponse, including all information about the HTTP response.
    * This especially comes in handy, when you need to access the headers or status code of the response.
    * @param destination - Destination or DestinationFetchOptions to execute the request against.
@@ -149,6 +129,26 @@ export class OpenApiRequestBuilder<ResponseT = any> {
     throw new Error(
       'Could not access response data. Response was not an axios response.'
     );
+  }
+
+  /**
+   * Get http request config.
+   * @returns Promise of http request config with origin.
+   */
+  private async requestConfig(): Promise<HttpRequestConfigWithOrigin> {
+    const defaultConfig = {
+      method: this.method,
+      url: this.getPath(),
+      headers: this.getHeaders(),
+      params: this.getParameters(),
+      timeout: this._timeout,
+      parameterEncoder: encodeTypedClientRequest,
+      data: this.parameters?.body
+    };
+    return {
+      ...defaultConfig,
+      ...filterCustomRequestConfig(this.customRequestConfiguration)
+    };
   }
 
   private getHeaders(): OriginOptions {


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#71.

Remove `method` from `defaultDisallowedKeys` in `http-request` to support custom http request method. 
Overwrite http `method` in `odata-common` and `openapi` if it is defined in custom http configuration.

The usage should look like

```typescript
const { myEntityApi } = myEntityService();
myEntityApi
  .requestBuilder()
  .getAll()
  .addCustomRequestConfiguration({ method: 'YOUR-METHOD' });
```

By default, http method is set to `get` by `getAll()`. Now, it will be overwritten by `YOUR-METHOD`.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->

TODO:
- [x] Update change log
