### PR TITLE
Fetch token for destinations from service bindings

### DIFF
--- a/.changeset/tidy-planets-collect.md
+++ b/.changeset/tidy-planets-collect.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[New Functionality] Fetch client credential token for destinations created by service bindings.

--- a/packages/connectivity/src/scp-cf/destination/__snapshots__/destination-from-vcap.spec.ts.snap
+++ b/packages/connectivity/src/scp-cf/destination/__snapshots__/destination-from-vcap.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`vcap-service-destination throws an error if no service binding can be found for the given name 1`] = `
-"Unable to find a service binding for given name \\"non-existent-service\\"! Found the following bindings: my-business-logging, my-custom-service, S4_SYSTEM.
+"Unable to find a service binding for given name \\"non-existent-service\\"! Found the following bindings: my-xsuaa, my-business-logging, my-workflow, my-destination-service, my-custom-service, my-s4-hana-cloud, my-saas-registry.
       "
 `;
 

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
@@ -6,7 +6,8 @@ import {
   providerServiceToken,
   subscriberServiceToken,
   subscriberUserJwt,
-  unmockDestinationsEnv
+  unmockDestinationsEnv,
+  xsuaaBindingMock
 } from '../../../../../test-resources/test/test-util';
 import {
   DestinationWithName,
@@ -67,7 +68,9 @@ describe('register-destination', () => {
     await expect(
       registerDestinationCache
         .getCacheInstance()
-        .hasKey('provider::RegisteredDestination')
+        .hasKey(
+          `${xsuaaBindingMock.credentials.subaccountid}::RegisteredDestination`
+        )
     ).resolves.toBe(true);
   });
 
@@ -125,7 +128,10 @@ describe('register-destination', () => {
 
   it('adds the auth token if forwardAuthToken is enabled', async () => {
     registerDestination(destinationWithForwarding);
-    const jwtPayload: JwtPayload = { exp: 1234, zid: 'provider' };
+    const jwtPayload: JwtPayload = {
+      exp: 1234,
+      zid: xsuaaBindingMock.credentials.subaccountid
+    };
     const jwtHeader: JwtHeader = { alg: 'HS256' };
 
     const payloadEncoded = base64url(JSON.stringify(jwtPayload));

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
@@ -1,7 +1,6 @@
 import { createLogger } from '@sap-cloud-sdk/util';
 import { decodeJwt } from '../jwt';
 import { getXsuaaServiceCredentials } from '../environment-accessor';
-import { parseSubdomain } from '../subdomain-replacer';
 import { Destination, DestinationAuthToken } from './destination-service-types';
 import { DestinationFetchOptions } from './destination-accessor-types';
 import {
@@ -127,16 +126,16 @@ function isolationStrategy(
  * @param options - Options passed to register the destination containing the jwt.
  * @returns The decoded JWT or a dummy JWT containing the tenant identifier (zid).
  */
-function decodedJwtOrZid(
+export function decodedJwtOrZid(
   options?: RegisterDestinationOptions
 ): Record<string, any> {
   if (options?.jwt) {
     return decodeJwt(options.jwt);
   }
 
-  const providerTenantId = parseSubdomain(
-    getXsuaaServiceCredentials(options?.jwt).url
-  );
+  const providerTenantId = getXsuaaServiceCredentials(
+    options?.jwt
+  ).subaccountid;
 
   return { zid: providerTenantId };
 }

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
@@ -1,36 +1,125 @@
+import {
+  mockServiceToken,
+  providerUserPayload,
+  xsuaaBindingMock
+} from '../../../../../test-resources/test/test-util';
+import * as tokenAccessor from '../token-accessor';
 import { getDestination } from './destination-accessor';
 import {
   destinationForServiceBinding,
   ServiceBinding
 } from './destination-from-vcap';
+import { destinationCache } from './destination-cache';
 
 describe('vcap-service-destination', () => {
+  const spy = jest.spyOn(tokenAccessor, 'serviceToken');
+
+  beforeAll(() => {
+    mockServiceToken();
+  });
+
   beforeEach(() => {
     mockServiceBindings();
   });
 
   afterEach(() => {
     delete process.env.VCAP_SERVICES;
+    jest.clearAllMocks();
   });
 
   it('creates a destination for the business logging service', async () => {
     await expect(
-      destinationForServiceBinding('my-business-logging')
+      destinationForServiceBinding('my-business-logging', {
+        jwt: providerUserPayload
+      })
     ).resolves.toEqual({
       url: 'https://business-logging.my.example.com',
       authentication: 'OAuth2ClientCredentials',
-      username: 'CLIENT_!_|_!_ID',
-      password: 'PASSWORD'
+      name: 'my-business-logging',
+      authTokens: [expect.objectContaining({ value: expect.any(String) })]
     });
+    expect(spy.mock.calls[0][0]['credentials']['clientid']).toBe(
+      'clientIdBusinessLogging'
+    );
+  });
+
+  it('creates a destination for the destination service', async () => {
+    await expect(
+      destinationForServiceBinding('my-destination-service', {
+        jwt: providerUserPayload
+      })
+    ).resolves.toEqual({
+      url: 'https://destination-configuration.cfapps.sap.hana.ondemand.com',
+      authentication: 'OAuth2ClientCredentials',
+      name: 'my-destination-service',
+      authTokens: [expect.objectContaining({ value: expect.any(String) })]
+    });
+    expect(spy.mock.calls[0][0]['credentials']['clientid']).toBe(
+      'clientIdDestination'
+    );
+  });
+
+  it('creates a destination for the saas registry', async () => {
+    await expect(
+      destinationForServiceBinding('my-saas-registry', {
+        jwt: providerUserPayload
+      })
+    ).resolves.toEqual({
+      url: 'https://saas-manager.mesh.cf.sap.hana.ondemand.com',
+      authentication: 'OAuth2ClientCredentials',
+      name: 'my-saas-registry',
+      authTokens: [expect.objectContaining({ value: expect.any(String) })]
+    });
+    expect(spy.mock.calls[0][0]['credentials']['clientid']).toBe(
+      'clientIdSaasRegistry'
+    );
+  });
+
+  it('creates a destination for the workflow', async () => {
+    await expect(
+      destinationForServiceBinding('my-workflow', {
+        jwt: providerUserPayload
+      })
+    ).resolves.toEqual({
+      url: 'https://api.workflow-sap.cfapps.sap.hana.ondemand.com/workflow-service/odata',
+      authentication: 'OAuth2ClientCredentials',
+      name: 'my-workflow',
+      authTokens: [expect.objectContaining({ value: expect.any(String) })]
+    });
+    expect(spy.mock.calls[0][0]['credentials']['clientid']).toBe(
+      'clientIdWorkFlow'
+    );
   });
 
   it('creates a destination for the XF s4 hana cloud service', async () => {
-    await expect(destinationForServiceBinding('S4_SYSTEM')).resolves.toEqual({
+    await expect(
+      destinationForServiceBinding('my-s4-hana-cloud')
+    ).resolves.toEqual({
       url: 'https://my.example.com',
       authentication: 'BasicAuthentication',
       username: 'USER_NAME',
       password: 'PASSWORD'
     });
+  });
+
+  it('uses the cache if enabled', async () => {
+    await destinationCache.clear();
+
+    await destinationForServiceBinding('my-destination-service', {
+      useCache: true,
+      jwt: providerUserPayload
+    });
+    await destinationForServiceBinding('my-destination-service', {
+      useCache: true,
+      jwt: providerUserPayload
+    });
+
+    expect(spy).toBeCalledTimes(1);
+    expect(
+      destinationCache
+        .getCacheInstance()
+        .get(`${providerUserPayload.zid}::my-destination`)
+    ).toBeDefined();
   });
 
   it('creates a destination using a custom transformation function', async () => {
@@ -93,15 +182,53 @@ function mockServiceBindings() {
 }
 
 const serviceBindings = {
+  xsuaa: [xsuaaBindingMock],
   'business-logging': [
     {
       name: 'my-business-logging',
+      label: 'business-logging',
+      tags: [
+        'business-logging',
+        'logging',
+        'com.sap.appbasic.businesslogs',
+        'comsapappbasicbusinesslogs'
+      ],
       credentials: {
         writeUrl: 'https://business-logging.my.example.com',
         uaa: {
-          clientid: 'CLIENT_!_|_!_ID',
+          clientid: 'clientIdBusinessLogging',
           clientsecret: 'PASSWORD'
         }
+      }
+    }
+  ],
+  workflow: [
+    {
+      name: 'my-workflow',
+      label: 'workflow',
+      tags: [],
+      credentials: {
+        endpoints: {
+          workflow_odata_url:
+            'https://api.workflow-sap.cfapps.sap.hana.ondemand.com/workflow-service/odata',
+          workflow_rest_url:
+            'https://api.workflow-sap.cfapps.sap.hana.ondemand.com/workflow-service/rest'
+        },
+        uaa: {
+          clientid: 'clientIdWorkFlow',
+          clientsecret: 'PASSWORD'
+        }
+      }
+    }
+  ],
+  destination: [
+    {
+      name: 'my-destination-service',
+      label: 'destination',
+      credentials: {
+        clientid: 'clientIdDestination',
+        clientsecret: 'PASSWORD',
+        uri: 'https://destination-configuration.cfapps.sap.hana.ondemand.com'
       }
     }
   ],
@@ -115,11 +242,23 @@ const serviceBindings = {
   ],
   's4-hana-cloud': [
     {
-      name: 'S4_SYSTEM',
+      name: 'my-s4-hana-cloud',
+      label: 's4-hana-cloud',
       credentials: {
         Password: 'PASSWORD',
         URL: 'https://my.example.com',
         User: 'USER_NAME'
+      }
+    }
+  ],
+  'saas-registry': [
+    {
+      label: 'saas-registry',
+      name: 'my-saas-registry',
+      credentials: {
+        clientid: 'clientIdSaasRegistry',
+        clientsecret: 'PASSWORD',
+        saas_registry_url: 'https://saas-manager.mesh.cf.sap.hana.ondemand.com'
       }
     }
   ]

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -35,7 +35,7 @@ describe('OAuth flows', () => {
     destinationService = getService('destination');
   });
 
-  it('creates a destination from service binding and gets a client credentials grant', async () => {
+  xit('creates a destination from service binding and gets a client credentials grant', async () => {
     let destination = await getDestination({
       destinationName: 'destination-js-sdk'
     });

--- a/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
+++ b/test-packages/integration-tests/test/auth-flows/auth-flow.spec.ts
@@ -35,6 +35,36 @@ describe('OAuth flows', () => {
     destinationService = getService('destination');
   });
 
+  it('creates a destination from service binding and gets a client credentials grant', async () => {
+    let destination = await getDestination({
+      destinationName: 'destination-js-sdk'
+    });
+    expect(destination?.authTokens![0].value).toBeDefined();
+    expect(destination?.url).toBeDefined();
+
+    destination = await getDestination({
+      destinationName: 'business-logging-js-sdk'
+    });
+    expect(destination?.authTokens![0].value).toBeDefined();
+    expect(destination?.url).toBeDefined();
+
+    destination = await getDestination({
+      destinationName: 's4-hana-cloud-js-sdk'
+    });
+    expect(destination?.username).toBeDefined();
+    expect(destination?.url).toBeDefined();
+
+    destination = await getDestination({
+      destinationName: 'saas-registry-js-sdk'
+    });
+    expect(destination?.authTokens![0].value).toBeDefined();
+    expect(destination?.url).toBeDefined();
+
+    destination = await getDestination({ destinationName: 'workflow-js-sdk' });
+    expect(destination?.authTokens![0].value).toBeDefined();
+    expect(destination?.url).toBeDefined();
+  }, 60000);
+
   xit('get assertion test', async () => {
     const destination = await getDestination({
       destinationName: systems.s4.providerSamlAssertion,

--- a/test-resources/test/test-util/environment-mocks.ts
+++ b/test-resources/test/test-util/environment-mocks.ts
@@ -33,7 +33,10 @@ export const xsuaaBindingMock: Service = {
     clientid: 'clientid',
     clientsecret: 'clientsecret',
     verificationkey: publicKey,
-    uaadomain: 'authentication.sap.hana.ondemand.com'
+    uaadomain: 'authentication.sap.hana.ondemand.com',
+    subaccountid: "a89ea924-d9c2-4eab-84fb-3ffcaadf5d24",
+    tenantid: "a89ea924-d9c2-4eab-84fb-3ffcaadf5d24",
+    zoneid: "a89ea924-d9c2-4eab-84fb-3ffcaadf5d24"
   }
 };
 


### PR DESCRIPTION
Closes SAP/cloud-sdk-backlog#572.

If necessary a client credential token is fetched when a destination is constructed for the service binding. Support services are currently: workflow, s4-hana-cloud, business-logging, destiantion, saas-registry. Cacheing is added to the service binding destinations as well.

I also adjusted the the cache key for the register destination to use the id instead of the domain. This feels safer because the id is unique for suere. Domain should also be unique but you never know.
