### PR TITLE
reproduce #2606

### DIFF
--- a/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
@@ -35,6 +35,9 @@ import {
 } from '../../test/test-util';
 import { DefaultDeSerializers } from '../de-serializers';
 import { GetAllRequestBuilder } from './get-all-request-builder';
+import {
+  testService
+} from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 
 describe('GetAllRequestBuilder', () => {
   let requestBuilder: GetAllRequestBuilder<TestEntity, DefaultDeSerializers>;
@@ -144,6 +147,8 @@ describe('GetAllRequestBuilder', () => {
     });
 
     it('test #2606', async () => {
+      const api = testService().testEntityApi;
+      const rB = new GetAllRequestBuilder(api);
       mockGetRequest(
         {
           responseBody: { d: { results: [
@@ -158,9 +163,9 @@ describe('GetAllRequestBuilder', () => {
                 }
             ] } }
         },
-        testEntityApi
+        api
       );
-      const actual = await requestBuilder.execute(defaultDestination);
+      const actual = await rB.execute(defaultDestination);
       expect(actual[0].toMultiLink[0].toMultiLink[0].stringProperty).toEqual('string');
     });
 

--- a/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
@@ -38,6 +38,17 @@ import { GetAllRequestBuilder } from './get-all-request-builder';
 import {
   testService
 } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
+import { testService as testServiceV4 } from '../../../../test-packages/test-services-odata-v2/test-service/service'
+
+describe('OData Client Service', () =>{
+  it('should contain schemas in nested apis', ()=>{
+    const {
+      testEntityCircularLinkParentApi,
+      testEntityCircularLinkChildApi
+    } = testServiceV4();
+    expect(testEntityCircularLinkParentApi.schema.TO_CHILD._linkedEntityApi.schema.TO_PARENT._linkedEntityApi.schema.TO_CHILD._linkedEntityApi.schema).toBeTruthy();
+  });
+});
 
 describe('GetAllRequestBuilder', () => {
   let requestBuilder: GetAllRequestBuilder<TestEntity, DefaultDeSerializers>;

--- a/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
@@ -28,6 +28,7 @@ import { parseDestination } from '../../../connectivity/src/scp-cf/destination/d
 import {
   testEntityApi,
   testEntitySingleLinkApi,
+  testEntityLvl2MultiLinkApi,
   createTestEntity,
   testEntityApiCustom,
   createTestEntityWithCustomDeSerializers
@@ -140,6 +141,27 @@ describe('GetAllRequestBuilder', () => {
       );
       const actual = await requestBuilder.skip(1).execute(defaultDestination);
       expect(actual).toEqual([createTestEntity(entityData2)]);
+    });
+
+    it('test #2606', async () => {
+      mockGetRequest(
+        {
+          responseBody: { d: { results: [
+                {
+                  to_MultiLink: {
+                    results: [{
+                      to_MultiLink: {
+                        results: [{
+                          StringProperty: 'string'
+                        }]}
+                    }]}
+                }
+            ] } }
+        },
+        testEntityApi
+      );
+      const actual = await requestBuilder.execute(defaultDestination);
+      expect(actual[0].toMultiLink[0].toMultiLink[0].stringProperty).toEqual('string');
     });
 
     it('throws an error when the destination cannot be found', async () => {

--- a/packages/odata-v2/test/test-util/test-data.ts
+++ b/packages/odata-v2/test/test-util/test-data.ts
@@ -10,12 +10,12 @@ import {
 } from '../../../../test-resources/test/test-util';
 
 export const {
-   testEntityApi,
-   testEntityMultiLinkApi,
-   testEntitySingleLinkApi,
-   testEntityLvl2MultiLinkApi,
-   testEntityLvl2SingleLinkApi
- } = testService();
+  testEntityApi,
+  testEntityMultiLinkApi,
+  testEntitySingleLinkApi,
+  testEntityLvl2MultiLinkApi,
+  testEntityLvl2SingleLinkApi
+} = testService();
 
 export const { testEntityApi: testEntityApiCustom } = testService(
   customTestDeSerializers

--- a/packages/odata-v2/test/test-util/test-data.ts
+++ b/packages/odata-v2/test/test-util/test-data.ts
@@ -9,13 +9,13 @@ import {
   customTestDeSerializers
 } from '../../../../test-resources/test/test-util';
 
-const service = testService();
-
-export const testEntityApi = service.testEntityApi;
-export const testEntityMultiLinkApi = service.testEntityMultiLinkApi;
-export const testEntitySingleLinkApi = service.testEntitySingleLinkApi;
-export const testEntityLvl2MultiLinkApi = service.testEntityLvl2MultiLinkApi;
-export const testEntityLvl2SingleLinkApi = service.testEntityLvl2SingleLinkApi;
+export const {
+   testEntityApi,
+   testEntityMultiLinkApi,
+   testEntitySingleLinkApi,
+   testEntityLvl2MultiLinkApi,
+   testEntityLvl2SingleLinkApi
+ } = testService();
 
 export const { testEntityApi: testEntityApiCustom } = testService(
   customTestDeSerializers

--- a/packages/odata-v2/test/test-util/test-data.ts
+++ b/packages/odata-v2/test/test-util/test-data.ts
@@ -11,11 +11,11 @@ import {
 
 const testService = testService();
 
-export testEntityApi = testService.testEntityApi;
-export testEntityMultiLinkApi = testService.testEntityMultiLinkApi;
-export testEntitySingleLinkApi = testService.testEntitySingleLinkApi;
-export testEntityLvl2MultiLinkApi = testService.testEntityLvl2MultiLinkApi;
-export testEntityLvl2SingleLinkApi = testService.testEntityLvl2SingleLinkApi;
+export const testEntityApi = testService.testEntityApi;
+export const testEntityMultiLinkApi = testService.testEntityMultiLinkApi;
+export const testEntitySingleLinkApi = testService.testEntitySingleLinkApi;
+export const testEntityLvl2MultiLinkApi = testService.testEntityLvl2MultiLinkApi;
+export const testEntityLvl2SingleLinkApi = testService.testEntityLvl2SingleLinkApi;
 
 export const { testEntityApi: testEntityApiCustom } = testService(
   customTestDeSerializers

--- a/packages/odata-v2/test/test-util/test-data.ts
+++ b/packages/odata-v2/test/test-util/test-data.ts
@@ -9,13 +9,13 @@ import {
   customTestDeSerializers
 } from '../../../../test-resources/test/test-util';
 
-const testService = testService();
+const service = testService();
 
-export const testEntityApi = testService.testEntityApi;
-export const testEntityMultiLinkApi = testService.testEntityMultiLinkApi;
-export const testEntitySingleLinkApi = testService.testEntitySingleLinkApi;
-export const testEntityLvl2MultiLinkApi = testService.testEntityLvl2MultiLinkApi;
-export const testEntityLvl2SingleLinkApi = testService.testEntityLvl2SingleLinkApi;
+export const testEntityApi = service.testEntityApi;
+export const testEntityMultiLinkApi = service.testEntityMultiLinkApi;
+export const testEntitySingleLinkApi = service.testEntitySingleLinkApi;
+export const testEntityLvl2MultiLinkApi = service.testEntityLvl2MultiLinkApi;
+export const testEntityLvl2SingleLinkApi = service.testEntityLvl2SingleLinkApi;
 
 export const { testEntityApi: testEntityApiCustom } = testService(
   customTestDeSerializers

--- a/packages/odata-v2/test/test-util/test-data.ts
+++ b/packages/odata-v2/test/test-util/test-data.ts
@@ -9,13 +9,13 @@ import {
   customTestDeSerializers
 } from '../../../../test-resources/test/test-util';
 
-export const {
-  testEntityApi,
-  testEntityMultiLinkApi,
-  testEntitySingleLinkApi,
-  testEntityLvl2MultiLinkApi,
-  testEntityLvl2SingleLinkApi
-} = testService();
+const testService = testService();
+
+export testEntityApi = testService.testEntityApi;
+export testEntityMultiLinkApi = testService.testEntityMultiLinkApi;
+export testEntitySingleLinkApi = testService.testEntitySingleLinkApi;
+export testEntityLvl2MultiLinkApi = testService.testEntityLvl2MultiLinkApi;
+export testEntityLvl2SingleLinkApi = testService.testEntityLvl2SingleLinkApi;
 
 export const { testEntityApi: testEntityApiCustom } = testService(
   customTestDeSerializers


### PR DESCRIPTION
We use the following code for almost all the tests:
```ts
export const {
  testEntityApi,
  testEntityMultiLinkApi,
  testEntitySingleLinkApi,
  testEntityLvl2MultiLinkApi,
  testEntityLvl2SingleLinkApi
} = testService();
```
However, this hides the bug in #2606.

This PR reproduces the issue by using different code:
```ts
import {
   testService
 } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
const api = testService().testEntityApi;
```
