### PR TITLE
fix: move xsuaa only when cache is needed

### DIFF
--- a/packages/connectivity/src/scp-cf/destination/__snapshots__/destination-from-vcap.spec.ts.snap
+++ b/packages/connectivity/src/scp-cf/destination/__snapshots__/destination-from-vcap.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`vcap-service-destination throws an error if no service binding can be found for the given name 1`] = `
-"Unable to find a service binding for given name \\"non-existent-service\\"! Found the following bindings: my-xsuaa, my-business-logging, my-workflow, my-destination-service, my-custom-service, my-s4-hana-cloud, my-saas-registry, my-service-manager.
+"Unable to find a service binding for given name \\"non-existent-service\\"! Found the following bindings: my-business-logging, my-workflow, my-destination-service, my-custom-service, my-s4-hana-cloud, my-saas-registry, my-service-manager.
       "
 `;
 

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
@@ -1,7 +1,6 @@
 import {
   mockServiceToken,
-  providerUserPayload,
-  xsuaaBindingMock
+  providerUserPayload
 } from '../../../../../test-resources/test/test-util';
 import * as tokenAccessor from '../token-accessor';
 import { getDestination } from './destination-accessor';
@@ -195,7 +194,6 @@ function mockServiceBindings() {
 }
 
 const serviceBindings = {
-  xsuaa: [xsuaaBindingMock],
   'business-logging': [
     {
       name: 'my-business-logging',

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
@@ -226,10 +226,12 @@ export async function searchServiceBindingForDestination({
   logger.debug('Attempting to retrieve destination from service binding.');
   try {
     const jwtFromOptions = iss ? { iss } : jwt ? decodeJwt(jwt) : undefined;
+    const useCacheIgnoringUndefined =
+      typeof useCache !== 'undefined' ? { useCache } : {};
     const destination = await destinationForServiceBinding(destinationName, {
       serviceBindingTransformFn,
       jwt: jwtFromOptions,
-      useCache: !!useCache
+      ...useCacheIgnoringUndefined
     });
     logger.info('Successfully retrieved destination from service binding.');
     return destination;

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
@@ -54,8 +54,8 @@ export async function destinationForServiceBinding(
   const serviceBindings = loadServiceBindings();
   const selected = findServiceByName(serviceBindings, serviceInstanceName);
   const destination = options.serviceBindingTransformFn
-    ? await options.serviceBindingTransformFn(selected, options.jwt)
-    : await transform(selected, options.jwt);
+    ? await options.serviceBindingTransformFn(selected, options)
+    : await transform(selected, options);
 
   const destWithProxy =
     destination &&
@@ -92,7 +92,7 @@ export interface DestinationForServiceBindingsOptions {
  */
 export type ServiceBindingTransformFunction = (
   serviceBinding: ServiceBinding,
-  jwt?: JwtPayload
+  options?: PartialDestinationFetchOptions
 ) => Promise<Destination>;
 
 /**
@@ -165,7 +165,7 @@ function findServiceByName(
 
 async function transform(
   serviceBinding: ServiceBinding,
-  jwt?: JwtPayload
+  options?: PartialDestinationFetchOptions
 ): Promise<Destination> {
   if (!serviceToDestinationTransformers[serviceBinding.type]) {
     throw serviceTypeNotSupportedError(serviceBinding.type);
@@ -173,7 +173,7 @@ async function transform(
 
   return serviceToDestinationTransformers[serviceBinding.type](
     serviceBinding,
-    jwt
+    options
   );
 }
 
@@ -229,7 +229,7 @@ export async function searchServiceBindingForDestination({
     const destination = await destinationForServiceBinding(destinationName, {
       serviceBindingTransformFn,
       jwt: jwtFromOptions,
-      useCache
+      useCache: !!useCache
     });
     logger.info('Successfully retrieved destination from service binding.');
     return destination;

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
@@ -1,8 +1,8 @@
-import { JwtPayload } from '../jsonwebtoken-type';
 import { Service } from '../environment-accessor-types';
 import { serviceToken } from '../token-accessor';
 import { decodeJwt } from '../jwt';
 import type {
+  PartialDestinationFetchOptions,
   ServiceBinding,
   ServiceBindingTransformFunction
 } from './destination-from-vcap';
@@ -25,7 +25,7 @@ export const serviceToDestinationTransformers: Record<
 
 async function serviceManagerBindingToDestination(
   serviceBinding: ServiceBinding,
-  jwt?: JwtPayload
+  options: PartialDestinationFetchOptions
 ): Promise<Destination> {
   const service: Service = {
     ...serviceBinding,
@@ -33,7 +33,7 @@ async function serviceManagerBindingToDestination(
     label: 'service-manager',
     credentials: { ...serviceBinding.credentials }
   };
-  const token = await serviceToken(service, { jwt });
+  const token = await serviceToken(service, options);
   return buildClientCredentialsDestination(
     token,
     serviceBinding.credentials.sm_url,
@@ -43,7 +43,7 @@ async function serviceManagerBindingToDestination(
 
 async function destinationBindingToDestination(
   serviceBinding: ServiceBinding,
-  jwt?: JwtPayload
+  options: PartialDestinationFetchOptions
 ): Promise<Destination> {
   const service: Service = {
     ...serviceBinding,
@@ -51,7 +51,7 @@ async function destinationBindingToDestination(
     label: 'destination',
     credentials: { ...serviceBinding.credentials }
   };
-  const token = await serviceToken(service, { jwt });
+  const token = await serviceToken(service, options);
   return buildClientCredentialsDestination(
     token,
     serviceBinding.credentials.uri,
@@ -61,7 +61,7 @@ async function destinationBindingToDestination(
 
 async function saasRegistryBindingToDestination(
   serviceBinding: ServiceBinding,
-  jwt?: JwtPayload
+  options: PartialDestinationFetchOptions
 ): Promise<Destination> {
   const service: Service = {
     ...serviceBinding,
@@ -69,7 +69,7 @@ async function saasRegistryBindingToDestination(
     label: 'saas-registry',
     credentials: { ...serviceBinding.credentials }
   };
-  const token = await serviceToken(service, { jwt });
+  const token = await serviceToken(service, options);
   return buildClientCredentialsDestination(
     token,
     serviceBinding.credentials['saas_registry_url'],
@@ -79,7 +79,7 @@ async function saasRegistryBindingToDestination(
 
 async function businessLoggingBindingToDestination(
   serviceBinding: ServiceBinding,
-  jwt?: JwtPayload
+  options: PartialDestinationFetchOptions
 ): Promise<Destination> {
   const service: Service = {
     ...serviceBinding,
@@ -87,7 +87,7 @@ async function businessLoggingBindingToDestination(
     label: 'business-logging',
     credentials: { ...serviceBinding.credentials.uaa }
   };
-  const token = await serviceToken(service, { jwt });
+  const token = await serviceToken(service, options);
   return buildClientCredentialsDestination(
     token,
     serviceBinding.credentials.writeUrl,
@@ -97,7 +97,7 @@ async function businessLoggingBindingToDestination(
 
 async function workflowBindingToDestination(
   serviceBinding: ServiceBinding,
-  jwt: JwtPayload
+  options: PartialDestinationFetchOptions
 ): Promise<Destination> {
   const service: Service = {
     ...serviceBinding,
@@ -105,7 +105,7 @@ async function workflowBindingToDestination(
     label: 'workflow',
     credentials: { ...serviceBinding.credentials.uaa }
   };
-  const token = await serviceToken(service, { jwt });
+  const token = await serviceToken(service, options);
   return buildClientCredentialsDestination(
     token,
     serviceBinding.credentials.endpoints.workflow_odata_url,

--- a/packages/connectivity/src/scp-cf/token-accessor.ts
+++ b/packages/connectivity/src/scp-cf/token-accessor.ts
@@ -60,6 +60,8 @@ export async function serviceToken(
     );
 
     if (opts.useCache) {
+      const xsuaa = multiTenantXsuaaCredentials(options);
+
       clientCredentialsTokenCache.cacheToken(
         xsuaa.url,
         serviceCredentials.clientid,

--- a/packages/connectivity/src/scp-cf/token-accessor.ts
+++ b/packages/connectivity/src/scp-cf/token-accessor.ts
@@ -38,10 +38,11 @@ export async function serviceToken(
 
   service = resolveService(service);
   const serviceCredentials = service.credentials;
-  // TODO 2.0 Once the xssec supports caching remove all xsuaa related content here and use their cache.
-  const xsuaa = multiTenantXsuaaCredentials(options);
 
+  // TODO 2.0 Once the xssec supports caching remove all xsuaa related content here and use their cache.
   if (opts.useCache) {
+    const xsuaa = multiTenantXsuaaCredentials(options);
+
     const cachedToken = clientCredentialsTokenCache.getToken(
       xsuaa.url,
       serviceCredentials.clientid


### PR DESCRIPTION
A small fix the for @mr-flannery we check the XSUAA only when cache is on. Only then we use the URL to build the cache key.