### PR TITLE
chore: Pluralize headings release Note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ API Docs: https://sap.github.io/cloud-sdk/api/2.5.0
 
 API Docs: https://sap.github.io/cloud-sdk/api/2.4.0
 
-## Compatibility Note
+## Compatibility Notes
 
 - [connectivity] Mark the function `noDestinationErrorMessage` as internal API. (0a008674)
 - [odata-v4] Mark the function `uriConverter` as internal API. (0a008674)
@@ -63,11 +63,11 @@ API Docs: https://sap.github.io/cloud-sdk/api/2.4.0
 
 - [connectivity] Support self-signed certificate using the `trustStore` property of the destination object. (0a008674)
 
-## Improvement
+## Improvements
 
 - [connectivity, http-client] Reduce default log output on the `info` level significantly. (04726a35)
 
-## Fixed Issue
+## Fixed Issues
 
 - [util] Fix a bug in the implementation of the trim method. (0a008674)
 


### PR DESCRIPTION
Relates to: https://github.com/SAP/cloud-sdk-backlog/issues/751

Just added a s for some heading in the release notes.