### PR TITLE
chore: pluralize the changelog headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 -
 
-## New Functionality
+## New Functionalities
 
 -
 

--- a/scripts/merge-changelogs.ts
+++ b/scripts/merge-changelogs.ts
@@ -120,12 +120,15 @@ function writeMessagesOfType(
         }`
     )
     .join('\n');
-  return `\n\n## ${type}\n\n${formatted}`;
+  
+  const pluralizedType = type.slice(-1) === 'y' ? type.slice(0, -1) + 'ies' : type + 's';
+  return `\n\n## ${pluralizedType}\n\n${formatted}`;
 }
 
 function createNewSection(version: string, messages: Change[]): string {
   return (
     writeHeader(version) +
+    writeMessagesOfType(messages, 'Known Issue') +
     writeMessagesOfType(messages, 'Compatibility Note') +
     writeMessagesOfType(messages, 'New Functionality') +
     writeMessagesOfType(messages, 'Improvement') +

--- a/scripts/merge-changelogs.ts
+++ b/scripts/merge-changelogs.ts
@@ -134,7 +134,7 @@ function createNewSection(version: string, messages: Change[]): string {
     writeMessagesOfType(messages, 'Improvement') +
     writeMessagesOfType(messages, 'Fixed Issue') +
     writeMessagesOfType(messages, 'Updated Dependencies') +
-    '\n'
+    '\n\n'
   );
 }
 


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

For example, the message type `Compatibility Note` will be transformed into the header `Compatibility Notes`.

Also, it seems that `Known Issue` was missing, so I added it. 

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
