### PR TITLE
feat: JSON spec file takes over the same service YAML one

### DIFF
--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -272,7 +272,7 @@ describe('generator', () => {
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
               "Could not generate client. Errors: [
-                ErrorWithCause: Could not write file \\"test.ts\\". File already exists. If you want to allow overwriting files, enable the \`overwrite\` flag.
+              	ErrorWithCause: Could not write file \\"test.ts\\". File already exists. If you want to allow overwriting files, enable the \`overwrite\` flag.
               ]"
             `);
     });
@@ -335,15 +335,17 @@ describe('generator', () => {
         })
       ).resolves.toBeUndefined();
 
-      const generatedClients = await promises.readdir('root/OutDir')
-      expect(generatedClients.length).toEqual(3)
+      const generatedClients = await promises.readdir('root/OutDir');
+      expect(generatedClients.length).toEqual(3);
 
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("client-generating from YAML file(s) below was skipped because you placed the JSON specification file(s) for the same service in a input directory")
-      )
+        expect.stringContaining(
+          'client-generating from YAML file(s) below was skipped because you placed the JSON specification file(s) for the same service in a input directory'
+        )
+      );
 
       mock.restore();
-    })
+    });
 
     it('should throw an error due to duplicated JSON files', async () => {
       mock.restore();
@@ -360,11 +362,15 @@ describe('generator', () => {
         }
       });
 
-      await expect(await generate({
-        input: 'root/inputDir',
-        outputDir: 'root/OutDir',
-        overwrite: true
-      })).resolves.toBeUndefined();
+      await expect(
+        generate({
+          input: 'root/inputDir',
+          outputDir: 'root/OutDir',
+          overwrite: true
+        })
+      ).rejects.toThrowError(
+        'Duplicate service directory names found. Customize directory names with `optionsPerService` or enable automatic name adjustment with `skipValidation`.'
+      );
 
       mock.restore();
     });
@@ -372,6 +378,3 @@ describe('generator', () => {
 });
 
 const endsWithNewLine = /\n$/;
-
-
-

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -326,8 +326,6 @@ describe('generator', () => {
         }
       });
 
-
-
       await expect(
         generate({
           input: 'root/inputDir',
@@ -340,9 +338,8 @@ describe('generator', () => {
       const generatedClients = await promises.readdir('root/OutDir')
       expect(generatedClients.length).toEqual(3)
 
-      expect(warnSpy).toHaveBeenCalledWith(`client-generating from YAML file(s) below was skipped because you placed the same JSON specification file(s) in a input directory.
-/Users/I346417/projects/sap-cloud-sdk-js/258/root/inputDir/sub-dir/test-service2.yaml
-/Users/I346417/projects/sap-cloud-sdk-js/258/root/inputDir/test-service.yaml`
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("client-generating from YAML file(s) below was skipped because you placed the JSON specification file(s) for the same service in a input directory")
       )
 
       mock.restore();

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -123,14 +123,17 @@ function validateInputFilePaths(inputFilePaths: string[]): string[] {
   const originalPathsWithoutExtension = inputFilePaths.map(file => parse(file).name);
   const uniquePathsWithoutExtension = unique(originalPathsWithoutExtension);
   const hasDuplicates = originalPathsWithoutExtension.length !== uniquePathsWithoutExtension.length;
+
   if (hasDuplicates) {
     const validatedInputFiles = removeDuplicatedYamlFiles(inputFilePaths);
     const duplicatedFilePaths = inputFilePaths.filter(file => !validatedInputFiles.includes(file)).join('\r\n');
     logger.warn(`client-generating from YAML file(s) below was skipped because you placed the JSON specification file(s) for the same service in a input directory.\n${duplicatedFilePaths}`);
     return validatedInputFiles;
   };
+
   return inputFilePaths;
 }
+
 function removeDuplicatedYamlFiles(file: string[]): string[] {
   const allJsonFiles = file.filter(files => files.endsWith('.json'));
   const allYamlFiles = file.filter(files => files.endsWith('.yaml'));

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -75,7 +75,9 @@ export async function generateWithParsedOptions(
   if (options.clearOutputDir) {
     await rmdir(options.outputDir, { recursive: true });
   }
-  const inputFilePaths = validateInputFilePaths(await getInputFilePaths(options.input));
+  const inputFilePaths = validateInputFilePaths(
+    await getInputFilePaths(options.input)
+  );
 
   const optionsPerService = await getOptionsPerService(inputFilePaths, options);
   const tsConfig = await tsconfigJson(options);
@@ -120,16 +122,23 @@ export async function generateWithParsedOptions(
 }
 
 function validateInputFilePaths(inputFilePaths: string[]): string[] {
-  const originalPathsWithoutExtension = inputFilePaths.map(file => parse(file).name);
+  const originalPathsWithoutExtension = inputFilePaths.map(
+    file => parse(file).name
+  );
   const uniquePathsWithoutExtension = unique(originalPathsWithoutExtension);
-  const hasDuplicates = originalPathsWithoutExtension.length !== uniquePathsWithoutExtension.length;
+  const hasDuplicates =
+    originalPathsWithoutExtension.length !== uniquePathsWithoutExtension.length;
 
   if (hasDuplicates) {
     const validatedInputFiles = removeDuplicatedYamlFiles(inputFilePaths);
-    const duplicatedFilePaths = inputFilePaths.filter(file => !validatedInputFiles.includes(file)).join('\r\n');
-    logger.warn(`client-generating from YAML file(s) below was skipped because you placed the JSON specification file(s) for the same service in a input directory.\n${duplicatedFilePaths}`);
+    const duplicatedFilePaths = inputFilePaths
+      .filter(file => !validatedInputFiles.includes(file))
+      .join('\r\n');
+    logger.warn(
+      `client-generating from YAML file(s) below was skipped because you placed the JSON specification file(s) for the same service in a input directory.\n${duplicatedFilePaths}`
+    );
     return validatedInputFiles;
-  };
+  }
 
   return inputFilePaths;
 }
@@ -137,11 +146,12 @@ function validateInputFilePaths(inputFilePaths: string[]): string[] {
 function removeDuplicatedYamlFiles(file: string[]): string[] {
   const allJsonFiles = file.filter(files => files.endsWith('.json'));
   const allYamlFiles = file.filter(files => files.endsWith('.yaml'));
-  const allowedYamlFiles = allYamlFiles
-    .filter(yamlFile => !allJsonFiles
-      .map(jsonFile => parse(jsonFile).name)
-      .includes(parse(yamlFile).name)
-    );
+  const allowedYamlFiles = allYamlFiles.filter(
+    yamlFile =>
+      !allJsonFiles
+        .map(jsonFile => parse(jsonFile).name)
+        .includes(parse(yamlFile).name)
+  );
   return allJsonFiles.concat(allowedYamlFiles);
 }
 


### PR DESCRIPTION
Relates https://github.com/SAP/cloud-sdk-backlog/issues/258

open-api generator chooses JSON file when a YAML file for the same service is given. It removes the YAML files and logs a warning message as well.