### PR TITLE
refactor: set validitytime in cache as milliseconds

### DIFF
--- a/packages/connectivity/src/scp-cf/cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/cache.spec.ts
@@ -21,7 +21,7 @@ const destinationOne: Destination = {
 };
 
 // Cache with expiration time
-const cacheOne = new Cache<Destination>({ hours: 0, minutes: 5, seconds: 0 });
+const cacheOne = new Cache<Destination>(300000);
 
 // Cache without expiration time
 const cacheTwo = new Cache<ClientCredentialsResponse>();

--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -38,11 +38,11 @@ export class Cache<T> implements CacheInterface<T> {
    * Default validity period for each entry in cache.
    * If `undefined`, all cached entries will be valid indefinitely.
    */
-  private defaultValidityTime: number | undefined;
+  private defaultValidityTimeInMs: number | undefined;
 
-  constructor(validityTime?: number) {
+  constructor(validityTimeInMs?: number) {
     this.cache = {};
-    this.defaultValidityTime = validityTime;
+    this.defaultValidityTimeInMs = validityTimeInMs;
   }
 
   /**
@@ -80,7 +80,7 @@ export class Cache<T> implements CacheInterface<T> {
   set(key: string | undefined, item: CacheEntry<T>): void {
     if (key) {
       const expires =
-        item.expires ?? inferExpirationTime(this.defaultValidityTime);
+        item.expires ?? inferExpirationTime(this.defaultValidityTimeInMs);
       this.cache[key] = { entry: item.entry, expires };
     }
   }
@@ -94,11 +94,11 @@ function isExpired<T>(item: CacheEntry<T>): boolean {
 }
 
 function inferExpirationTime(
-  expirationTime: number | undefined
+  validityTimeInMs: number | undefined
 ): number | undefined {
-  return expirationTime
+  return validityTimeInMs
     ? new Date()
-        .setMilliseconds(new Date().getMilliseconds() + expirationTime)
+        .setMilliseconds(new Date().getMilliseconds() + validityTimeInMs)
         .valueOf()
     : undefined;
 }

--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -96,9 +96,10 @@ function isExpired<T>(item: CacheEntry<T>): boolean {
 function inferExpirationTime(
   validityTimeInMs: number | undefined
 ): number | undefined {
+  const now = new Date();
   return validityTimeInMs
     ? new Date()
-        .setMilliseconds(new Date().getMilliseconds() + validityTimeInMs)
+        .setMilliseconds(now.getMilliseconds() + validityTimeInMs)
         .valueOf()
     : undefined;
 }

--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -6,16 +6,6 @@ interface CacheInterface<T> {
 }
 
 /**
- * @internal
- */
-export interface DateInputObject {
-  hours?: number;
-  minutes?: number;
-  seconds?: number;
-  milliseconds?: number;
-}
-
-/**
  * Respresentation of a cached object.
  */
 export interface CacheEntry<T> {
@@ -48,9 +38,9 @@ export class Cache<T> implements CacheInterface<T> {
    * Default validity period for each entry in cache.
    * If `undefined`, all cached entries will be valid indefinitely.
    */
-  private defaultValidityTime: DateInputObject | undefined;
+  private defaultValidityTime: number | undefined;
 
-  constructor(validityTime?: DateInputObject) {
+  constructor(validityTime?: number) {
     this.cache = {};
     this.defaultValidityTime = validityTime;
   }
@@ -104,22 +94,11 @@ function isExpired<T>(item: CacheEntry<T>): boolean {
 }
 
 function inferExpirationTime(
-  expirationTime: DateInputObject | undefined
+  expirationTime: number | undefined
 ): number | undefined {
   return expirationTime
-    ? inferExpirationTimeFromDate(expirationTime)
+    ? new Date()
+        .setMilliseconds(new Date().getMilliseconds() + expirationTime)
+        .valueOf()
     : undefined;
-}
-
-function inferExpirationTimeFromDate(expirationTime: DateInputObject): number {
-  const currentDate = new Date();
-  const milliseconds =
-    (expirationTime?.hours ?? 0) * 60 * 60 * 1000 +
-    (expirationTime?.minutes ?? 0) * 60 * 1000 +
-    (expirationTime?.seconds ?? 0) * 1000 +
-    (expirationTime?.milliseconds ?? 0);
-
-  return currentDate
-    .setMilliseconds(currentDate.getMilliseconds() + milliseconds)
-    .valueOf();
 }

--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -98,8 +98,6 @@ function inferExpirationTime(
 ): number | undefined {
   const now = new Date();
   return validityTimeInMs
-    ? new Date()
-        .setMilliseconds(now.getMilliseconds() + validityTimeInMs)
-        .valueOf()
+    ? now.setMilliseconds(now.getMilliseconds() + validityTimeInMs).valueOf()
     : undefined;
 }

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.ts
@@ -1,5 +1,5 @@
 import { createLogger, first } from '@sap-cloud-sdk/util';
-import { Cache, CacheEntry, DateInputObject } from '../cache';
+import { Cache, CacheEntry } from '../cache';
 import { tenantId } from '../tenant';
 import { userId } from '../user';
 import { JwtPayload } from '../jsonwebtoken-type';
@@ -38,7 +38,7 @@ export interface DestinationCacheInterface {
 export class DefaultDestinationCache implements DestinationCacheInterface {
   cache: Cache<Destination>;
 
-  constructor(validityTime?: DateInputObject) {
+  constructor(validityTime?: number) {
     this.cache = new Cache<Destination>(validityTime);
   }
 
@@ -110,11 +110,7 @@ export interface DestinationCacheType {
  * @internal
  */
 export const DestinationCache = (
-  cache: DestinationCacheInterface = new DefaultDestinationCache({
-    hours: 0,
-    minutes: 5,
-    seconds: 0
-  })
+  cache: DestinationCacheInterface = new DefaultDestinationCache(300000)
 ): DestinationCacheType => ({
   retrieveDestinationFromCache: async (
     decodedJwt: Record<string, any>,

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.ts
@@ -38,8 +38,8 @@ export interface DestinationCacheInterface {
 export class DefaultDestinationCache implements DestinationCacheInterface {
   cache: Cache<Destination>;
 
-  constructor(validityTime?: number) {
-    this.cache = new Cache<Destination>(validityTime);
+  constructor(validityTimeInMs?: number) {
+    this.cache = new Cache<Destination>(validityTimeInMs);
   }
 
   /**

--- a/packages/connectivity/src/scp-cf/destination/destination-service-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-cache.ts
@@ -33,5 +33,5 @@ const DestinationServiceCache = (cache: Cache<Destination[]>) => ({
  * @internal
  */
 export const destinationServiceCache = DestinationServiceCache(
-  new Cache<Destination[]>({ hours: 0, minutes: 5, seconds: 0 })
+  new Cache<Destination[]>(300000)
 );

--- a/packages/connectivity/src/scp-cf/jwt.ts
+++ b/packages/connectivity/src/scp-cf/jwt.ts
@@ -152,7 +152,7 @@ const defaultVerifyJwtOptions: VerifyJwtOptions = {
  * 15 minutes is the default value used by the xssec lib
  *  @internal
  */
-export const verificationKeyCache = new Cache<TokenKey>({ minutes: 15 });
+export const verificationKeyCache = new Cache<TokenKey>(900000);
 
 /**
  * Get the issuer URL of a decoded JWT.


### PR DESCRIPTION


Closes https://github.com/SAP/cloud-sdk-backlog/issues/534
Make `Cache` class just accepts milliseconds instead of `DateInputObject` like `new Cache<T>(validityTime?: number)`

### Change
1. Changed `validityTime` to `number`
2. Removed interface `DateInputObject`
3. Adjusted other parts that use Cache class with `DateInputObject`