### PR TITLE
Fix: `serviceToken` so it accepts `XsuaaServiceCredentials` again.

### DIFF
--- a/.changeset/2.0-fix.md
+++ b/.changeset/2.0-fix.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Fixed Issues] Fix a breaking change of `serviceToken` introduced in 2.0, so it accepts `XsuaaServiceCredentials` again as an option.

--- a/packages/connectivity/src/index.ts
+++ b/packages/connectivity/src/index.ts
@@ -60,6 +60,7 @@ export type {
   DestinationOrFetchOptions,
   DestinationOptions,
   ServiceCredentials,
+  XsuaaServiceCredentials,
   DestinationProxyType,
   AuthenticationType,
   DestinationWithName,

--- a/packages/connectivity/src/scp-cf/environment-accessor-types.ts
+++ b/packages/connectivity/src/scp-cf/environment-accessor-types.ts
@@ -43,7 +43,6 @@ export type DestinationServiceCredentials = ServiceCredentials & {
 
 /**
  * Credentials for the XSUAA service.
- *  @internal
  */
 export type XsuaaServiceCredentials = ServiceCredentials & {
   identityzone: string;

--- a/packages/connectivity/src/scp-cf/token-accessor.ts
+++ b/packages/connectivity/src/scp-cf/token-accessor.ts
@@ -28,6 +28,8 @@ export async function serviceToken(
   options?: CachingOptions &
     ResilienceOptions & {
       jwt?: string | JwtPayload;
+      // TODO 2.0 Once the xssec supports caching remove all xsuaa related content here and use their cache.
+      xsuaaCredentials?: XsuaaServiceCredentials;
     }
 ): Promise<string> {
   const opts = {


### PR DESCRIPTION
This is a partial revert of https://github.com/SAP/cloud-sdk-js/pull/1898, as this parameter is "used".