### PR TITLE
chore: revert the workspace scripts removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,22 @@
     "check:dependencies": "turbo run check:dependencies",
     "check:license": "ts-node scripts/check-licenses.ts",
     "check:test-service": "yarn generate --force && yarn ts-node scripts/check-test-service-for-changes.ts",
-    "check:public-api": "turbo run check:public-api"
+    "check:public-api": "turbo run check:public-api",
+    "connectivity": "yarn workspace @sap-cloud-sdk/connectivity",
+    "generator": "yarn workspace @sap-cloud-sdk/generator",
+    "generator-common": "yarn workspace @sap-cloud-sdk/generator-common",
+    "http-client": "yarn workspace @sap-cloud-sdk/http-client",
+    "openapi": "yarn workspace @sap-cloud-sdk/openapi",
+    "openapi-generator": "yarn workspace @sap-cloud-sdk/openapi-generator",
+    "odata-common": "yarn workspace @sap-cloud-sdk/odata-common",
+    "odata-v2": "yarn workspace @sap-cloud-sdk/odata-v2",
+    "odata-v4": "yarn workspace @sap-cloud-sdk/odata-v4",
+    "test-util": "yarn workspace @sap-cloud-sdk/test-util",
+    "util": "yarn workspace @sap-cloud-sdk/util",
+    "temporal-de-serializers": "yarn workspace @sap-cloud-sdk/temporal-de-serializers",
+    "e2e-tests": "yarn workspace @sap-cloud-sdk/e2e-tests",
+    "integration-tests": "yarn workspace @sap-cloud-sdk/integration-tests",
+    "type-tests": "yarn workspace @sap-cloud-sdk/type-tests"
   },
   "devDependencies": {
     "@changesets/cli": "^2.22.0",


### PR DESCRIPTION
The convenient scripts were removed.
I would like to keep them so I can e.g., start the e2e test app with a shorter command.