### PR TITLE
fix: canary release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,5 +5,8 @@
   "fixed": [["@sap-cloud-sdk/*"]],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
           date=`date +%Y%m%d%H%M%S`
-          rm .changeset *.md
+          rm .changeset/*.md
           cp canary-release-changeset.md .changeset
           yarn changeset pre enter {$date}
           yarn changeset version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,11 @@ jobs:
       - name: Canary Release
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
-          yarn changeset version --snapshot canary
+          date=`date +%Y%m%d%H%M%S`
+          rm .changeset *.md
+          cp canary-release-changeset.md .changeset
+          yarn changeset pre enter {$date}
+          yarn changeset version
           yarn changeset publish --tag canary
         env:
           NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Canary Release
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
-          date=`date +%Y%m%d%H%M%S`
+          yarn changeset version --snapshot canary
           yarn changeset publish --tag canary
         env:
           NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}

--- a/canary-release-changeset.md
+++ b/canary-release-changeset.md
@@ -1,0 +1,25 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+'@sap-cloud-sdk/eslint-config': patch
+'@sap-cloud-sdk/generator': patch
+'@sap-cloud-sdk/generator-common': patch
+'@sap-cloud-sdk/http-client': patch
+'@sap-cloud-sdk/odata-common': patch
+'@sap-cloud-sdk/odata-v2': patch
+'@sap-cloud-sdk/odata-v4': patch
+'@sap-cloud-sdk/openapi': patch
+'@sap-cloud-sdk/openapi-generator': patch
+'@sap-cloud-sdk/temporal-de-serializers': patch
+'@sap-cloud-sdk/test-util': patch
+'@sap-cloud-sdk/util': patch
+'@sap-cloud-sdk/e2e-tests': patch
+'@sap-cloud-sdk/integration-tests': patch
+'@sap-cloud-sdk/test-services-e2e': patch
+'@sap-cloud-sdk/test-services-odata-common': patch
+'@sap-cloud-sdk/test-services-odata-v2': patch
+'@sap-cloud-sdk/test-services-odata-v4': patch
+'@sap-cloud-sdk/test-services-openapi': patch
+'@sap-cloud-sdk/type-tests': patch
+---
+
+Canary release


### PR DESCRIPTION
Currently the canary release does nothing, because there is no [snapshot version id created](https://github.com/SAP/cloud-sdk-js/runs/6285802719?check_suite_focus=true):

![image](https://user-images.githubusercontent.com/56544999/166707812-81967b85-bea3-4320-b465-a3fb61ca71bf.png)


In this PR I used the [build in function of changeset](https://github.com/changesets/changesets/blob/main/docs/snapshot-releases.md).

However, this would lead to versions 0.0.0-{tag}-DATETIMESTAMP instead of 2.3.0-{tag}-DATETIMESTAMP. Since the tag is used to identify and all version are changed this should work:

![image](https://user-images.githubusercontent.com/56544999/166709939-a0aa8075-576d-4437-ac47-200170825f6c.png)

However I am not sure if this a beautiful thing to do. On the other hand if we start having separate version on the different packages it could become difficult to take the latest version and add some timestamp postfix since each package potentially has a different version.