### PR TITLE
fix: remove hardcoded format json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,7 @@
 
 ## Compatibility Notes
 
-- [odata-common] Remove all `$format=json` query parameters since header `Accept: application/json` is sent by default.
-- [odata-v2] Remove all `$format=json` query parameters since header `Accept: application/json` is sent by default.
-- [odata-v4] Remove all `$format=json` query parameters since header `Accept: application/json` is sent by default.
+- [odata-common, odata-v2, odata-v4] Remove all `$format=json` query parameters since header `Accept: application/json` is sent by default.
 
 ## New Functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 
 ## Compatibility Notes
 
--
+- [odata-common] Remove all `$format=json` query parameters since header `Accept: application/json` is sent by default.
+- [odata-v2] Remove all `$format=json` query parameters since header `Accept: application/json` is sent by default.
+- [odata-v4] Remove all `$format=json` query parameters since header `Accept: application/json` is sent by default.
 
 ## New Functionality
 

--- a/knowledge-base/adr/0008-v4-api.md
+++ b/knowledge-base/adr/0008-v4-api.md
@@ -134,7 +134,7 @@ This document contains a collection of OData v4 features we want to implement an
 - One-To-One Links:
 
   - v2 example:
-    https://services.odata.org/V2/Northwind/Northwind.svc/Products?$select=Category/CategoryID&$expand=Category&$format=json&$filter=Category/CategoryID%20eq%202
+    https://services.odata.org/V2/Northwind/Northwind.svc/Products?$select=Category/CategoryID&$expand=Category&$filter=Category/CategoryID%20eq%202
 
   - v4 example:
     https://services.odata.org/Experimental/Northwind/Northwind.svc/Products?$select=Category&$expand=Category($select=CategoryID)&$filter=Category/CategoryID%20eq%202

--- a/knowledge-base/adr/0024-url-encoding.md
+++ b/knowledge-base/adr/0024-url-encoding.md
@@ -108,7 +108,6 @@ Similar to path section, we also discuss OData and OpenAPI separately.
 
 OData allows you to use the following query options:
 
-- `$format=json`
 - `$top=1`
 - `$skip=1`
 - `$orderby=StringProperty`

--- a/packages/odata-common/src/request-builder/batch/__snapshots__/batch-request-serializer.spec.ts.snap
+++ b/packages/odata-common/src/request-builder/batch/__snapshots__/batch-request-serializer.spec.ts.snap
@@ -19,7 +19,7 @@ Accept: application/json
 Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-GET /sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity?$format=json HTTP/1.1
+GET /sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 
@@ -52,7 +52,7 @@ Accept: application/json
 Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-GET /sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity(KeyPropertyGuid=testId,KeyPropertyString='test')?$format=json HTTP/1.1
+GET /sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity(KeyPropertyGuid=testId,KeyPropertyString='test') HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 
@@ -156,7 +156,7 @@ exports[`batch request serializer serializeRequest serializes getAll request 1`]
 "Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-GET /sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity?$format=json HTTP/1.1
