### PR TITLE
fix: reuse check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14.x'
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v1.1
       - uses: actions/cache@v2
         id: cache
         with:
@@ -65,8 +67,6 @@ jobs:
         name: API Doc Check
       - run: yarn check:license
         name: License Check
-      - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v1.1
   e2e-tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

When running the check just after checkout, the irrelavant files (node_modules) would not be a problem.
See example [here](https://github.com/fsfe/reuse-action#example-usage).

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

<!-- Check List:
* Tests created/adjusted for your changes.
* Release notes updated.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
