### PR TITLE
feat: support send html body of emails

### DIFF
--- a/packages/mail-client/src/mail-client-types.ts
+++ b/packages/mail-client/src/mail-client-types.ts
@@ -131,6 +131,10 @@ export interface MailOptions {
    */
   text?: string | Buffer | Readable | AttachmentLike | undefined;
   /**
+   * The HTML version of the message.
+   */
+  html?: string | Buffer | Readable | AttachmentLike | undefined;
+  /**
    * Object or array with additional headers.
    */
   headers?: Headers | undefined;

--- a/packages/mail-client/src/mail-client.spec.ts
+++ b/packages/mail-client/src/mail-client.spec.ts
@@ -42,6 +42,7 @@ describe('mail client', () => {
       to: 'to1@example.com',
       subject: 'subject',
       text: 'txt',
+      html: 'html',
       attachments: [{ content: 'content' }]
     };
     const mailOptions2: MailOptions = {


### PR DESCRIPTION
This key is mandatory for some mail servers 🤷 

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
