### PR TITLE
fix: use socks 2.6.2

### DIFF
--- a/packages/connectivity/src/scp-cf/connectivity-service.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.ts
@@ -84,7 +84,7 @@ export async function socksProxyHostAndPort(): Promise<ProxyConfiguration> {
   } as any);
   return {
     host: service.credentials.onpremise_proxy_host,
-    port: service.credentials.onpremise_socks5_proxy_port,
+    port: parseInt(service.credentials.onpremise_socks5_proxy_port),
     protocol: Protocol.SOCKS,
     'proxy-authorization': connectivityServiceToken
   };

--- a/packages/mail-client/package.json
+++ b/packages/mail-client/package.json
@@ -40,8 +40,8 @@
   "dependencies": {
     "@sap-cloud-sdk/connectivity": "^2.7.0",
     "@sap-cloud-sdk/util": "^2.7.0",
-    "nodemailer": "^6.7.7",
-    "socks": "^2.7.0"
+    "nodemailer": "6.7.7",
+    "socks": "2.6.2"
   },
   "devDependencies": {
     "@types/nodemailer": "^6.4.5",

--- a/packages/mail-client/src/mail-client.spec.ts
+++ b/packages/mail-client/src/mail-client.spec.ts
@@ -1,7 +1,8 @@
 import nodemailer from 'nodemailer';
 import { SocksClient } from 'socks';
-import { sendMail } from './mail-client';
-import { MailOptions } from './mail-client-types';
+import { Protocol } from '@sap-cloud-sdk/connectivity';
+import { buildSocksProxy, sendMail } from './mail-client';
+import { MailDestination, MailOptions } from './mail-client-types';
 
 describe('mail client', () => {
   beforeEach(() => {
@@ -100,3 +101,29 @@ describe('mail client', () => {
     expect(spyDestroySocket).toBeCalledTimes(1);
   });
 });
+
+describe('buildSocksProxy', () => {
+  it('build valid socks proxy', () => {
+    const dest: MailDestination = {
+      proxyConfiguration: {
+        host: 'www.proxy.com',
+        port: 12345,
+        protocol: Protocol.SOCKS
+      }
+    };
+    const proxy = buildSocksProxy(dest);
+    expect(isValidSocksProxy(proxy)).toBe(true);
+  });
+});
+
+// copied from socks lib
+function isValidSocksProxy(proxy) {
+  return (
+    proxy &&
+    (typeof proxy.host === 'string' || typeof proxy.ipaddress === 'string') &&
+    typeof proxy.port === 'number' &&
+    proxy.port >= 0 &&
+    proxy.port <= 65535 &&
+    (proxy.type === 4 || proxy.type === 5)
+  );
+}

--- a/packages/mail-client/src/mail-client.ts
+++ b/packages/mail-client/src/mail-client.ts
@@ -10,7 +10,7 @@ import {
   transformVariadicArgumentToArray
 } from '@sap-cloud-sdk/util';
 import nodemailer, { SentMessageInfo, Transporter } from 'nodemailer';
-import { SocksClient, SocksClientOptions } from 'socks';
+import { SocksClient, SocksClientOptions, SocksProxy } from 'socks';
 // eslint-disable-next-line import/no-internal-modules
 import type { Options } from 'nodemailer/lib/smtp-pool';
 import {
@@ -87,25 +87,32 @@ function getCredentials(
   return { username, password };
 }
 
-async function createSocket(mailDestination: MailDestination): Promise<Socket> {
+/**
+ * @internal
+ */
+export function buildSocksProxy(mailDestination: MailDestination): SocksProxy {
   if (!mailDestination.proxyConfiguration) {
     throw Error(
       'The proxy configuration is undefined, which is mandatory for creating a socket connection.'
     );
   }
+  return {
+    host: mailDestination.proxyConfiguration.host,
+    port: mailDestination.proxyConfiguration.port,
+    type: 5,
+    custom_auth_method: 0x80,
+    custom_auth_request_handler: () =>
+      customAuthRequestHandler(
+        mailDestination.proxyConfiguration?.['proxy-authentication']
+      ),
+    custom_auth_response_size: 2,
+    custom_auth_response_handler: customAuthResponseHandler
+  };
+}
+
+async function createSocket(mailDestination: MailDestination): Promise<Socket> {
   const connectionOptions: SocksClientOptions = {
-    proxy: {
-      host: mailDestination.proxyConfiguration.host,
-      port: mailDestination.proxyConfiguration.port,
-      type: 5,
-      custom_auth_method: 0x80,
-      custom_auth_request_handler: () =>
-        customAuthRequestHandler(
-          mailDestination.proxyConfiguration?.['proxy-authentication']
-        ),
-      custom_auth_response_size: 2,
-      custom_auth_response_handler: customAuthResponseHandler
-    },
+    proxy: buildSocksProxy(mailDestination),
     command: 'connect',
     destination: {
       host: mailDestination.host!,

--- a/packages/mail-client/src/mail-client.ts
+++ b/packages/mail-client/src/mail-client.ts
@@ -100,6 +100,8 @@ export function buildSocksProxy(mailDestination: MailDestination): SocksProxy {
     host: mailDestination.proxyConfiguration.host,
     port: mailDestination.proxyConfiguration.port,
     type: 5,
+    // socks doc here: https://github.com/JoshGlazebrook/socks#socksclientoptions
+    // see customAuthRequestHandler and customAuthResponseHandler for custom auth details.
     custom_auth_method: 0x80,
     custom_auth_request_handler: () =>
       customAuthRequestHandler(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4705,11 +4705,6 @@ ip@^1.1.5:
   resolved "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
-ip@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
-  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
-
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -6413,7 +6408,7 @@ nodemailer@6.7.3:
   resolved "https://registry.npmjs.org/nodemailer/-/nodemailer-6.7.3.tgz#b73f9a81b9c8fa8acb4ea14b608f5e725ea8e018"
   integrity sha512-KUdDsspqx89sD4UUyUKzdlUOper3hRkDVkrKh/89G+d9WKsU5ox51NWS4tB1XR5dPUdR4SP0E3molyEfOvSa3g==
 
-nodemailer@^6.7.7:
+nodemailer@6.7.7:
   version "6.7.7"
   resolved "https://registry.npmjs.org/nodemailer/-/nodemailer-6.7.7.tgz#e522fbd7507b81c51446d3f79c4603bf00083ddd"
   integrity sha512-pOLC/s+2I1EXuSqO5Wa34i3kXZG3gugDssH+ZNCevHad65tc8vQlCQpOLaUjopvkRQKm2Cki2aME7fEOPRy3bA==
@@ -7969,20 +7964,12 @@ socks-proxy-agent@^6.0.0:
     debug "^4.3.3"
     socks "^2.6.2"
 
-socks@^2.3.3, socks@^2.6.2:
+socks@2.6.2, socks@^2.3.3, socks@^2.6.2:
   version "2.6.2"
   resolved "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz#ec042d7960073d40d94268ff3bb727dc685f111a"
   integrity sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==
   dependencies:
     ip "^1.1.5"
-    smart-buffer "^4.2.0"
-
-socks@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz#f9225acdb841e874dca25f870e9130990f3913d0"
-  integrity sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==
-  dependencies:
-    ip "^2.0.0"
     smart-buffer "^4.2.0"
 
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:


### PR DESCRIPTION
When using `socks@2.7.0`  (with `nodemailer`) for creating socket connection, it failed.
As it's working with `socks@2.6.2`, let's stick to the old version for now.

Also, there is a type fix about port.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
