### PR TITLE
chore: record more download statistics

### DIFF
--- a/scripts/npm-stats.ts
+++ b/scripts/npm-stats.ts
@@ -26,18 +26,18 @@ async function getStatsForPackage(page, packageName) {
 
 async function getAllStats(page) {
   return [
-    '@sap-cloud-sdk/util', 
-    '@sap-cloud-sdk/connectivity', 
-    '@sap-cloud-sdk/http-client', 
+    '@sap-cloud-sdk/util',
+    '@sap-cloud-sdk/connectivity',
+    '@sap-cloud-sdk/http-client',
     '@sap-cloud-sdk/odata-v2',
     '@sap-cloud-sdk/odata-v4',
-    '@sap-cloud-sdk/generator'
+    '@sap-cloud-sdk/generator',
     '@sap-cloud-sdk/openapi',
     '@sap-cloud-sdk/openapi-generator',
-    '@sap-cloud-sdk/test-util', 
-    '@sap-cloud-sdk/eslint-confg', 
-    '@sap-cloud-sdk/temporal-de-serializers', 
-    '@sap-cloud-sdk/odata-common', 
+    '@sap-cloud-sdk/test-util',
+    '@sap-cloud-sdk/eslint-confg',
+    '@sap-cloud-sdk/temporal-de-serializers',
+    '@sap-cloud-sdk/odata-common',
     '@sap/cds'].reduce(
     async (stats, packageName) => ({
       ...(await stats),

--- a/scripts/npm-stats.ts
+++ b/scripts/npm-stats.ts
@@ -25,7 +25,20 @@ async function getStatsForPackage(page, packageName) {
 }
 
 async function getAllStats(page) {
-  return ['@sap-cloud-sdk/util', '@sap/cds'].reduce(
+  return [
+    '@sap-cloud-sdk/util', 
+    '@sap-cloud-sdk/connectivity', 
+    '@sap-cloud-sdk/http-client', 
+    '@sap-cloud-sdk/odata-v2',
+    '@sap-cloud-sdk/odata-v4',
+    '@sap-cloud-sdk/generator'
+    '@sap-cloud-sdk/openapi',
+    '@sap-cloud-sdk/openapi-generator',
+    '@sap-cloud-sdk/test-util', 
+    '@sap-cloud-sdk/eslint-confg', 
+    '@sap-cloud-sdk/temporal-de-serializers', 
+    '@sap-cloud-sdk/odata-common', 
+    '@sap/cds'].reduce(
     async (stats, packageName) => ({
       ...(await stats),
       [packageName]: await getStatsForPackage(page, packageName)


### PR DESCRIPTION
I added all the published packages to the list so we understand the trend of:
- our internal download
- `odata-v2` download
- `generator` download
- `connectivity` download