### PR TITLE
fix: OpenAPI generator should create output directory

### DIFF
--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -41,6 +41,8 @@
     "@sap-cloud-sdk/generator-common": "^2.6.0",
     "@sap-cloud-sdk/openapi": "^2.6.0",
     "@sap-cloud-sdk/util": "^2.6.0",
+    "@types/fs-extra": "^9.0.1",
+    "fs-extra": "^10.0.0",
     "glob": "^8.0.1",
     "js-yaml": "^4.0.0",
     "openapi-types": "^12.0.0",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -41,8 +41,6 @@
     "@sap-cloud-sdk/generator-common": "^2.6.0",
     "@sap-cloud-sdk/openapi": "^2.6.0",
     "@sap-cloud-sdk/util": "^2.6.0",
-    "@types/fs-extra": "^9.0.1",
-    "fs-extra": "^10.0.0",
     "glob": "^8.0.1",
     "js-yaml": "^4.0.0",
     "openapi-types": "^12.0.0",

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -70,7 +70,8 @@ describe('generator', () => {
         include: 'root/additionalFiles/*',
         readme: true,
         packageJson: true,
-        packageVersion: '1.2.3'
+        packageVersion: '1.2.3',
+        clearOutputDir: true
       });
     }, 80000);
 

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -8,6 +8,7 @@ import {
   formatJson,
   ErrorWithCause
 } from '@sap-cloud-sdk/util';
+import { emptyDirSync } from 'fs-extra';
 import {
   getSdkMetadataFileNames,
   getSdkVersion,
@@ -44,7 +45,7 @@ import {
 import { tsconfigJson } from './options/tsconfig-json';
 import { sdkMetadata } from './sdk-metadata';
 
-const { rm, mkdir, lstat } = promisesFs;
+const { mkdir, lstat } = promisesFs;
 const logger = createLogger('openapi-generator');
 
 /**
@@ -73,7 +74,7 @@ export async function generateWithParsedOptions(
   }
 
   if (options.clearOutputDir) {
-    await rm(options.outputDir, { recursive: true });
+    await emptyDirSync(options.outputDir);
   }
   const inputFilePaths = await getInputFilePaths(options.input);
 

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -43,7 +43,7 @@ import {
 import { tsconfigJson } from './options/tsconfig-json';
 import { sdkMetadata } from './sdk-metadata';
 
-const { readdir, rmdir, mkdir, lstat } = promisesFs;
+const { readdir, rm, mkdir, lstat } = promisesFs;
 const logger = createLogger('openapi-generator');
 
 /**
@@ -72,7 +72,7 @@ export async function generateWithParsedOptions(
   }
 
   if (options.clearOutputDir) {
-    await rmdir(options.outputDir, { recursive: true });
+    await rm(options.outputDir, { recursive: true });
   }
   const inputFilePaths = await getInputFilePaths(options.input);
 

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -8,7 +8,6 @@ import {
   formatJson,
   ErrorWithCause
 } from '@sap-cloud-sdk/util';
-import { emptyDirSync } from 'fs-extra';
 import {
   getSdkMetadataFileNames,
   getSdkVersion,
@@ -74,7 +73,8 @@ export async function generateWithParsedOptions(
   }
 
   if (options.clearOutputDir) {
-    await emptyDirSync(options.outputDir);
+    const rm = promisesFs.rm || promisesFs.rmdir;
+    await rm(options.outputDir, { recursive: true });
   }
   const inputFilePaths = await getInputFilePaths(options.input);
 


### PR DESCRIPTION

Closes https://github.com/SAP/cloud-sdk-backlog/issues/416

As this [comment](https://github.com/SAP/cloud-sdk-backlog/issues/416#issuecomment-1191386388) about the root cause, the problem is `fs.rmdir(path, { recursive: true })` is used in `generator()`that will be deprecated in future Node versions. 

### Change:

1. Changed `fs.rmdir` to ~~`fs.rm`~~ which will be supported in future versions.
2. Added --clearOutputDir in a test of a file creating process to test this issue.

### Update:
Since `fs.rm` is not supported in Node v12, I use `fs-extra` instead of it.