+GET /sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 
@@ -167,7 +167,7 @@ exports[`batch request serializer serializeRequest serializes getAll request wit
 "Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-GET http://example.com/sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity?$format=json HTTP/1.1
+GET http://example.com/sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 
@@ -178,7 +178,7 @@ exports[`batch request serializer serializeRequest serializes getAll request wit
 "Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-GET /sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity?$format=json HTTP/1.1
+GET /sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 Custom-Header: custom
@@ -190,7 +190,7 @@ exports[`batch request serializer serializeRequest serializes getAll request wit
 "Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-GET /A_CommonEntity?$format=json HTTP/1.1
+GET /A_CommonEntity HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 
@@ -201,7 +201,7 @@ exports[`batch request serializer serializeRequest serializes getAll request wit
 "Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-GET /sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity?$format=json&$filter=(StringProperty%20eq%20'test') HTTP/1.1
+GET /sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity?$filter=(StringProperty%20eq%20'test') HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 
@@ -212,7 +212,7 @@ exports[`batch request serializer serializeRequest serializes getByKey request 1
 "Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-GET /sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity(KeyPropertyGuid=testId,KeyPropertyString='test')?$format=json HTTP/1.1
+GET /sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity(KeyPropertyGuid=testId,KeyPropertyString='test') HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 

--- a/packages/odata-common/src/request-builder/count-request-builder.spec.ts
+++ b/packages/odata-common/src/request-builder/count-request-builder.spec.ts
@@ -31,7 +31,7 @@ describe('CountRequestBuilder', () => {
       expect(actual).toBe(expected);
     });
 
-    it('ignores methods which must not affect count like $format, $top, $skip', async () => {
+    it('ignores methods which must not affect count like $top, $skip', async () => {
       const expected =
         '/testination/sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity/$count';
       const actual = await requestBuilder

--- a/packages/odata-common/src/request/odata-count-request-config.ts
+++ b/packages/odata-common/src/request/odata-count-request-config.ts
@@ -39,14 +39,10 @@ export class ODataCountRequestConfig<
 
   queryParameters(): Record<string, any> {
     const parametersAllowedInCount = ['$apply', '$search', '$filter'];
-    const defaultParameters = ['$format'];
     const parameters = this.getAllRequest.requestConfig.queryParameters();
 
     Object.keys(parameters).forEach(key => {
-      if (
-        !parametersAllowedInCount.includes(key) &&
-        !defaultParameters.includes(key)
-      ) {
+      if (!parametersAllowedInCount.includes(key)) {
         logger.warn(
           `The query parameter ${key} must not be used in a count request and has been ignored.`
         );

--- a/packages/odata-common/src/request/odata-delete-request-config.spec.ts
+++ b/packages/odata-common/src/request/odata-delete-request-config.spec.ts
@@ -26,8 +26,4 @@ describe('ODataDeleteRequestConfig', () => {
       testEntityResourcePath(keyPropGuid, keyPropString)
     );
   });
-
-  it('has no format', () => {
-    expect(Object.keys(config.queryParameters())).not.toContain('$format');
-  });
 });

--- a/packages/odata-common/src/request/odata-get-all-request-config.spec.ts
+++ b/packages/odata-common/src/request/odata-get-all-request-config.spec.ts
@@ -18,10 +18,6 @@ describe('ODataGetAllRequestConfig', () => {
     expect(config.resourcePath()).toBe(CommonEntity._entityName);
   });
 
-  it('has format json', () => {
-    expect(config.queryParameters()['$format']).toBe('json');
-  });
-
   it('has skip if set', () => {
     config.skip = 10;
     expect(config.queryParameters()['$skip']).toBe(config.skip);

--- a/packages/odata-common/src/request/odata-get-all-request-config.ts
+++ b/packages/odata-common/src/request/odata-get-all-request-config.ts
@@ -50,7 +50,6 @@ export class ODataGetAllRequestConfig<
 
   queryParameters(): Record<string, any> {
     const params: Record<string, any> = {
-      format: 'json',
       ...this.oDataUri.getSelect(this.selects),
       ...this.oDataUri.getExpand(this.selects, this.expands, this.entityApi),
       ...this.oDataUri.getFilter(this.filter, this.entityApi),

--- a/packages/odata-common/src/request/odata-get-by-key-request-config.spec.ts
+++ b/packages/odata-common/src/request/odata-get-by-key-request-config.spec.ts
@@ -27,10 +27,6 @@ describe('ODataGetByKeyRequestConfig', () => {
     );
   });
 
-  it('has format json', () => {
-    expect(config.queryParameters()['$format']).toBe('json');
-  });
-
   it('has selection', () => {
     config.selects = [
       commonEntityApi.schema.STRING_PROPERTY,

--- a/packages/odata-common/src/request/odata-get-by-key-request-config.ts
+++ b/packages/odata-common/src/request/odata-get-by-key-request-config.ts
@@ -45,7 +45,6 @@ export class ODataGetByKeyRequestConfig<
 
   queryParameters(): Record<string, any> {
     return this.prependDollarToQueryParameters({
-      format: 'json',
       ...this.oDataUri.getSelect(this.selects),
       ...this.oDataUri.getExpand(this.selects, this.expands, this.entityApi)
     });

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -1,6 +1,5 @@
 import { v4 as uuid } from 'uuid';
 import { Destination } from '@sap-cloud-sdk/connectivity';
-import { OriginOptions } from '@sap-cloud-sdk/http-client';
 import { encodeTypedClientRequest } from '@sap-cloud-sdk/http-client/internal';
 import { commonODataUri } from '../../test/common-request-config';
 import { CommonEntity, commonEntityApi } from '../../test/common-entity';
@@ -9,17 +8,6 @@ import { ODataGetAllRequestConfig } from './odata-get-all-request-config';
 import { ODataRequest } from './odata-request';
 
 describe('OData Request', () => {
-  describe('format', () => {
-    function createRequestWithHeaders(
-      configConstructor,
-      destination?
-    ): ODataRequest<any> {
-      const req = createRequest(configConstructor, destination);
-      jest.spyOn(req, 'headers').mockResolvedValue({} as OriginOptions);
-      return req;
-    }
-  });
-
   it('should be noParamEncoder', async () => {
     const request = createRequest(ODataGetAllRequestConfig);
     expect(request.config.parameterEncoder).toBe(encodeTypedClientRequest);

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -6,33 +6,10 @@ import { commonODataUri } from '../../test/common-request-config';
 import { CommonEntity, commonEntityApi } from '../../test/common-entity';
 import { DefaultDeSerializers } from '../de-serializers';
 import { ODataGetAllRequestConfig } from './odata-get-all-request-config';
-import { ODataCreateRequestConfig } from './odata-create-request-config';
-import { ODataUpdateRequestConfig } from './odata-update-request-config';
-import { ODataDeleteRequestConfig } from './odata-delete-request-config';
 import { ODataRequest } from './odata-request';
 
 describe('OData Request', () => {
   describe('format', () => {
-    it('should be json for GET', async () => {
-      const request = createRequestWithHeaders(ODataGetAllRequestConfig);
-      expect(request.url()).toContain('$format=json');
-    });
-
-    it('should not be json for POST', async () => {
-      const request = createRequestWithHeaders(ODataCreateRequestConfig);
-      expect(request.url()).not.toContain('$format=json');
-    });
-
-    it('should not be json for PATCH', async () => {
-      const request = createRequestWithHeaders(ODataUpdateRequestConfig);
-      expect(request.url()).not.toContain('$format=json');
-    });
-
-    it('should not be json for DELETE', async () => {
-      const request = createRequestWithHeaders(ODataDeleteRequestConfig);
-      expect(request.url()).not.toContain('$format=json');
-    });
-
     function createRequestWithHeaders(
       configConstructor,
       destination?
@@ -41,13 +18,6 @@ describe('OData Request', () => {
       jest.spyOn(req, 'headers').mockResolvedValue({} as OriginOptions);
       return req;
     }
-  });
-
-  describe('query', () => {
-    it('should have json parameter by default for get request', () => {
-      const request = createRequest(ODataGetAllRequestConfig);
-      expect(request.query()).toEqual('?$format=json');
-    });
   });
 
   it('should be noParamEncoder', async () => {
@@ -89,7 +59,7 @@ describe('OData Request', () => {
       >;
       requestConfig.appendPath('/$value');
       expect(request.relativeUrl()).toBe(
-        'sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity/$value?$format=json'
+        'sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity/$value'
       );
     });
 
@@ -101,7 +71,7 @@ describe('OData Request', () => {
       >;
       requestConfig.appendPath('/');
       expect(request.relativeUrl()).toBe(
-        'sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity/?$format=json'
+        'sap/opu/odata/sap/API_COMMON_SRV/A_CommonEntity/'
       );
     });
   });

--- a/packages/odata-v2/src/request-builder/function-import-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/function-import-request-builder.spec.ts
@@ -45,7 +45,7 @@ describe('FunctionImportRequestBuilder', () => {
 
     nock(defaultHost)
       .get(`${serviceUrl}/TestFunctionImportGET`)
-      .query({ $format: 'json', SimpleParam: `'${simpleParam}'` })
+      .query({ SimpleParam: `'${simpleParam}'` })
       .reply(200);
 
     await expect(
@@ -59,12 +59,12 @@ describe('FunctionImportRequestBuilder', () => {
 
     nock(defaultHost)
       .get(`${serviceUrl}/TestFunctionImportPOST`)
-      .query({ $format: 'json', SimpleParam: `'${simpleParam}'` })
+      .query({ SimpleParam: `'${simpleParam}'` })
       .reply(200, undefined, mockedBuildHeaderResponse);
 
     nock(defaultHost)
       .post(`${serviceUrl}/TestFunctionImportPOST`)
-      .query({ $format: 'json', SimpleParam: `'${simpleParam}'` })
+      .query({ SimpleParam: `'${simpleParam}'` })
       .reply(200);
 
     await expect(
@@ -77,7 +77,7 @@ describe('FunctionImportRequestBuilder', () => {
 
     nock(defaultHost)
       .get(`${serviceUrl}/TestFunctionImportEdmReturnType`)
-      .query({ $format: 'json' })
+      .query({})
       .reply(200, { d: { TestFunctionImportEdmReturnType: true } });
 
     const returnValue = await requestBuilder.execute(defaultDestination);
@@ -95,7 +95,7 @@ describe('FunctionImportRequestBuilder', () => {
 
     nock(defaultHost)
       .get(`${serviceUrl}/TestFunctionImportUnsupportedEdmTypes`)
-      .query({ $format: 'json', SimpleParam: 'SomeUntypedValue' })
+      .query({ SimpleParam: 'SomeUntypedValue' })
       .reply(200, untypedResponse);
 
     const returnValue = await requestBuilder.execute(defaultDestination);
@@ -107,7 +107,7 @@ describe('FunctionImportRequestBuilder', () => {
 
     nock(defaultHost)
       .get(`${serviceUrl}/TestFunctionImportEdmReturnTypeCollection`)
-      .query({ $format: 'json' })
+      .query({})
       .reply(200, { d: { results: [true, false] } });
 
     const returnValue = await requestBuilder.execute(defaultDestination);
@@ -120,7 +120,7 @@ describe('FunctionImportRequestBuilder', () => {
 
     nock(defaultHost)
       .get(`${serviceUrl}/TestFunctionImportEntityReturnType`)
-      .query({ $format: 'json' })
+      .query({})
       .reply(200, { d: getTestEntityData(expected) });
 
     const returnValue = await requestBuilder.execute(defaultDestination);
@@ -133,7 +133,7 @@ describe('FunctionImportRequestBuilder', () => {
 
     nock(defaultHost)
       .get(`${serviceUrl}/TestFunctionImportEntityReturnTypeCollection`)
-      .query({ $format: 'json' })
+      .query({})
       .reply(200, { d: { results: expected.map(e => getTestEntityData(e)) } });
 
     const returnValue = await requestBuilder.execute(defaultDestination);
@@ -146,7 +146,7 @@ describe('FunctionImportRequestBuilder', () => {
 
     nock(defaultHost)
       .get(`${serviceUrl}/TestFunctionImportComplexReturnType`)
-      .query({ $format: 'json' })
+      .query({})
       .reply(200, { d: getTestComplexTypeData(expected) });
 
     const returnValue = await requestBuilder.execute(defaultDestination);
@@ -159,7 +159,7 @@ describe('FunctionImportRequestBuilder', () => {
 
     nock(defaultHost)
       .get(`${serviceUrl}/TestFunctionImportEntityReturnTypeCollection`)
-      .query({ $format: 'json' })
+      .query({})
       .reply(200, {
         d: { results: expected.map(e => getTestComplexTypeData(e)) }
       });
@@ -170,11 +170,11 @@ describe('FunctionImportRequestBuilder', () => {
 
   it('return undefined or throw in failure case', async () => {
     nock(defaultHost)
-      .get(`${serviceUrl}/TestFunctionImportNoReturnType?$format=json`)
+      .get(`${serviceUrl}/TestFunctionImportNoReturnType`)
       .reply(200, undefined, mockedBuildHeaderResponse);
 
     nock(defaultHost)
-      .post(`${serviceUrl}/TestFunctionImportNoReturnType?$format=json`)
+      .post(`${serviceUrl}/TestFunctionImportNoReturnType`)
       .reply(200);
 
     const response = await testFunctionImportNoReturnType({}).execute(
@@ -183,7 +183,7 @@ describe('FunctionImportRequestBuilder', () => {
     expect(response).toBe(undefined);
 
     nock(defaultHost)
-      .post(`${serviceUrl}/TestFunctionImportNoReturnType?$format=json`)
+      .post(`${serviceUrl}/TestFunctionImportNoReturnType`)
       .reply(400);
 
     await expect(
@@ -194,7 +194,7 @@ describe('FunctionImportRequestBuilder', () => {
   it('throws an error when shared entity type is used as return type', async () => {
     nock(defaultHost)
       .get(`${serviceUrl}/TestFunctionImportSharedEntityReturnType()`)
-      .query({ $format: 'json' })
+      .query({})
       .reply(200, {});
     const requestBuilder = testFunctionImportSharedEntityReturnType({}) as any;
 

--- a/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
@@ -49,14 +49,14 @@ describe('GetAllRequestBuilder', () => {
   describe('url', () => {
     it('is built correctly', async () => {
       const expected =
-        '/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$format=json';
+        '/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity';
       const actual = await requestBuilder.url(defaultDestination);
       expect(actual).toBe(expected);
     });
 
     it('is built correctly with URI encoding', async () => {
       const expected =
-        "/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$format=json&$filter=(StringProperty%20eq%20'%C3%A4%20%C3%B6%2B%20''c')";
+        "/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$filter=(StringProperty%20eq%20'%C3%A4%20%C3%B6%2B%20''c')";
       const actual = await requestBuilder
         .filter(testEntityApi.schema.STRING_PROPERTY.equals("ä ö+ 'c"))
         .url(defaultDestination);
@@ -65,7 +65,7 @@ describe('GetAllRequestBuilder', () => {
 
     it('adds expand for nested selects', async () => {
       const expected =
-        '/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$format=json&$select=to_SingleLink/BooleanProperty&$expand=to_SingleLink';
+        '/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$select=to_SingleLink/BooleanProperty&$expand=to_SingleLink';
       const actual = await requestBuilder
         .select(
           testEntityApi.schema.TO_SINGLE_LINK.select(
@@ -303,11 +303,7 @@ describe('GetAllRequestBuilder', () => {
             }
           },
           parameterEncoder: encodeTypedClientRequest,
-          params: {
-            requestConfig: {
-              $format: 'json'
-            }
-          },
+          params: {},
           url: 'sap/opu/odata/sap/API_TEST_SRV/A_TestEntity',
           method: 'get',
 

--- a/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
@@ -303,10 +303,11 @@ describe('GetAllRequestBuilder', () => {
             }
           },
           parameterEncoder: encodeTypedClientRequest,
-          params: {},
+          params: {
+            requestConfig: {}
+          },
           url: 'sap/opu/odata/sap/API_TEST_SRV/A_TestEntity',
           method: 'get',
-
           data: undefined
         },
         { fetchCsrfToken: true }

--- a/packages/odata-v2/src/request-builder/get-by-key-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-by-key-request-builder.spec.ts
@@ -21,7 +21,7 @@ describe('GetByKeyRequestBuilder', () => {
         KeyPropertyString: 'DEV?TEST06'
       });
       const expected =
-        /^\/testination\/sap\/opu\/odata\/sap\/API_TEST_SRV\/A_TestEntity\(KeyPropertyGuid=guid'\w{8}-\w{4}-\w{4}-\w{4}-\w{12}',KeyPropertyString='DEV%3FTEST06'\)\?\$format=json$/;
+        /^\/testination\/sap\/opu\/odata\/sap\/API_TEST_SRV\/A_TestEntity\(KeyPropertyGuid=guid'\w{8}-\w{4}-\w{4}-\w{4}-\w{12}',KeyPropertyString='DEV%3FTEST06'\)$/;
 
       const actual = await new GetByKeyRequestBuilder(testEntityApi, {
         KeyPropertyGuid: entity.keyPropertyGuid,
@@ -34,7 +34,7 @@ describe('GetByKeyRequestBuilder', () => {
       const entityData = createOriginalTestEntityData1();
       const entity = createTestEntity(entityData);
       const expected =
-        /^\/testination\/sap\/opu\/odata\/sap\/API_TEST_SRV\/A_TestEntity\(KeyPropertyGuid=guid'\w{8}-\w{4}-\w{4}-\w{4}-\w{12}',KeyPropertyString='ABCDE'\)\/to_SingleLink\/to_MultiLink\/\?\$format=json$/;
+        /^\/testination\/sap\/opu\/odata\/sap\/API_TEST_SRV\/A_TestEntity\(KeyPropertyGuid=guid'\w{8}-\w{4}-\w{4}-\w{4}-\w{12}',KeyPropertyString='ABCDE'\)\/to_SingleLink\/to_MultiLink\/$/;
 
       const actual = await new GetByKeyRequestBuilder(testEntityApi, {
         KeyPropertyGuid: entity.keyPropertyGuid,

--- a/packages/odata-v2/src/request/odata-function-import-request-config.spec.ts
+++ b/packages/odata-v2/src/request/odata-function-import-request-config.spec.ts
@@ -47,7 +47,6 @@ describe('ODataFunctionImportRequestConfig', () => {
 
   it('has query parameters', () => {
     expect(config.queryParameters()).toEqual({
-      $format: 'json',
       Test1: "'test'",
       Test2: 'false',
       Test3: '10D'

--- a/packages/odata-v2/src/request/odata-function-import-request-config.ts
+++ b/packages/odata-v2/src/request/odata-function-import-request-config.ts
@@ -38,9 +38,6 @@ export class ODataFunctionImportRequestConfig<
 
   queryParameters(): Record<string, any> {
     return {
-      ...this.prependDollarToQueryParameters({
-        format: 'json'
-      }),
       ...(Object.values(this.parameters)
         .filter(
           (parameter: FunctionImportParameter<ParametersT>) =>

--- a/packages/odata-v4/src/request-builder/action-import-request-builder.spec.ts
+++ b/packages/odata-v4/src/request-builder/action-import-request-builder.spec.ts
@@ -33,7 +33,7 @@ function mockCsrfTokenRequest(path?: string) {
     }
   })
     .head(path ? `${servicePath}/${path}` : servicePath)
-    .query({ $format: 'json' })
+    .query({})
     .reply(200, '', mockedBuildHeaderResponse);
 }
 
@@ -47,7 +47,7 @@ describe('action import request builder', () => {
       }
     })
       .post(`${servicePath}/TestActionImportNoParameterNoReturnType`)
-      .query({ $format: 'json' })
+      .query({})
       .reply(204);
 
     const result = await testActionImportNoParameterNoReturnType({}).execute(
@@ -66,7 +66,7 @@ describe('action import request builder', () => {
       .post(`${servicePath}/TestActionImportUnsupportedEdmTypes`, {
         SimpleParam: 'someUntypedParameter'
       })
-      .query({ $format: 'json' })
+      .query({})
       .reply(200, response);
 
     const result = await testActionImportUnsupportedEdmTypes({
@@ -91,7 +91,7 @@ describe('action import request builder', () => {
         `${servicePath}/TestActionImportMultipleParameterComplexReturnType`,
         httpBody
       )
-      .query({ $format: 'json' })
+      .query({})
       .reply(200, httpResponse);
 
     const result = await testActionImportMultipleParameterComplexReturnType(
@@ -106,7 +106,7 @@ describe('action import request builder', () => {
 
       nock(host)
         .post(`${servicePath}/TestActionImportNoParameterNoReturnType`)
-        .query({ $format: 'json' })
+        .query({})
         .reply(204, {});
 
       const actual = await testActionImportNoParameterNoReturnType(

--- a/packages/odata-v4/src/request-builder/action-import-request-builder.spec.ts
+++ b/packages/odata-v4/src/request-builder/action-import-request-builder.spec.ts
@@ -33,7 +33,6 @@ function mockCsrfTokenRequest(path?: string) {
     }
   })
     .head(path ? `${servicePath}/${path}` : servicePath)
-    .query({})
     .reply(200, '', mockedBuildHeaderResponse);
 }
 
@@ -47,7 +46,6 @@ describe('action import request builder', () => {
       }
     })
       .post(`${servicePath}/TestActionImportNoParameterNoReturnType`)
-      .query({})
       .reply(204);
 
     const result = await testActionImportNoParameterNoReturnType({}).execute(
@@ -66,7 +64,6 @@ describe('action import request builder', () => {
       .post(`${servicePath}/TestActionImportUnsupportedEdmTypes`, {
         SimpleParam: 'someUntypedParameter'
       })
-      .query({})
       .reply(200, response);
 
     const result = await testActionImportUnsupportedEdmTypes({
@@ -91,7 +88,6 @@ describe('action import request builder', () => {
         `${servicePath}/TestActionImportMultipleParameterComplexReturnType`,
         httpBody
       )
-      .query({})
       .reply(200, httpResponse);
 
     const result = await testActionImportMultipleParameterComplexReturnType(
@@ -106,7 +102,6 @@ describe('action import request builder', () => {
 
       nock(host)
         .post(`${servicePath}/TestActionImportNoParameterNoReturnType`)
-        .query({})
         .reply(204, {});
 
       const actual = await testActionImportNoParameterNoReturnType(

--- a/packages/odata-v4/src/request-builder/function-import-request-builder.spec.ts
+++ b/packages/odata-v4/src/request-builder/function-import-request-builder.spec.ts
@@ -9,7 +9,7 @@ describe('FunctionImportRequestBuilder', () => {
 
     const url = await requestBuilder.url(defaultDestination);
     const expected = expect.stringMatching(
-      /TestFunctionImportMultipleParams\(.*StringParam.*\)?\$format=json/
+      /TestFunctionImportMultipleParams\(.*StringParam.*\)/
     );
     expect(url).toEqual(expected);
     expect(url).toContain(`StringParam='${params.stringParam}'`);

--- a/packages/odata-v4/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v4/src/request-builder/get-all-request-builder.spec.ts
@@ -33,14 +33,14 @@ describe('GetAllRequestBuilder', () => {
   describe('url', () => {
     it('is built correctly', async () => {
       const expected =
-        '/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$format=json';
+        '/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity';
       const actual = await requestBuilder.url(defaultDestination);
       expect(actual).toBe(expected);
     });
 
     it('is built correctly for nested expands', async () => {
       const expected =
-        '/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$format=json&$expand=to_MultiLink($expand=to_MultiLink1($expand=to_MultiLink2))';
+        '/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$expand=to_MultiLink($expand=to_MultiLink1($expand=to_MultiLink2))';
       const actual = await requestBuilder
         .expand(
           testEntityApi.schema.TO_MULTI_LINK.expand(
@@ -56,7 +56,7 @@ describe('GetAllRequestBuilder', () => {
 
   it('is built correctly for selects inside of an expand', async () => {
     const expected =
-      '/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$format=json&$expand=to_SingleLink($select=BooleanProperty)';
+      '/testination/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$expand=to_SingleLink($select=BooleanProperty)';
     const actual = await requestBuilder
       .expand(
         testEntityApi.schema.TO_SINGLE_LINK.select(

--- a/packages/odata-v4/src/request/odata-action-import-request-config.ts
+++ b/packages/odata-v4/src/request/odata-action-import-request-config.ts
@@ -37,9 +37,7 @@ export class ODataActionImportRequestConfig<
   }
 
   queryParameters(): Record<string, any> {
-    return {
-      ...this.prependDollarToQueryParameters({})
-    };
+    return {};
   }
 
   private buildHttpPayload(

--- a/packages/odata-v4/src/request/odata-action-import-request-config.ts
+++ b/packages/odata-v4/src/request/odata-action-import-request-config.ts
@@ -38,9 +38,7 @@ export class ODataActionImportRequestConfig<
 
   queryParameters(): Record<string, any> {
     return {
-      ...this.prependDollarToQueryParameters({
-        format: 'json'
-      })
+      ...this.prependDollarToQueryParameters({})
     };
   }
 

--- a/packages/odata-v4/src/request/odata-function-import-request-config.ts
+++ b/packages/odata-v4/src/request/odata-function-import-request-config.ts
@@ -45,6 +45,6 @@ export class ODataFunctionImportRequestConfig<
   }
 
   queryParameters(): Record<string, any> {
-    return this.prependDollarToQueryParameters({});
+    return {};
   }
 }

--- a/packages/odata-v4/src/request/odata-function-import-request-config.ts
+++ b/packages/odata-v4/src/request/odata-function-import-request-config.ts
@@ -45,8 +45,6 @@ export class ODataFunctionImportRequestConfig<
   }
 
   queryParameters(): Record<string, any> {
-    return this.prependDollarToQueryParameters({
-      format: 'json'
-    });
+    return this.prependDollarToQueryParameters({});
   }
 }

--- a/test-packages/e2e-tests/test/function.spec.ts
+++ b/test-packages/e2e-tests/test/function.spec.ts
@@ -14,7 +14,7 @@ describe('functions', () => {
     const request = returnSapCloudSdk({});
     it('should serialize url', async () => {
       expect(await request.url(destination)).toBe(
-        `${url}odata/test-service/returnSapCloudSdk()?$format=json`
+        `${url}odata/test-service/returnSapCloudSdk()`
       );
     });
 
@@ -39,7 +39,7 @@ describe('functions', () => {
 
     it('should serialize url', async () => {
       expect(await request.url(destination)).toBe(
-        `${url}odata/test-service/concatStrings(Str1='test',Str2='string')?$format=json`
+        `${url}odata/test-service/concatStrings(Str1='test',Str2='string')`
       );
     });
 

--- a/test-packages/integration-tests/test/test-data/batch/retrieve-request.ts
+++ b/test-packages/integration-tests/test/test-data/batch/retrieve-request.ts
@@ -5,7 +5,7 @@ export const getAllRequest = [
   'Content-Type: application/http',
   'Content-Transfer-Encoding: binary',
   '',
-  'GET /sap/opu/odata/sap/API_TEST_SRV/A_TestEntity\\?\\$format=json HTTP/1\\.1',
+  'GET /sap/opu/odata/sap/API_TEST_SRV/A_TestEntity HTTP/1\\.1',
   ...requestHeader(),
   '',
   ''
@@ -15,7 +15,7 @@ export const getByKeyRequest = [
   'Content-Type: application/http',
   'Content-Transfer-Encoding: binary',
   '',
-  `GET /sap/opu/odata/sap/API_TEST_SRV/A_TestEntity\\(KeyPropertyGuid=guid'\\${testEntityKeyPropGuid}',KeyPropertyString='\\${testEntityKeyPropString}'\\)\\?\\$format=json HTTP/1\\.1`,
+  `GET /sap/opu/odata/sap/API_TEST_SRV/A_TestEntity\\(KeyPropertyGuid=guid'\\${testEntityKeyPropGuid}',KeyPropertyString='\\${testEntityKeyPropString}'\\) HTTP/1\\.1`,
   ...requestHeader(),
   '',
   ''

--- a/test-packages/integration-tests/test/v2/complex-types.spec.ts
+++ b/test-packages/integration-tests/test/v2/complex-types.spec.ts
@@ -41,7 +41,7 @@ describe('Complex types', () => {
       }
     })
       .get(
-        `${servicePath}/${entityName}?$format=json&$filter=(ComplexTypeProperty/StringProperty%20eq%20%27someComplexTypeProperty%27)`
+        `${servicePath}/${entityName}?$filter=(ComplexTypeProperty/StringProperty%20eq%20%27someComplexTypeProperty%27)`
       )
       .reply(200, getAllResponse);
 
@@ -70,7 +70,7 @@ describe('Complex types', () => {
       }
     })
       .get(
-        `${servicePath}/${entityName}?$format=json&$orderby=ComplexTypeProperty/StringProperty%20asc`
+        `${servicePath}/${entityName}?$orderby=ComplexTypeProperty/StringProperty%20asc`
       )
       .reply(200, getAllResponse);
 

--- a/test-packages/integration-tests/test/v2/custom-fields.spec.ts
+++ b/test-packages/integration-tests/test/v2/custom-fields.spec.ts
@@ -51,7 +51,7 @@ describe('Custom Fields', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/${entityName}?$format=json`)
+      .get(`${servicePath}/${entityName}`)
       .reply(200, getAllResponseWithCustomField);
 
     const entities = await testEntityApi
@@ -73,7 +73,7 @@ describe('Custom Fields', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/${entityName}?$format=json&$select=MyCustomField`)
+      .get(`${servicePath}/${entityName}?$select=MyCustomField`)
       .reply(200, getAllResponseWithCustomField);
 
     const request = testEntityApi
@@ -97,7 +97,7 @@ describe('Custom Fields', () => {
       }
     })
       .get(
-        `${servicePath}/${entityName}?$format=json&$filter=(MyCustomField%20eq%20%27ToMatch%27)`
+        `${servicePath}/${entityName}?$filter=(MyCustomField%20eq%20%27ToMatch%27)`
       )
       .reply(200, getAllResponseWithCustomField);
 
@@ -129,7 +129,7 @@ describe('Custom Fields', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/${entityName}?$format=json`)
+      .get(`${servicePath}/${entityName}`)
       .reply(200, getAllResponseWithCustomField);
 
     nock(destination.url, {

--- a/test-packages/integration-tests/test/v2/function-imports.spec.ts
+++ b/test-packages/integration-tests/test/v2/function-imports.spec.ts
@@ -50,7 +50,7 @@ describe('Function imports', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/TestFunctionImportEdmReturnType?$format=json`)
+      .get(`${servicePath}/TestFunctionImportEdmReturnType`)
       .reply(200, singleTestEntityResponse());
 
     const request = functionImports
@@ -72,7 +72,7 @@ describe('Function imports', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/TestFunctionImportEdmReturnType?$format=json`)
+      .get(`${servicePath}/TestFunctionImportEdmReturnType`)
       .reply(400, errorResponse());
 
     const request = functionImports

--- a/test-packages/integration-tests/test/v2/mock-central-destination.spec.ts
+++ b/test-packages/integration-tests/test/v2/mock-central-destination.spec.ts
@@ -29,7 +29,7 @@ describe('mockAllTestDestinations', () => {
         'content-type': 'application/json'
       }
     })
-      .get('/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity?$format=json')
+      .get('/sap/opu/odata/sap/API_TEST_SRV/A_TestEntity')
       .reply(200, getAllResponse);
 
     const request = testEntityApi

--- a/test-packages/integration-tests/test/v2/request-builder.spec.ts
+++ b/test-packages/integration-tests/test/v2/request-builder.spec.ts
@@ -84,7 +84,7 @@ describe('Request Builder', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/${entityName}?$format=json`)
+      .get(`${servicePath}/${entityName}`)
       .reply(200, getAllResponse);
 
     const request = testEntityApi
@@ -102,7 +102,7 @@ describe('Request Builder', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/${entityName}?$format=json`)
+      .get(`${servicePath}/${entityName}`)
       .reply(200, getAllResponse);
 
     const request = testEntityApi.requestBuilder().getAll().execute({
@@ -127,7 +127,7 @@ describe('Request Builder', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/${entityName}?$format=json`)
+      .get(`${servicePath}/${entityName}`)
       .reply(200, getAllResponse);
 
     const request = testEntityApi
@@ -171,7 +171,7 @@ describe('Request Builder', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/${entityName}?$format=json`)
+      .get(`${servicePath}/${entityName}`)
       .reply(200, getAllResponse);
 
     const request = testEntityApi
@@ -195,7 +195,7 @@ describe('Request Builder', () => {
       }
     })
       .get(
-        `${servicePath}/${entityName}(KeyPropertyGuid=guid%27aaaabbbb-cccc-dddd-eeee-ffff00001111%27,KeyPropertyString=%27abcd%3F1234%27)?$format=json`
+        `${servicePath}/${entityName}(KeyPropertyGuid=guid%27aaaabbbb-cccc-dddd-eeee-ffff00001111%27,KeyPropertyString=%27abcd%3F1234%27)`
       )
       .reply(200, response);
 
@@ -216,7 +216,7 @@ describe('Request Builder', () => {
       }
     })
       .get(
-        `${servicePath}/${entityName}?$format=json&$select=*,to_SingleLink/*&$expand=to_SingleLink`
+        `${servicePath}/${entityName}?$select=*,to_SingleLink/*&$expand=to_SingleLink`
       )
       .reply(200, getAllResponse);
 
@@ -242,7 +242,7 @@ describe('Request Builder', () => {
       }
     })
       .get(
-        `${servicePath}/${entityName}(KeyPropertyGuid=guid%27aaaabbbb-cccc-dddd-eeee-ffff00001111%27,KeyPropertyString=%27abcd1234%27)?$format=json&$select=to_SingleLink/*&$expand=to_SingleLink`
+        `${servicePath}/${entityName}(KeyPropertyGuid=guid%27aaaabbbb-cccc-dddd-eeee-ffff00001111%27,KeyPropertyString=%27abcd1234%27)?$select=to_SingleLink/*&$expand=to_SingleLink`
       )
       .reply(200, response);
 
@@ -491,7 +491,7 @@ describe('Request Builder', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/${entityName}?$format=json`)
+      .get(`${servicePath}/${entityName}`)
       .reply(200, getAllResponse);
 
     const request = testEntityApi
@@ -516,7 +516,7 @@ describe('Request Builder', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/${entityName}?$format=json`)
+      .get(`${servicePath}/${entityName}`)
       .reply(200, getAllResponse);
 
     const request = testEntityApi
@@ -539,7 +539,6 @@ describe('Request Builder', () => {
     nock(destinationServiceUri)
       .get(`${servicePath}/${entityName}`)
       .query({
-        $format: 'json',
         testParameter: 'customcustom'
       })
       .reply(200, getAllResponse);
@@ -561,7 +560,6 @@ describe('Request Builder', () => {
     nock(destinationServiceUri)
       .get(`${servicePath}/${entityName}`)
       .query({
-        $format: 'json',
         testParameter: 'customcustom',
         additionalParameter: 'additional'
       })
@@ -635,7 +633,7 @@ describe('Request Builder', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/${entityName}?$format=json`)
+      .get(`${servicePath}/${entityName}`)
       .reply(200, {});
 
     const request = testEntityApi.requestBuilder().getAll().execute({

--- a/test-packages/integration-tests/test/v4/request-builder.spec.ts
+++ b/test-packages/integration-tests/test/v4/request-builder.spec.ts
@@ -59,7 +59,7 @@ describe('Request Builder', () => {
         'content-type': 'application/json'
       }
     })
-      .get(`${servicePath}/${entityName}?$format=json`)
+      .get(`${servicePath}/${entityName}`)
       .reply(200, getAllResponse);
 
     const request = testEntityApi

--- a/test-resources/test/test-util/request-mocker.ts
+++ b/test-resources/test/test-util/request-mocker.ts
@@ -154,7 +154,7 @@ export function mockGetRequest<T extends EntityApi<EntityBase, any>>(
     ...params,
     statusCode: params.statusCode || 200,
     method: params.method || 'get',
-    query: { $format: 'json', ...params.query }
+    query: params.query
   });
 }
 


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#55.

All occurrences of format json are removed. 
Documentations in knowledge base are updated.


<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->

TODO:

- [x] [cloud-sdk](https://github.com/SAP/cloud-sdk) Check `docs` in this repository. (SAP/cloud-sdk#750)
- [x] Run e2e test for internal odata v2 to make sure `.xml` is still an acceptable response.
