### PR TITLE
feat: Improve OpenAPI generator input handling

### DIFF
--- a/.changeset/few-zoos-repeat.md
+++ b/.changeset/few-zoos-repeat.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/openapi-generator': minor
 ---
 
-[New Functionality] the `input` option accepts glob as `input`
+[New Functionality] Support globs in the `input` option.

--- a/.changeset/few-zoos-repeat.md
+++ b/.changeset/few-zoos-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/openapi-generator': minor
+---
+
+[New Functionality] the `input` option accepts glob as `input`

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -29,8 +29,8 @@ describe('generator', () => {
             'empty-dir': {},
             'sub-dir': {
               'test-service.YAML': 'dummy YAML specification file',
-              'test-service2.yml': 'dummy yml specification file',
-              'test-service2.YML': 'dummy YML specification file',
+              'test-service.yml': 'dummy yml specification file',
+              'test-service.YML': 'dummy YML specification file',
               'test-service.xml': 'dummy xml specification file'
             }
           },

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -62,14 +62,6 @@ describe('generator', () => {
       ]);
     });
 
-    it('should return an array of all types of JSON and YAML file paths only in a top level directory.', async () => {
-      expect(await getInputFilePaths('root/inputDir/*')).toEqual([
-        resolve('root/inputDir/test-service.json'),
-        resolve('root/inputDir/test-service.JSON'),
-        resolve('root/inputDir/test-service.yaml')
-      ]);
-    });
-
     it('should return an array of all types of JSON and YAML file paths including subdirectories.', async () => {
       expect(
         await getInputFilePaths(
@@ -93,10 +85,11 @@ describe('generator', () => {
       ]);
     });
 
-    it('should return all .json file paths including subdirectories.', async () => {
-      expect(await getInputFilePaths('root/inputDir/**/*.json')).toEqual([
-        resolve('root/inputDir/sub-dir/test-service2.json'),
-        resolve('root/inputDir/test-service.json')
+    it('should return an array of all types of JSON and YAML file paths only in a top level directory.', async () => {
+      expect(await getInputFilePaths('root/inputDir/*')).toEqual([
+        resolve('root/inputDir/test-service.json'),
+        resolve('root/inputDir/test-service.JSON'),
+        resolve('root/inputDir/test-service.yaml')
       ]);
     });
 

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -17,27 +17,55 @@ describe('generator', () => {
     mock.restore();
   });
 
-  it('getInputFilePaths returns an array of all file paths, including subdirectories', async () => {
-    mock({
-      '/path/to/test/dir': {
-        'test-service.txt': 'file content here',
-        'empty-dir': {},
-        'sub-dir': {
-          'test-service.txt': 'another fake service',
-          'sub-directory-service.txt': 'just to add some more'
+  describe('get input file paths', () => {
+    beforeAll(() => {
+      mock({
+        root: {
+          inputDir: {
+            'test-service.text': 'dummy text specification file',
+            'test-service.json': 'dummy json specification file',
+            'test-service.JSON': 'dummy JSON specification file',
+            'test-service.yaml': 'dummy yaml specification file',
+            'empty-dir': {},
+            'sub-dir': {
+              'test-service.YAML': 'dummy YAML specification file',
+              'test-service2.yml': 'dummy yml specification file',
+              'test-service2.YML': 'dummy YML specification file',
+              'test-service.xml': 'dummy xml specification file'
+            }
+          },
+          outputDir: {}
         }
-      }
+      });
     });
 
-    expect(await getInputFilePaths('/path/to/test/dir')).toEqual([
-      resolve('/path/to/test/dir/sub-dir/sub-directory-service.txt'),
-      resolve('/path/to/test/dir/sub-dir/test-service.txt'),
-      resolve('/path/to/test/dir/test-service.txt')
-    ]);
+    afterAll(() => {
+      mock.restore();
+    });
 
-    mock.restore();
+    it('should return an array of all type of JSON and YAML file paths including subdirectories.', async () => {
+      expect((await getInputFilePaths('root/inputDir')).length).toEqual(6);
+    });
+
+    it('should return a file path.', async () => {
+      expect(
+        (await getInputFilePaths('root/inputDir/test-service.json')).length
+      ).toEqual(1);
+    });
+
+    it('should return all .json file paths including subdirectories.', async () => {
+      expect(
+        (await getInputFilePaths('root/inputDir/**/*(*.json)')).length
+      ).toEqual(1);
+    });
+
+    it('should return all .json and .yaml file paths only in a top level directory.', async () => {
+      expect(
+        (await getInputFilePaths('root/inputDir/*(*.json|*.yaml)')).length
+      ).toEqual(2);
+    });
   });
-
+  
   describe('creation of files', () => {
     beforeAll(async () => {
       mock.restore();
@@ -287,6 +315,7 @@ describe('generator', () => {
       ).resolves.toBeUndefined();
     });
   });
+
 });
 
 const endsWithNewLine = /\n$/;

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -22,7 +22,7 @@ describe('generator', () => {
       mock({
         root: {
           inputDir: {
-            'test-service.text': 'dummy text specification file',
+            'test-service.txt': 'dummy text specification file',
             'test-service.json': 'dummy json specification file',
             'test-service.JSON': 'dummy JSON specification file',
             'test-service.yaml': 'dummy yaml specification file',

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -31,7 +31,8 @@ describe('generator', () => {
               'test-service.YAML': 'dummy YAML specification file',
               'test-service.yml': 'dummy yml specification file',
               'test-service.YML': 'dummy YML specification file',
-              'test-service.xml': 'dummy xml specification file'
+              'test-service.xml': 'dummy xml specification file',
+              'test-service2.json': 'dummy json specification file'
             }
           },
           outputDir: {}
@@ -43,26 +44,69 @@ describe('generator', () => {
       mock.restore();
     });
 
-    it('should return an array of all type of JSON and YAML file paths including subdirectories.', async () => {
-      expect((await getInputFilePaths('root/inputDir')).length).toEqual(6);
-    });
-
     it('should return a file path.', async () => {
       expect(
-        (await getInputFilePaths('root/inputDir/test-service.json')).length
-      ).toEqual(1);
+        await getInputFilePaths('root/inputDir/test-service.json')
+      ).toEqual([resolve('root/inputDir/test-service.json')]);
+    });
+
+    it('should return an array of all types of JSON and YAML file paths including subdirectories.', async () => {
+      expect(await getInputFilePaths('root/inputDir')).toEqual([
+        resolve('root/inputDir/sub-dir/test-service.YAML'),
+        resolve('root/inputDir/sub-dir/test-service.yml'),
+        resolve('root/inputDir/sub-dir/test-service.YML'),
+        resolve('root/inputDir/sub-dir/test-service2.json'),
+        resolve('root/inputDir/test-service.json'),
+        resolve('root/inputDir/test-service.JSON'),
+        resolve('root/inputDir/test-service.yaml')
+      ]);
+    });
+
+    it('should return an array of all types of JSON and YAML file paths including subdirectories.', async () => {
+      expect(await getInputFilePaths('root/inputDir/*')).toEqual([
+        resolve('root/inputDir/test-service.json'),
+        resolve('root/inputDir/test-service.JSON'),
+        resolve('root/inputDir/test-service.yaml')
+      ]);
+    });
+
+    it('should return an array of all types of JSON and YAML file paths including subdirectories.', async () => {
+      expect(
+        await getInputFilePaths(
+          'root/inputDir/**/**.{json,JSON,yaml,YAML,yml,YML}'
+        )
+      ).toEqual([
+        resolve('root/inputDir/sub-dir/test-service.YAML'),
+        resolve('root/inputDir/sub-dir/test-service.yml'),
+        resolve('root/inputDir/sub-dir/test-service.YML'),
+        resolve('root/inputDir/sub-dir/test-service2.json'),
+        resolve('root/inputDir/test-service.json'),
+        resolve('root/inputDir/test-service.JSON'),
+        resolve('root/inputDir/test-service.yaml')
+      ]);
     });
 
     it('should return all .json file paths including subdirectories.', async () => {
-      expect(
-        (await getInputFilePaths('root/inputDir/**/*(*.json)')).length
-      ).toEqual(1);
+      expect(await getInputFilePaths('root/inputDir/**/*(*.json)')).toEqual([
+        resolve('root/inputDir/sub-dir/test-service2.json'),
+        resolve('root/inputDir/test-service.json')
+      ]);
+    });
+
+    it('should return all .json file paths including subdirectories.', async () => {
+      expect(await getInputFilePaths('root/inputDir/**/*.json')).toEqual([
+        resolve('root/inputDir/sub-dir/test-service2.json'),
+        resolve('root/inputDir/test-service.json')
+      ]);
     });
 
     it('should return all .json and .yaml file paths only in a top level directory.', async () => {
-      expect(
-        (await getInputFilePaths('root/inputDir/*(*.json|*.yaml)')).length
-      ).toEqual(2);
+      expect(await getInputFilePaths('root/inputDir/*(*.json|*.yaml)')).toEqual(
+        [
+          resolve('root/inputDir/test-service.json'),
+          resolve('root/inputDir/test-service.yaml')
+        ]
+      );
     });
   });
 

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -62,7 +62,7 @@ describe('generator', () => {
       ]);
     });
 
-    it('should return an array of all types of JSON and YAML file paths including subdirectories.', async () => {
+    it('should return an array of all types of JSON and YAML file paths only in a top level directory.', async () => {
       expect(await getInputFilePaths('root/inputDir/*')).toEqual([
         resolve('root/inputDir/test-service.json'),
         resolve('root/inputDir/test-service.JSON'),

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -91,7 +91,7 @@ describe('generator', () => {
         resolve('root/inputDir/test-service.json')
       ]);
     });
-    
+
     it('should return an array of all types of JSON and YAML file paths only in a top level directory.', async () => {
       expect(await getInputFilePaths('root/inputDir/*')).toEqual([
         resolve('root/inputDir/test-service.json'),

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -65,7 +65,7 @@ describe('generator', () => {
       ).toEqual(2);
     });
   });
-  
+
   describe('creation of files', () => {
     beforeAll(async () => {
       mock.restore();
@@ -315,7 +315,6 @@ describe('generator', () => {
       ).resolves.toBeUndefined();
     });
   });
-
 });
 
 const endsWithNewLine = /\n$/;

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -40,73 +40,106 @@ describe('generator', () => {
       });
     });
 
+    const inputDir = 'root/inputDir';
+
     afterAll(() => {
       mock.restore();
     });
 
-    it('should return an array of a file path.', async () => {
+    it('should return an array with one path for one input file', async () => {
       expect(
         await getInputFilePaths('root/inputDir/test-service.json')
-      ).toEqual([resolve('root/inputDir/test-service.json')]);
+      ).toEqual([resolve(inputDir, 'test-service.json')]);
     });
 
-    it('should return an array of all types of JSON and YAML file paths including subdirectories.', async () => {
-      expect(await getInputFilePaths('root/inputDir')).toEqual([
-        resolve('root/inputDir/sub-dir/test-service.YAML'),
-        resolve('root/inputDir/sub-dir/test-service.yml'),
-        resolve('root/inputDir/sub-dir/test-service.YML'),
-        resolve('root/inputDir/sub-dir/test-service2.json'),
-        resolve('root/inputDir/test-service.json'),
-        resolve('root/inputDir/test-service.JSON'),
-        resolve('root/inputDir/test-service.yaml')
+    it('should recursively return an array for all JSON and YAML file paths for an input directory', async () => {
+      expect(await getInputFilePaths(inputDir)).toEqual([
+        resolve(inputDir, 'sub-dir/test-service.YAML'),
+        resolve(inputDir, 'sub-dir/test-service.yml'),
+        resolve(inputDir, 'sub-dir/test-service.YML'),
+        resolve(inputDir, 'sub-dir/test-service2.json'),
+        resolve(inputDir, 'test-service.json'),
+        resolve(inputDir, 'test-service.JSON'),
+        resolve(inputDir, 'test-service.yaml')
       ]);
     });
 
-    it('should return an array of all types of JSON and YAML file paths including subdirectories.', async () => {
-      expect(
-        await getInputFilePaths(
-          'root/inputDir/**/**.{json,JSON,yaml,YAML,yml,YML}'
-        )
-      ).toEqual([
-        resolve('root/inputDir/sub-dir/test-service.YAML'),
-        resolve('root/inputDir/sub-dir/test-service.yml'),
-        resolve('root/inputDir/sub-dir/test-service.YML'),
-        resolve('root/inputDir/sub-dir/test-service2.json'),
-        resolve('root/inputDir/test-service.json'),
-        resolve('root/inputDir/test-service.JSON'),
-        resolve('root/inputDir/test-service.yaml')
-      ]);
-    });
-
-    it('should return all .json file paths including subdirectories.', async () => {
-      expect(await getInputFilePaths('root/inputDir/**/*(*.json)')).toEqual([
-        resolve('root/inputDir/sub-dir/test-service2.json'),
-        resolve('root/inputDir/test-service.json')
-      ]);
-    });
-
-    it('should return all .json file paths including subdirectories.', async () => {
+    it('should recursively return an array for all JSON file paths only with the lowercase file extension for an input directory', async () => {
       expect(await getInputFilePaths('root/inputDir/**/*.json')).toEqual([
-        resolve('root/inputDir/sub-dir/test-service2.json'),
-        resolve('root/inputDir/test-service.json')
+        resolve(inputDir, 'sub-dir/test-service2.json'),
+        resolve(inputDir, 'test-service.json')
       ]);
     });
 
-    it('should return an array of all types of JSON and YAML file paths only in a top level directory.', async () => {
+    it('should non-recursively return an array for all JSON and YAML file paths for an input directory', async () => {
       expect(await getInputFilePaths('root/inputDir/*')).toEqual([
-        resolve('root/inputDir/test-service.json'),
-        resolve('root/inputDir/test-service.JSON'),
-        resolve('root/inputDir/test-service.yaml')
+        resolve(inputDir, 'test-service.json'),
+        resolve(inputDir, 'test-service.JSON'),
+        resolve(inputDir, 'test-service.yaml')
       ]);
     });
 
-    it('should return all .json and .yaml file paths only in a top level directory.', async () => {
-      expect(await getInputFilePaths('root/inputDir/*(*.json|*.yaml)')).toEqual(
-        [
-          resolve('root/inputDir/test-service.json'),
-          resolve('root/inputDir/test-service.yaml')
-        ]
-      );
+    it('should non-recursively return an array for all JSON and YAML file paths only with the lowercase file extension for an input directory', async () => {
+      expect(await getInputFilePaths('root/inputDir/*.{json,yaml}')).toEqual([
+        resolve(inputDir, 'test-service.json'),
+        resolve(inputDir, 'test-service.yaml')
+      ]);
+    });
+
+    it('should recursively return an array for all JSON and YAML file paths for an input directory containing no non-JSON/-YAML files', async () => {
+      mock.restore();
+      mock({
+        root: {
+          inputDir: {
+            'test-service.json': 'dummy json specification file',
+            'test-service.JSON': 'dummy JSON specification file',
+            'test-service.yaml': 'dummy yaml specification file',
+            'empty-dir': {},
+            'sub-dir': {
+              'test-service.YAML': 'dummy YAML specification file',
+              'test-service.yml': 'dummy yml specification file',
+              'test-service.YML': 'dummy YML specification file',
+              'test-service2.json': 'dummy json specification file'
+            }
+          },
+          outputDir: {}
+        }
+      });
+      expect(await getInputFilePaths(inputDir)).toEqual([
+        resolve(inputDir, 'sub-dir/test-service.YAML'),
+        resolve(inputDir, 'sub-dir/test-service.yml'),
+        resolve(inputDir, 'sub-dir/test-service.YML'),
+        resolve(inputDir, 'sub-dir/test-service2.json'),
+        resolve(inputDir, 'test-service.json'),
+        resolve(inputDir, 'test-service.JSON'),
+        resolve(inputDir, 'test-service.yaml')
+      ]);
+    });
+
+    it('should non-recursively return an array for all JSON and YAML file paths for an input directory containing no non-JSON/-YAML files', async () => {
+      mock.restore();
+      mock({
+        root: {
+          inputDir: {
+            'test-service.json': 'dummy json specification file',
+            'test-service.JSON': 'dummy JSON specification file',
+            'test-service.yaml': 'dummy yaml specification file',
+            'empty-dir': {},
+            'sub-dir': {
+              'test-service.YAML': 'dummy YAML specification file',
+              'test-service.yml': 'dummy yml specification file',
+              'test-service.YML': 'dummy YML specification file',
+              'test-service2.json': 'dummy json specification file'
+            }
+          },
+          outputDir: {}
+        }
+      });
+      expect(await getInputFilePaths('root/inputDir/*')).toEqual([
+        resolve(inputDir, 'test-service.json'),
+        resolve(inputDir, 'test-service.JSON'),
+        resolve(inputDir, 'test-service.yaml')
+      ]);
     });
   });
 

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -64,7 +64,7 @@ describe('generator', () => {
       ]);
     });
 
-    it('should recursively return an array for all JSON file paths only with the lowercase file extension for an input directory', async () => {
+    it('should recursively return an array for all .json files for an input directory', async () => {
       expect(await getInputFilePaths('root/inputDir/**/*.json')).toEqual([
         resolve(inputDir, 'sub-dir/test-service2.json'),
         resolve(inputDir, 'test-service.json')

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -85,6 +85,13 @@ describe('generator', () => {
       ]);
     });
 
+    it('should return all .json file paths including subdirectories.', async () => {
+      expect(await getInputFilePaths('root/inputDir/**/*.json')).toEqual([
+        resolve('root/inputDir/sub-dir/test-service2.json'),
+        resolve('root/inputDir/test-service.json')
+      ]);
+    });
+    
     it('should return an array of all types of JSON and YAML file paths only in a top level directory.', async () => {
       expect(await getInputFilePaths('root/inputDir/*')).toEqual([
         resolve('root/inputDir/test-service.json'),

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -44,7 +44,7 @@ describe('generator', () => {
       mock.restore();
     });
 
-    it('should return a file path.', async () => {
+    it('should return an array of a file path.', async () => {
       expect(
         await getInputFilePaths('root/inputDir/test-service.json')
       ).toEqual([resolve('root/inputDir/test-service.json')]);

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -46,13 +46,13 @@ describe('generator', () => {
       mock.restore();
     });
 
-    it('should return an array with one path for one input file', async () => {
+    it('should return an array with one file path for an input file', async () => {
       expect(
         await getInputFilePaths('root/inputDir/test-service.json')
       ).toEqual([resolve(inputDir, 'test-service.json')]);
     });
 
-    it('should recursively return an array for all JSON and YAML file paths for an input directory', async () => {
+    it('should return an array with all JSON and YAML file paths within the input directory and all subdirectories', async () => {
       expect(await getInputFilePaths(inputDir)).toEqual([
         resolve(inputDir, 'sub-dir/test-service.YAML'),
         resolve(inputDir, 'sub-dir/test-service.yml'),
@@ -64,14 +64,14 @@ describe('generator', () => {
       ]);
     });
 
-    it('should recursively return an array for all .json files for an input directory', async () => {
+    it('should return an array with all `.json` files within the input directory and all subdirectories', async () => {
       expect(await getInputFilePaths('root/inputDir/**/*.json')).toEqual([
         resolve(inputDir, 'sub-dir/test-service2.json'),
         resolve(inputDir, 'test-service.json')
       ]);
     });
 
-    it('should non-recursively return an array for all JSON and YAML file paths for an input directory', async () => {
+    it('should return an array with all JSON and YAML file paths within the input directory', async () => {
       expect(await getInputFilePaths('root/inputDir/*')).toEqual([
         resolve(inputDir, 'test-service.json'),
         resolve(inputDir, 'test-service.JSON'),
@@ -79,65 +79,9 @@ describe('generator', () => {
       ]);
     });
 
-    it('should non-recursively return an array for all JSON and YAML file paths only with the lowercase file extension for an input directory', async () => {
+    it('should return an array with all `.json` and `.yaml` files within the input directory', async () => {
       expect(await getInputFilePaths('root/inputDir/*.{json,yaml}')).toEqual([
         resolve(inputDir, 'test-service.json'),
-        resolve(inputDir, 'test-service.yaml')
-      ]);
-    });
-
-    it('should recursively return an array for all JSON and YAML file paths for an input directory containing no non-JSON/-YAML files', async () => {
-      mock.restore();
-      mock({
-        root: {
-          inputDir: {
-            'test-service.json': 'dummy json specification file',
-            'test-service.JSON': 'dummy JSON specification file',
-            'test-service.yaml': 'dummy yaml specification file',
-            'empty-dir': {},
-            'sub-dir': {
-              'test-service.YAML': 'dummy YAML specification file',
-              'test-service.yml': 'dummy yml specification file',
-              'test-service.YML': 'dummy YML specification file',
-              'test-service2.json': 'dummy json specification file'
-            }
-          },
-          outputDir: {}
-        }
-      });
-      expect(await getInputFilePaths(inputDir)).toEqual([
-        resolve(inputDir, 'sub-dir/test-service.YAML'),
-        resolve(inputDir, 'sub-dir/test-service.yml'),
-        resolve(inputDir, 'sub-dir/test-service.YML'),
-        resolve(inputDir, 'sub-dir/test-service2.json'),
-        resolve(inputDir, 'test-service.json'),
-        resolve(inputDir, 'test-service.JSON'),
-        resolve(inputDir, 'test-service.yaml')
-      ]);
-    });
-
-    it('should non-recursively return an array for all JSON and YAML file paths for an input directory containing no non-JSON/-YAML files', async () => {
-      mock.restore();
-      mock({
-        root: {
-          inputDir: {
-            'test-service.json': 'dummy json specification file',
-            'test-service.JSON': 'dummy JSON specification file',
-            'test-service.yaml': 'dummy yaml specification file',
-            'empty-dir': {},
-            'sub-dir': {
-              'test-service.YAML': 'dummy YAML specification file',
-              'test-service.yml': 'dummy yml specification file',
-              'test-service.YML': 'dummy YML specification file',
-              'test-service2.json': 'dummy json specification file'
-            }
-          },
-          outputDir: {}
-        }
-      });
-      expect(await getInputFilePaths('root/inputDir/*')).toEqual([
-        resolve(inputDir, 'test-service.json'),
-        resolve(inputDir, 'test-service.JSON'),
         resolve(inputDir, 'test-service.yaml')
       ]);
     });

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -264,7 +264,9 @@ async function generateService(
  */
 export async function getInputFilePaths(input: string): Promise<string[]> {
   if (glob.hasMagic(input)) {
-    return glob.sync(input);
+    return glob
+      .sync(resolve(input))
+      .filter(path => /(.json|.JSON|.yaml|.YAML|.yml|.YML)$/.test(path));
   }
 
   if (lstatSync(input).isDirectory()) {

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -278,7 +278,7 @@ export async function getInputFilePaths(input: string): Promise<string[]> {
   if ((await lstat(input)).isDirectory()) {
     return new Promise(resolvePromise => {
       glob(
-        resolve(input, './**/*(*.json|*.JSON|*.yaml|*.YAML|*.yml|*.YML)'),
+        resolve(input, '**/*.{json,JSON,yaml,YAML,yml,YML}'),
         (_error, paths) => {
           resolvePromise(paths);
         }

--- a/packages/openapi-generator/src/options/options-per-service.spec.ts
+++ b/packages/openapi-generator/src/options/options-per-service.spec.ts
@@ -168,7 +168,7 @@ describe('getOptionsPerService', () => {
         skipValidation: false
       } as ParsedGeneratorOptions)
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
-            "Duplicate service directory names found. Customize directory names with \`optionsPerService\` or enable automatic name adjustment with \`skipValidation\`.
+            "Duplicate service file names would result in duplicate directory names. Customize directory names with \`optionsPerService\` or enable automatic name adjustment with \`skipValidation\`.
             	Duplicates:
             		Directory name: 'service', specifications: [
             			/user/path1/service,

--- a/packages/openapi-generator/src/options/options-per-service.ts
+++ b/packages/openapi-generator/src/options/options-per-service.ts
@@ -157,7 +157,7 @@ function validateDirectoryNames(dirNamesByPaths: Record<string, string>): void {
       )
       .join('\n');
 
-    const errorMessage = `Duplicate service directory names found. Customize directory names with \`optionsPerService\` or enable automatic name adjustment with \`skipValidation\`.\n\tDuplicates:\n${duplicatesList}`;
+    const errorMessage = `Duplicate service file names would result in duplicate directory names. Customize directory names with \`optionsPerService\` or enable automatic name adjustment with \`skipValidation\`.\n\tDuplicates:\n${duplicatesList}`;
     throw new Error(errorMessage);
   }
 }


### PR DESCRIPTION
Relates https://github.com/SAP/cloud-sdk-backlog/issues/803
### Changes:

1. I changed an error message for duplicated specification files to notify users should use options for avoiding the error.
2. I changed `getInputFilePaths()` to enable the function to accept glob expression as an argument as well.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
