### PR TITLE
chore: disable memory tests from PR builds

### DIFF
--- a/.github/workflows/memory-tests.yml
+++ b/.github/workflows/memory-tests.yml
@@ -1,7 +1,6 @@
 name: memory-tests
 
 on:
-  pull_request: ~
   workflow_dispatch:
   schedule:
     - cron: 0 21 * * *


### PR DESCRIPTION
It was enabled for testing on the initial PR, but should be removed now.