### PR TITLE
chore: disable dependabot for v1 main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    target-branch: 1.0-main
-    directory: '/'
-    schedule:
-      interval: daily
-      time: '01:00'
-      timezone: 'Europe/Berlin'
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: npm
     target-branch: main
     directory: '/'
     schedule:


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
