### PR TITLE
chore: add schema tests

### DIFF
--- a/test-packages/integration-tests/test/v2/service.spec.ts
+++ b/test-packages/integration-tests/test/v2/service.spec.ts
@@ -1,0 +1,11 @@
+import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
+
+describe('OData Client Service', () => {
+  it('should contain schemas in nested apis', () => {
+    const { testEntityApi, testEntityMultiLinkApi } = testService();
+    expect(
+      testEntityApi.schema?.TO_MULTI_LINK._linkedEntityApi.schema.TO_MULTI_LINK
+        ._linkedEntityApi.schema.STRING_PROPERTY
+    ).toBeTruthy();
+  });
+});

--- a/test-packages/integration-tests/test/v4/service.spec.ts
+++ b/test-packages/integration-tests/test/v4/service.spec.ts
@@ -1,0 +1,12 @@
+import { testService } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
+
+describe('OData Client Service', () => {
+  it('should contain schemas when having circular navigation properties', () => {
+    const { testEntityCircularLinkParentApi, testEntityCircularLinkChildApi } =
+      testService();
+    expect(
+      testEntityCircularLinkParentApi.schema.TO_CHILDREN._linkedEntityApi.schema
+        .TO_PARENT._linkedEntityApi.schema
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Related to: #2606 
The deserialisation problem of the linked issue was related to the schema, where navigation properties were missing.
This PR adds some test for covering such cases.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
