### PR TITLE
fix: fix windows test

### DIFF
--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -1,5 +1,5 @@
 import { PathLike } from 'fs';
-import { resolve, dirname } from 'path';
+import { resolve, dirname, sep, posix } from 'path';
 import {
   createLogger,
   ErrorWithCause,
@@ -199,7 +199,9 @@ async function generateAdditionalFiles(
     const additionalFilesDir = resolve(
       options.inputDir.toString(),
       options.additionalFiles
-    );
+    )
+      .split(sep)
+      .join(posix.sep);
     const serviceDir = resolvePath(service.directoryName, options);
     const files = new GlobSync(additionalFilesDir).found;
     await copyFiles(files, serviceDir, options.forceOverwrite);

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -1,4 +1,4 @@
-import { resolve, extname } from 'path';
+import { resolve, extname, posix, sep } from 'path';
 import { existsSync, lstatSync } from 'fs';
 import { GlobSync } from 'glob';
 import yargs from 'yargs';
@@ -53,7 +53,9 @@ export const generatorOptions = {
   include: {
     string: true,
     coerce: (input?: string): string[] | undefined =>
-      typeof input !== 'undefined' ? new GlobSync(input).found : undefined,
+      typeof input !== 'undefined'
+        ? new GlobSync(input.split(sep).join(posix.sep)).found
+        : undefined,
     description:
       'Include files matching the given glob into the root of each generated client directory.'
   },


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Glob package included option `allowWindowsEscape` (from `minimist` package) which always treats `\` in patterns as escapes, not path separators. They have recommended to use `/` as path separators. 
Because of this, the `new GlobSync(pattern)` stopped working as expected and couldn't find any files. 

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
