### PR TITLE
fix: Adjust how arguments are passed to jest

### DIFF
--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install --frozen-lockfile
-      - run: yarn test:unit --continue -- -- --json --outputFile=unit-test-output.json
-      - run: yarn test:integration -- -- --json --outputFile=int-test-output.json
+      - run: yarn test:unit --continue -- -- -- --json --outputFile=unit-test-output.json
+      - run: yarn test:integration -- -- -- --json --outputFile=int-test-output.json
         if: always()
       - run: yarn test:type
       - name: Archive results


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->
Seems like yarn or turborepo behave differently on windows and need additional `--` to pass the args to the actual executable.

If you have a windows computer, feel free to test the following commands (they work on mac but that didnt help with my previous fix):
- `yarn test:unit --continue -- -- -- --json --outputFile=unit-test-output.json`
- `yarn test:integration -- -- -- --json --outputFile=int-test-output.json`