### PR TITLE
fix: adjust wrong dependency name

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -28,8 +28,8 @@
     "eslint-config-prettier": "^8.0.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-parser": "^5.4.0",
-    "@typescript-eslint/eslint-plugin": "^5.4.0",
+    "@typescript-eslint/parser": "^5.21.0",
+    "@typescript-eslint/eslint-plugin": "^5.21.0",
     "eslint": "^8.0.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-unused-imports": "^2.0.0"


### PR DESCRIPTION
I just realized while doing the tutorial that we have a wrong peer dependency mentioned. Fails on installation in the project.
Correct name should be: https://www.npmjs.com/package/@typescript-eslint/parser