### PR TITLE
feat: allow deserialization to all request builders

### DIFF
--- a/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
+++ b/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
@@ -196,5 +196,3 @@ TBD
 - [Original Ticket](https://github.com/SAP/cloud-sdk-backlog/issues/73)
 - [Original issue](https://github.com/SAP/cloud-sdk-js/issues/682)
 - [Mixins](https://www.typescriptlang.org/docs/handbook/mixins.html)
-
-dataAccessor need  to be change a name

--- a/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
+++ b/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
@@ -55,7 +55,7 @@ async execute(
 ## Discussion
 Some other request builders also should have the `dataAcccessor()`. However multiple implementation options are there.
 
-### **Q1. the `dataAccessor()` should be in the `exexute()` function parameter as optional or separeted as another function?**
+#### **Q1. the `dataAccessor()` should be in the `exexute()` function parameter as optional or separeted as another function?**
 
 **option 1** - palce in the `execute()` as same as a current implementation. (currently it is only implemented in action/function import request builder.) User call the function like
 ```
@@ -76,7 +76,7 @@ const request = functionImports
 - pros: keep `execure()` simple.
 - cons: current one will be deprecated. both are needed. old one will be removed in fure version(breaking change)?
 
-### **Q2-1. If it should be included, how?**
+#### **Q2-1. If it should be included, how?**
 
 **option 1**: create another class like `MethodRequestBuilderWithDataAccessor`
 (see below all request builder list)
@@ -136,7 +136,7 @@ async execute(
     });
 ```
 
-### **Q2-2. If it should be separated, how?**
+#### **Q2-2. If it should be separated, how?**
 
 **option 1**: create another class like `MethodRequestBuilderWithDataAccessor` to separete it. can user call like.
 ```

--- a/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
+++ b/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
@@ -1,0 +1,168 @@
+# Allow Deserialization to All Request Builders
+
+This ADR is about deserialization 
+
+## Status
+need a discussion
+
+## Context
+Generally request bilders take one argument `destination` but only action/function imports request builder takes an additional argument `deataAccessor()` to change a responce data structure.
+
+This is a response of `GetAttachmentCount` in the cloud s/4 service `API_CV_ATTACHMENT_SRV`
+```
+{
+  "d": {
+    "GetAttachmentCount": {
+      "AttachmentCount": 0
+    }
+  }
+}
+```
+In this case, user wants a value of `AttachmentCount` but it's wrapped by another object `GetAttachmentCount`.
+
+The `dataAccessor` can change the structure to what user want
+```
+const request = functionImports
+    .getAttachmentCount({param})
+    .execute(destination, data => data.d.GetAttachmentCount
+```
+then retuns
+```
+{
+  "d": {
+    "AttachmentCount": 0
+  }
+}
+```
+
+## Discussion
+Some other request builders also should have the `dataAcccessor`. However multiple implementation options are there.
+
+Q1. the `dataAccessor` should be in `exexute()` function parameter as optional or separeted?
+
+option 1 - in `execute()` as same as a current implementation currentl implementation is nonly in action/function import request builder.
+```
+#User call the function like
+
+const request = functionImports
+    .getAttachmentCount({param})
+    .execute(destination, data => data.d.GetAttachmentCount)
+```
+- pros: same as current functionality
+- cons: complicated. other request builder set by the builder like skip or selct are separeted but why dataAccessor uis special one?
+
+option 2 - separated
+```
+#User call the function like (disscuss about how to separete later!)
+
+const request = functionImports
+    .getAttachmentCount({param})
+    .dataAccessor(data => data.d.GetAttachmentCount)
+    .execute(destination)
+```
+- pros: keep `execure()` simple
+- cons: breaking change. deprecate. keep both.
+
+Q2-1. If it should be included, how?
+
+option 1: create another class `MethodRequestBuilderWithDataAccessor`
+see below for a request builder list that shold have dataAccessor.
+
+```
+#action-function-import-request-builder-base.ts
+
+async execute(
+  destination: DestinationOrFetchOptions,
+  this.dataAccessor?
+): Promise<ReturnT> {
+  return this.executeRaw(destination).then(response => {
+    const data = dataAccessor
+      ? { d: dataAccessor(response.data) }
+      : response.data;
+    return this.responseTransformer(data);
+  });
+}
+```
+
+option 2: add `dataAccessor` into each request builders repeatedly
+```
+#action-function-import-request-builder-base.ts
+
+async execute(
+  destination: DestinationOrFetchOptions,
+  dataAccessor?: (data: any) => any
+): Promise<ReturnT> {
+  return this.executeRaw(destination).then(response => {
+    const data = dataAccessor
+      ? { d: dataAccessor(response.data) }
+      : response.data;
+    return this.responseTransformer(data);
+  });
+}
+
+#get-all-request-builder-base.ts
+
+async execute(
+    destination: DestinationOrFetchOptions,
+    dataAccessor?: (data: any) => any
+  ): Promise<EntityT[]> {
+    return this.executeRaw(destination).then(response => {
+      const data = dataAccessor
+        ? { d: dataAccessor(response.data) }
+        : response.data;
+
+      return this.dataAccessor
+        .getCollectionResult(data) 
+        .map(json =>
+          this.entityDeserializer.deserializeEntity(
+            json,
+            this._entityApi,
+            response.headers
+          )
+        )
+    });
+```
+option 
+
+Q2-2. If it should be separated, how?
+
+option 1: class between
+```
+const request = functionImports
+    .getAttachmentCount({param})
+    .dataAccessor(data => data.d.GetAttachmentCount)
+    .execute(destination)
+```
+pros: no-duplication
+cons: more complicated inhelitance
+
+options 2: in each child cladd, dataAccessor method will be implemented..
+pros: not comlicated inheritance, simple
+cons: co-duplication
+
+## Target Request Builders
+
+Which request builders should have the `dataAccessor()` or not?
+
+- packages/odata-common/src/request-builder/batch/batch-request-builder.ts
+- packages/odata-common/src/request-builder/action-function-import-request-builder-base.ts
+- packages/odata-common/src/request-builder/count-request-builder.ts
+- packages/odata-common/src/request-builder/create-request-builder-base.ts
+- packages/odata-common/src/request-builder/delete-request-builder-base.ts
+- packages/odata-common/src/request-builder/get-all-request-builder-base.ts
+- packages/odata-common/src/request-builder/get-by-key-request-builder-base.ts
+- packages/odata-common/src/request-builder/update-request-builder-base.ts
+- packages/openapi/src/openapi-request-builder.ts
+
+
+## Decision
+
+
+## Appendix
+
+
+### Useful links
+
+- [Ticket](https://github.com/SAP/cloud-sdk-backlog/issues/698)
+- [Original Ticket](https://github.com/SAP/cloud-sdk-backlog/issues/73)
+- [Original issue](https://github.com/SAP/cloud-sdk-js/issues/682)

--- a/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
+++ b/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
@@ -3,7 +3,7 @@
 This ADR is about deserialization for all request builders
 
 ## Status
-need a discussion
+investigating the possibility
 
 ## Context
 Generally request bilders take one argument `destination` but only action/function imports request builder takes an additional argument `deataAccessor()` to change a responce data structure like below.
@@ -185,6 +185,7 @@ Which request builders should have the `dataAccessor()` or not?
 
 ## Decision
 TBD
+(dataAccessor should be changed to more explisit name)
 
 ## Appendix
 
@@ -195,3 +196,5 @@ TBD
 - [Original Ticket](https://github.com/SAP/cloud-sdk-backlog/issues/73)
 - [Original issue](https://github.com/SAP/cloud-sdk-js/issues/682)
 - [Mixins](https://www.typescriptlang.org/docs/handbook/mixins.html)
+
+dataAccessor need  to be change a name

--- a/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
+++ b/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
@@ -40,7 +40,7 @@ Some other request builders also should have the `dataAcccessor()`. However mult
 
 Q1. the `dataAccessor()` should be in `exexute()` function parameter as optional or separeted?
 
-option 1 - in `execute()` as same as a current implementation currentl implementation is nonly in action/function import request builder.
+option 1 - in `execute()` as same as a current implementation. (currently it is only implemented in action/function import request builder.)
 ```
 #User call the function like
 
@@ -49,7 +49,7 @@ const request = functionImports
     .execute(destination, data => data.d.GetAttachmentCount)
 ```
 - pros: same as current functionality
-- cons: complicated. other methods `set`, `skip` or `selct` are separeted but why only dataAccessor() is included?
+- cons: complicated. other methods `set`, `skip` or `selct` are separeted. why only `dataAccessor()` is included?
 
 option 2 - separated
 ```

--- a/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
+++ b/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
@@ -57,7 +57,7 @@ Some other request builders also should have the `dataAcccessor()`. However mult
 
 #### **Q1. the `dataAccessor()` should be in the `exexute()` function parameter as optional or separeted as another function?**
 
-**option 1** - palce in the `execute()` as same as a current implementation. (currently it is only implemented in action/function import request builder.) User call the function like
+**option 1** - palce the `dataAccessor()` in the `execute()` as same as a current implementation. (currently it is only implemented in action/function import request builder.) User call the function like
 ```
 const request = functionImports
     .getAttachmentCount({param})

--- a/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
+++ b/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
@@ -1,6 +1,6 @@
 # Allow Deserialization to All Request Builders
 
-This ADR is about deserialization 
+This ADR is about deserialization for all request builders
 
 ## Status
 need a discussion

--- a/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
+++ b/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
@@ -125,17 +125,17 @@ async execute(
 
 Q2-2. If it should be separated, how?
 
-option 1: make it separeted and cann be called with below
+option 1: create another class like `MethodRequestBuilderWithDataAccessor` to separete it and cann be called with below
 ```
 const request = functionImports
     .getAttachmentCount({param})
     .dataAccessor(data => data.d.GetAttachmentCount)
     .execute(destination)
 ```
-pros: no-duplication
-cons: more complicated inhelitance
+- pros: no-duplication
+- cons: more complicated inhelitance
 
-options 2: dataAccessor method is implemented in each child class.
+options 2: dataAccessor method is implemented in each child classes.
 - pros: not comlicated inheritance, simple
 - cons: co-duplication
 

--- a/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
+++ b/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
@@ -168,7 +168,7 @@ Which request builders should have the `dataAccessor()` or not?
 
 
 ## Decision
-
+TBD
 
 ## Appendix
 
@@ -178,3 +178,4 @@ Which request builders should have the `dataAccessor()` or not?
 - [Ticket](https://github.com/SAP/cloud-sdk-backlog/issues/698)
 - [Original Ticket](https://github.com/SAP/cloud-sdk-backlog/issues/73)
 - [Original issue](https://github.com/SAP/cloud-sdk-js/issues/682)
+- [Mixins](https://www.typescriptlang.org/docs/handbook/mixins.html)

--- a/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
+++ b/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
@@ -78,22 +78,26 @@ const request = functionImports
 
 #### **Q2-1. If it should be included, how?**
 
-**option 1**: create another class like `MethodRequestBuilderWithDataAccessor`
+**option 1**: create another parant class like `MethodRequestBuilderWithDataAccessor`
 (see below all request builder list)
 
 ```
 #action-function-import-request-builder-base.ts
 
-async execute(
-  destination: DestinationOrFetchOptions,
-  this.dataAccessor?
-): Promise<ReturnT> {
-  return this.executeRaw(destination).then(response => {
-    const data = dataAccessor
-      ? { d: dataAccessor(response.data) }
-      : response.data;
-    return this.responseTransformer(data);
-  });
+export abstract class ActionFunctionImportRequestBuilderBase<...>
+  extends MethodRequestBuilderWithDataAccessor<...> {
+  ...
+  async execute(
+    destination: DestinationOrFetchOptions,
+    this.dataAccessor?
+  ): Promise<ReturnT> {
+    return this.executeRaw(destination).then(response => {
+      const data = dataAccessor
+        ? { d: dataAccessor(response.data) }
+        : response.data;
+      return this.responseTransformer(data);
+    });
+  }
 }
 ```
 
@@ -138,12 +142,24 @@ async execute(
 
 #### **Q2-2. If it should be separated, how?**
 
-**option 1**: create another class like `MethodRequestBuilderWithDataAccessor` to separete it. can user call like.
+**option 1**: create another parent class like `MethodRequestBuilderWithDataAccessor` to separete it. can user call like.
+
 ```
 const request = functionImports
     .getAttachmentCount({param})
     .dataAccessor(data => data.d.GetAttachmentCount)
     .execute(destination)
+```
+
+the `dataAccessor()` will be in parent class like
+```
+#request-builder-base.ts
+
+export abstract class MethodRequestBuilderWithDataAccessor<...> {
+  ...
+  dataAccessor(...){...}
+  ...
+}
 ```
 - pros: no-duplication
 - cons: more complicated inhelitance

--- a/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
+++ b/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
@@ -135,7 +135,7 @@ const request = functionImports
 pros: no-duplication
 cons: more complicated inhelitance
 
-options 2: in each child cladd, dataAccessor method will be implemented..
+options 2: dataAccessor method is implemented in each child class.
 - pros: not comlicated inheritance, simple
 - cons: co-duplication
 

--- a/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
+++ b/knowledge-base/adr/0034-allow-deserialization-to-all-request-builders.md
@@ -20,7 +20,7 @@ This is a response of `GetAttachmentCount` in the cloud s/4 service `API_CV_ATTA
 ```
 In this case, user wants a value of `AttachmentCount` but it's wrapped by another object `GetAttachmentCount`.
 
-The `dataAccessor` can change the structure to what user want
+The `dataAccessor()` can change the structure to what user want
 ```
 const request = functionImports
     .getAttachmentCount({param})
@@ -36,9 +36,9 @@ then retuns
 ```
 
 ## Discussion
-Some other request builders also should have the `dataAcccessor`. However multiple implementation options are there.
+Some other request builders also should have the `dataAcccessor()`. However multiple implementation options are there.
 
-Q1. the `dataAccessor` should be in `exexute()` function parameter as optional or separeted?
+Q1. the `dataAccessor()` should be in `exexute()` function parameter as optional or separeted?
 
 option 1 - in `execute()` as same as a current implementation currentl implementation is nonly in action/function import request builder.
 ```
@@ -49,7 +49,7 @@ const request = functionImports
     .execute(destination, data => data.d.GetAttachmentCount)
 ```
 - pros: same as current functionality
-- cons: complicated. other request builder set by the builder like skip or selct are separeted but why dataAccessor uis special one?
+- cons: complicated. other methods `set`, `skip` or `selct` are separeted but why only dataAccessor() is included?
 
 option 2 - separated
 ```
@@ -60,13 +60,13 @@ const request = functionImports
     .dataAccessor(data => data.d.GetAttachmentCount)
     .execute(destination)
 ```
-- pros: keep `execure()` simple
-- cons: breaking change. deprecate. keep both.
+- pros: keep `execure()` simple.
+- cons: current one will be deprecated. both are needed. old one will be removed in fure version(breaking change)?
 
 Q2-1. If it should be included, how?
 
-option 1: create another class `MethodRequestBuilderWithDataAccessor`
-see below for a request builder list that shold have dataAccessor.
+option 1: create another class like `MethodRequestBuilderWithDataAccessor`
+(see below all request builder list)
 
 ```
 #action-function-import-request-builder-base.ts
@@ -122,11 +122,10 @@ async execute(
         )
     });
 ```
-option 
 
 Q2-2. If it should be separated, how?
 
-option 1: class between
+option 1: make it separeted and cann be called with below
 ```
 const request = functionImports
     .getAttachmentCount({param})
@@ -137,8 +136,8 @@ pros: no-duplication
 cons: more complicated inhelitance
 
 options 2: in each child cladd, dataAccessor method will be implemented..
-pros: not comlicated inheritance, simple
-cons: co-duplication
+- pros: not comlicated inheritance, simple
+- cons: co-duplication
 
 ## Target Request Builders
 

--- a/packages/odata-common/src/request-builder/action-function-import-request-builder-base.ts
+++ b/packages/odata-common/src/request-builder/action-function-import-request-builder-base.ts
@@ -24,8 +24,6 @@ export abstract class ActionFunctionImportRequestBuilderBase<
     super(requestConfig);
   }
 
-
-  //Zongping made a change a beloow to allow a deserialization
   /**
    * Execute request.
    * @param destination - Destination or DestinationFetchOptions to execute the request against.

--- a/packages/odata-common/src/request-builder/action-function-import-request-builder-base.ts
+++ b/packages/odata-common/src/request-builder/action-function-import-request-builder-base.ts
@@ -24,6 +24,8 @@ export abstract class ActionFunctionImportRequestBuilderBase<
     super(requestConfig);
   }
 
+
+  //Zongping made a change a beloow to allow a deserialization
   /**
    * Execute request.
    * @param destination - Destination or DestinationFetchOptions to execute the request against.


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes https://github.com/SAP/cloud-sdk-backlog/issues/698

Currently, only the action/function import request builder has `dataAccessor()` to deserialize different response structures. It also makes sense for all other request builders. 

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
