### PR TITLE
chore: Remove peerDeps in generated clients

### DIFF
--- a/packages/generator/src/service/package-json.spec.ts
+++ b/packages/generator/src/service/package-json.spec.ts
@@ -49,10 +49,6 @@ describe('package-json', () => {
       dependencies: {
         '@sap-cloud-sdk/odata-common': '^1.2.3',
         '@sap-cloud-sdk/odata-v2': '^1.2.3'
-      },
-      peerDependencies: {
-        '@sap-cloud-sdk/odata-common': '^1.2.3',
-        '@sap-cloud-sdk/odata-v2': '^1.2.3'
       }
     });
   });
@@ -85,10 +81,6 @@ describe('package-json', () => {
       description: 'my v4 package description',
       ...packageJsonStatic,
       dependencies: {
-        '@sap-cloud-sdk/odata-common': '^1.2.3',
-        '@sap-cloud-sdk/odata-v4': '^1.2.3'
-      },
-      peerDependencies: {
         '@sap-cloud-sdk/odata-common': '^1.2.3',
         '@sap-cloud-sdk/odata-v4': '^1.2.3'
       }

--- a/packages/generator/src/service/package-json.ts
+++ b/packages/generator/src/service/package-json.ts
@@ -46,10 +46,6 @@ export async function packageJson(
           '@sap-cloud-sdk/odata-common': `^${options.sdkVersion}`,
           [oDataModule]: `^${options.sdkVersion}`
         },
-        peerDependencies: {
-          '@sap-cloud-sdk/odata-common': `^${options.sdkVersion}`,
-          [oDataModule]: `^${options.sdkVersion}`
-        },
         devDependencies: {
           typescript: '~4.5'
         }

--- a/packages/openapi-generator/src/file-serializer/__snapshots__/package-json.spec.ts.snap
+++ b/packages/openapi-generator/src/file-serializer/__snapshots__/package-json.spec.ts.snap
@@ -27,9 +27,6 @@ exports[`packageJson returns the package.json content 1`] = `
   \\"dependencies\\": {
     \\"@sap-cloud-sdk/openapi\\": \\"^1.35.0\\"
   },
-  \\"peerDependencies\\": {
-    \\"@sap-cloud-sdk/openapi\\": \\"^1.35.0\\"
-  },
   \\"devDependencies\\": {
     \\"typescript\\": \\"~4.1.2\\"
   }

--- a/packages/openapi-generator/src/file-serializer/package-json.ts
+++ b/packages/openapi-generator/src/file-serializer/package-json.ts
@@ -23,9 +23,6 @@ export function packageJson(options: PackageJsonOptions): string {
         dependencies: {
           '@sap-cloud-sdk/openapi': `^${options.sdkVersion}`
         },
-        peerDependencies: {
-          '@sap-cloud-sdk/openapi': `^${options.sdkVersion}`
-        },
         devDependencies: {
           typescript: '~4.1.2'
         }

--- a/test-packages/test-services/openapi/no-schema-service/package.json
+++ b/test-packages/test-services/openapi/no-schema-service/package.json
@@ -24,9 +24,6 @@
   "dependencies": {
     "@sap-cloud-sdk/openapi": "^2.3.0"
   },
-  "peerDependencies": {
-    "@sap-cloud-sdk/openapi": "^2.3.0"
-  },
   "devDependencies": {
     "typescript": "~4.1.2"
   }

--- a/test-packages/test-services/openapi/swagger-yaml-service/package.json
+++ b/test-packages/test-services/openapi/swagger-yaml-service/package.json
@@ -24,9 +24,6 @@
   "dependencies": {
     "@sap-cloud-sdk/openapi": "^2.3.0"
   },
-  "peerDependencies": {
-    "@sap-cloud-sdk/openapi": "^2.3.0"
-  },
   "devDependencies": {
     "typescript": "~4.1.2"
   }

--- a/test-packages/test-services/openapi/test-service/package.json
+++ b/test-packages/test-services/openapi/test-service/package.json
@@ -24,9 +24,6 @@
   "dependencies": {
     "@sap-cloud-sdk/openapi": "^2.3.0"
   },
-  "peerDependencies": {
-    "@sap-cloud-sdk/openapi": "^2.3.0"
-  },
   "devDependencies": {
     "typescript": "~4.1.2"
   }


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

The peerDependencies are not necessary as the same dependencies are declared already.
