### PR TITLE
fix: do not fail if files are not there

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
           date=`date +%Y%m%d%H%M%S`
-          rm .changeset/*.md
+          rm -f .changeset/*.md
           cp canary-release-changeset.md .changeset
           yarn changeset pre enter ${date}
           yarn changeset version


### PR DESCRIPTION
We had a small mistake, that if no changeset is there the `rm` fails in the canary release. This adds the `-f` option to it so this does not happen.