### PR TITLE
chore: add a test for special char in http client

### DIFF
--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -228,7 +228,7 @@ describe('generic http client', () => {
       })
         .get('/api/entity')
         .query({
-          a: 'a',
+          '$a': 'a',
           b: 'b'
         })
         .reply(200, { res: 'ult' }, { sharp: 'header' });
@@ -238,7 +238,7 @@ describe('generic http client', () => {
         method: 'GET',
         url: '/api/entity',
         params: {
-          a: 'a',
+          '$a': 'a',
           b: 'b'
         }
       };

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -228,7 +228,7 @@ describe('generic http client', () => {
       })
         .get('/api/entity')
         .query({
-          '$a': 'a',
+          $a: 'a',
           b: 'b'
         })
         .reply(200, { res: 'ult' }, { sharp: 'header' });
@@ -238,7 +238,7 @@ describe('generic http client', () => {
         method: 'GET',
         url: '/api/entity',
         params: {
-          '$a': 'a',
+          $a: 'a',
           b: 'b'
         }
       };


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

An explicit test is added for testing `$abc` as a key of query parameter of the http client, although it was covered by the odata cases.

related to: https://github.com/SAP/cloud-sdk-js/issues/2561

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
