### PR TITLE
chore: only test node 14 for sdk 1.0

### DIFF
--- a/.github/workflows/1.0-build.yml
+++ b/.github/workflows/1.0-build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1


### PR DESCRIPTION
Apr. 30 is the last day of node 12 support.
Node [reference](https://nodejs.org/en/about/releases/).