### PR TITLE
fix: only show warning when overwriting headers

### DIFF
--- a/.changeset/miss-schnitzel.md
+++ b/.changeset/miss-schnitzel.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/http-client': minor
+---
+
+[Fixed Issue] Fix the `executeHttpRequest`/`executeHttpRequestWithOrigin` function, so the warning is only shown when overwriting headers by using custom headers.

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -684,7 +684,9 @@ sap-client:001`);
             'sap-client': '001',
             'SAP-Connectivity-SCC-Location_ID': 'efg'
           },
-          requestConfig: {}
+          requestConfig: {
+            authorization: 'def'
+          }
         }
       };
       const logger = createLogger({
@@ -699,8 +701,6 @@ sap-client:001`);
         1,
         `The following custom headers will overwrite headers created by the SDK, if they use the same key:
   - "authorization"
-  - "sap-client"
-  - "SAP-Connectivity-SCC-Location_ID"
 If the parameters from multiple origins use the same key, the priority is 1. Custom, 2. Destination, 3. Internal.`
       );
     });


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Before, we list all the custom headers in the warning, however, not every header will overwrite something.
Now, we only show headers that are overwritten by custom headers.

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
