### PR TITLE
fix: type issue

### DIFF
--- a/packages/odata-common/src/filter/filterable.ts
+++ b/packages/odata-common/src/filter/filterable.ts
@@ -20,7 +20,7 @@ export type Filterable<
   DeSerializersT extends DeSerializers,
   LinkedEntityApiT extends EntityApi<EntityBase, DeSerializersT> = EntityApi<
     EntityBase,
-    DeSerializersT
+    any
   >
 > =
   | Filter<EntityT, DeSerializersT, any>

--- a/packages/odata-v4/src/entity.ts
+++ b/packages/odata-v4/src/entity.ts
@@ -3,6 +3,6 @@ import { EntityBase } from '@sap-cloud-sdk/odata-common/internal';
 /**
  * Super class for all representations of OData v4 entity types.
  */
-export abstract class Entity extends EntityBase {
+export class Entity extends EntityBase {
   readonly _oDataVersion: 'v4' = 'v4';
 }

--- a/test-packages/type-tests/test/v4/filters.spec.ts
+++ b/test-packages/type-tests/test/v4/filters.spec.ts
@@ -11,32 +11,12 @@ const schema = testEntityApi.schema;
 const singleLinkSchema = testEntitySingleLinkApi.schema;
 const multiLinkSchema = testEntityMultiLinkApi.schema;
 
-// -----------
-/*
-TODO: Fix the type issue for the following `and(...)` test
-It seems that `and()` is ignoring the type of DeSerializersT and treats it as `any`.
-Expected: FilterList<TestEntity<DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>>, DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>>
-Got:      FilterList<TestEntity<DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>>, any>
-
-The return type of `filter()` is correct:
-OneToManyLink<TestEntity<DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>>, DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>, TestEntityMultiLinkApi<DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>>>
-
-If we cast the return value of `filter()` into the expected type using `as`, the type is still `any` for DeSerializers.
-If we replace the third type parameter `TestEntityMultiLinkApi<...>` with `any`, the type will be correct.
-*/
-
-// import { and, any } from '@sap-cloud-sdk/odata-v4';
-// const { testEntityMultiLinkApi } = testService();
-// const multiLinkSchema = testEntityMultiLinkApi.schema;
-
-// // $ExpectType FilterList<TestEntity<DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>>, DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>>
-// and(
-//   schema.TO_MULTI_LINK.filter(
-//     any(multiLinkSchema.STRING_PROPERTY.equals('test'))
-//   )
-// );
-
-// -----------
+// $ExpectType FilterList<TestEntity<DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>>, DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>>
+and(
+  schema.TO_MULTI_LINK.filter(
+    any(multiLinkSchema.STRING_PROPERTY.equals('test'))
+  )
+);
 
 // $ExpectType Filter<TestEntity<DeSerializers<any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any>>, DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>, string>
 schema.ENUM_PROPERTY.equals('Member1');

--- a/test-packages/type-tests/test/v4/filters.spec.ts
+++ b/test-packages/type-tests/test/v4/filters.spec.ts
@@ -18,6 +18,11 @@ and(
   )
 );
 
+// $ExpectType FilterList<TestEntity<DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>>, DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>>
+and(
+  schema?.TO_SINGLE_LINK.filter(singleLinkSchema.STRING_PROPERTY.equals('test'))
+);
+
 // $ExpectType Filter<TestEntity<DeSerializers<any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any, any>>, DeSerializers<string, boolean, number, BigNumber, number, number, number, number, BigNumber, string, number, number, string, any, Moment, Moment, Duration, Time, any>, string>
 schema.ENUM_PROPERTY.equals('Member1');
 


### PR DESCRIPTION
Closes SAP/cloud-sdk-backlog#691.
 
So I give up, I do not understand why it works for V2 and not for v4 on a deep level. The change to the `Entity` in this PR  was not relevant. On the play ground I did the following:
- Create a minimal example for an Entity with a single 1:1 nav prop no enum, complex type what so ever
- Align deserializers for v2 and v4 and types
- Remove one-to-many type also from filterable
- Align entity (version is v2 for both)

The error remains only for v4 not for v2 using the reduced example.

I knew from the investigation and tests that the default value set to any fixes it, but this leaves a bitter taste because I do not see why, WHY, WHYYYY but I have to accept that I do not see the reason.....