### PR TITLE
fix: glob pattern in openapi-generator on windows

### DIFF
--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -111,7 +111,7 @@ describe('generator', () => {
       });
 
       await generate({
-        input: 'root/inputDir/mySpec.json',
+        input: 'root/inputDir/*.json',
         outputDir: 'root/outputDir',
         skipValidation: true,
         transpile: true,

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -1,5 +1,5 @@
 import { promises as promisesFs } from 'fs';
-import { resolve, parse, basename, dirname } from 'path';
+import { resolve, parse, basename, dirname, sep, posix } from 'path';
 import {
   createLogger,
   kebabCase,
@@ -266,11 +266,11 @@ async function generateService(
 export async function getInputFilePaths(input: string): Promise<string[]> {
   if (glob.hasMagic(input)) {
     return new Promise(resolvePromise => {
-      glob(resolve(input), (_error, paths) => {
+      glob(resolve(input).split(sep).join(posix.sep), (_error, paths) => {
         resolvePromise(
-          paths.filter(path =>
-            /(.json|.JSON|.yaml|.YAML|.yml|.YML)$/.test(path)
-          )
+          paths
+            .filter(path => /(.json|.JSON|.yaml|.YAML|.yml|.YML)$/.test(path))
+            .map(path => resolve(path))
         );
       });
     });
@@ -279,9 +279,11 @@ export async function getInputFilePaths(input: string): Promise<string[]> {
   if ((await lstat(input)).isDirectory()) {
     return new Promise(resolvePromise => {
       glob(
-        resolve(input, '**/*.{json,JSON,yaml,YAML,yml,YML}'),
+        resolve(input, '**/*.{json,JSON,yaml,YAML,yml,YML}')
+          .split(sep)
+          .join(posix.sep),
         (_error, paths) => {
-          resolvePromise(paths);
+          resolvePromise(paths.map(path => resolve(path)));
         }
       );
     });

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -1,5 +1,5 @@
 import { promises as promisesFs } from 'fs';
-import { resolve, parse, basename, dirname, sep, posix } from 'path';
+import { resolve, parse, basename, dirname, posix } from 'path';
 import {
   createLogger,
   kebabCase,
@@ -266,7 +266,7 @@ async function generateService(
 export async function getInputFilePaths(input: string): Promise<string[]> {
   if (glob.hasMagic(input)) {
     return new Promise(resolvePromise => {
-      glob(resolve(input).split(sep).join(posix.sep), (_error, paths) => {
+      glob(input, (_error, paths) => {
         resolvePromise(
           paths
             .filter(path => /(.json|.JSON|.yaml|.YAML|.yml|.YML)$/.test(path))
@@ -279,9 +279,7 @@ export async function getInputFilePaths(input: string): Promise<string[]> {
   if ((await lstat(input)).isDirectory()) {
     return new Promise(resolvePromise => {
       glob(
-        resolve(input, '**/*.{json,JSON,yaml,YAML,yml,YML}')
-          .split(sep)
-          .join(posix.sep),
+        posix.join(input, '**/*.{json,JSON,yaml,YAML,yml,YML}'),
         (_error, paths) => {
           resolvePromise(paths.map(path => resolve(path)));
         }

--- a/packages/openapi-generator/src/options/generator-options.spec.ts
+++ b/packages/openapi-generator/src/options/generator-options.spec.ts
@@ -43,7 +43,7 @@ describe('parseGeneratorOptions', () => {
         outputDir: 'outputDir'
       })
     ).toEqual({
-      input: posix.join(...process.cwd().split(sep), 'inputDir'),
+      input: join(process.cwd(), 'inputDir').split(sep).join(posix.sep),
       outputDir: join(process.cwd(), 'outputDir'),
       ...options
     });

--- a/packages/openapi-generator/src/options/generator-options.spec.ts
+++ b/packages/openapi-generator/src/options/generator-options.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join, posix, sep } from 'path';
 import mock from 'mock-fs';
 import { createLogger } from '@sap-cloud-sdk/util';
 import { generateWithParsedOptions } from '../generator';
@@ -43,7 +43,7 @@ describe('parseGeneratorOptions', () => {
         outputDir: 'outputDir'
       })
     ).toEqual({
-      input: join(process.cwd(), 'inputDir'),
+      input: posix.join(...process.cwd().split(sep), 'inputDir'),
       outputDir: join(process.cwd(), 'outputDir'),
       ...options
     });

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -33,7 +33,7 @@ export const generatorOptions = {
     description:
       'Specify the path to the directory or file containing the OpenAPI service definition(s) to generate clients for. Accepts Swagger and OpenAPI definitions as YAML and JSON files. Throws an error if the path does not exist.',
     coerce: (input: string): string =>
-      typeof input !== 'undefined' ? resolve(input) : ''
+      typeof input !== 'undefined' ? resolve(input).split(sep).join(posix.sep) : ''
   },
   outputDir: {
     string: true,

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -33,7 +33,9 @@ export const generatorOptions = {
     description:
       'Specify the path to the directory or file containing the OpenAPI service definition(s) to generate clients for. Accepts Swagger and OpenAPI definitions as YAML and JSON files. Throws an error if the path does not exist.',
     coerce: (input: string): string =>
-      typeof input !== 'undefined' ? resolve(input).split(sep).join(posix.sep) : ''
+      typeof input !== 'undefined'
+        ? resolve(input).split(sep).join(posix.sep)
+        : ''
   },
   outputDir: {
     string: true,


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

The generation of openapi- clients fails on Windows when globs are used as input.
On Windows, `\\` is used as path separator, however only `/` character is used by  glob implementation. This PR adjusts the glob pattern passed as input to the openapi-generator.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
