### PR TITLE
Update GH actions to new node and new actions versions

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -10,7 +10,7 @@ jobs:
   push-to-documentation-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Add key
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -12,14 +12,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [14.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --depth=1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v2
+          node-version: 14
+      - uses: actions/cache@v3
         id: cache
         with:
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [12.x, 14.x]
+        node-version: [14, 16]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --depth=1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache
         with:
           path: |
@@ -38,14 +38,14 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --depth=1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 14
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1.1
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache
         with:
           path: |
@@ -70,12 +70,12 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --depth=1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
-      - uses: actions/cache@v2
+          node-version: 14
+      - uses: actions/cache@v3
         id: cache
         with:
           path: |
@@ -112,12 +112,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests, checks, e2e-tests]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --depth=1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
-      - uses: actions/cache@v2
+          node-version: 14
+      - uses: actions/cache@v3
         id: cache
         with:
           path: |
@@ -142,12 +142,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests, checks]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --depth=1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
-      - uses: actions/cache@v2
+          node-version: 14
+      - uses: actions/cache@v3
         id: cache
         with:
           path: |

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -7,13 +7,13 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
           ref: 'main'
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 14
       - run: yarn install --frozen-lockfile
       - name: Setup git
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.

--- a/.github/workflows/downloads.yml
+++ b/.github/workflows/downloads.yml
@@ -9,12 +9,12 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --depth=1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
-      - uses: actions/cache@v2
+          node-version: 14
+      - uses: actions/cache@v3
         id: cache
         with:
           path: |

--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Security rating'
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.3.4
       - uses: SAP/fosstars-rating-core-action@v1.3.0
         with:
           report-branch: fosstars-report

--- a/.github/workflows/memory-tests.yml
+++ b/.github/workflows/memory-tests.yml
@@ -9,11 +9,11 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
-      - uses: actions/cache@v2
+          node-version: 14
+      - uses: actions/cache@v3
         id: cache
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
           ref: 'main'
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 14
       - run: yarn install --frozen-lockfile
       - name: Version 1 Stable Release
         if: startsWith(github.ref, 'refs/tags/v1')
@@ -34,7 +34,7 @@ jobs:
         with:
           repository: SAP/cloud-sdk
           token: ${{ secrets.GH_DOCS_TOKEN }}
-          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.  
+          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
           path: ./cloud-sdk
       - name: Update release notes
         run: |

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -8,25 +8,21 @@ on:
 
 jobs:
   tests:
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
     timeout-minutes: 15
-    strategy:
-      matrix:
-        os: [windows-latest]
-        node-version: [14.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --depth=1
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 14
       - run: yarn install --frozen-lockfile
       - run: yarn test:unit --continue -- -- -- --json --outputFile=unit-test-output.json
       - run: yarn test:integration -- -- -- --json --outputFile=int-test-output.json
         if: always()
       - run: yarn test:type
       - name: Archive results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: windows-test-results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ API Docs: https://sap.github.io/cloud-sdk/api/2.4.0
   - `jsdoc/require-jsdoc`
   - `jsdoc/require-param`
   - `jsdoc/require-returns` (0a008674)
-- [connectivity, http-client] Only log the successful retrieval of destinations on the`info` log level, log everything else is on the `debug` or `warn` level. (04726a35)
+- [connectivity, http-client] Only log the successful retrieval of destinations on the `info` log level, log everything else as `debug` or `warn`. (04726a35)
 
 ## New Functionality
 


### PR DESCRIPTION
Currently the checks fail as puppeteer does not accept node v12. I updated the node versions and the actions versions. Not sure if we need to keep testing with node v12...