### PR TITLE
fix: proxy authentication typo for sending mails

### DIFF
--- a/packages/mail-client/src/mail-client.spec.ts
+++ b/packages/mail-client/src/mail-client.spec.ts
@@ -84,7 +84,9 @@ describe('mail client', () => {
       proxyType: 'OnPremise',
       proxyConfiguration: {
         host: 'smtp.gmail.com',
-        port: 587
+        port: 587,
+        protocol: Protocol.SOCKS,
+        'proxy-authorization': 'jwt'
       }
     };
     const mailOptions: MailOptions = {
@@ -108,7 +110,8 @@ describe('buildSocksProxy', () => {
       proxyConfiguration: {
         host: 'www.proxy.com',
         port: 12345,
-        protocol: Protocol.SOCKS
+        protocol: Protocol.SOCKS,
+        'proxy-authorization': 'jwt'
       }
     };
     const proxy = buildSocksProxy(dest);

--- a/packages/mail-client/src/mail-client.ts
+++ b/packages/mail-client/src/mail-client.ts
@@ -96,7 +96,7 @@ export function buildSocksProxy(mailDestination: MailDestination): SocksProxy {
       'The proxy configuration is undefined, which is mandatory for creating a socket connection.'
     );
   }
-  
+
   const proxyAuthorization =
     mailDestination.proxyConfiguration['proxy-authorization'];
   if (!proxyAuthorization) {

--- a/packages/mail-client/src/mail-client.ts
+++ b/packages/mail-client/src/mail-client.ts
@@ -103,6 +103,7 @@ export function buildSocksProxy(mailDestination: MailDestination): SocksProxy {
     throw Error(
       'The proxy authorization is undefined, which is mandatory for creating a socket connection.'
     );
+  }
   return {
     host: mailDestination.proxyConfiguration.host,
     port: mailDestination.proxyConfiguration.port,

--- a/packages/mail-client/src/mail-client.ts
+++ b/packages/mail-client/src/mail-client.ts
@@ -93,6 +93,13 @@ async function createSocket(mailDestination: MailDestination): Promise<Socket> {
       'The proxy configuration is undefined, which is mandatory for creating a socket connection.'
     );
   }
+  const proxyAuthorization =
+    mailDestination.proxyConfiguration['proxy-authorization'];
+  if (!proxyAuthorization) {
+    throw Error(
+      'The proxy authorization is undefined, which is mandatory for creating a socket connection.'
+    );
+  }
   const connectionOptions: SocksClientOptions = {
     proxy: {
       host: mailDestination.proxyConfiguration.host,
@@ -100,9 +107,7 @@ async function createSocket(mailDestination: MailDestination): Promise<Socket> {
       type: 5,
       custom_auth_method: 0x80,
       custom_auth_request_handler: () =>
-        customAuthRequestHandler(
-          mailDestination.proxyConfiguration?.['proxy-authentication']
-        ),
+        customAuthRequestHandler(proxyAuthorization),
       custom_auth_response_size: 2,
       custom_auth_response_handler: customAuthResponseHandler
     },


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

There is a typo (`proxy-authorization` vs `proxy-authentication`), which was not detected during compile time 🤷 , even the key was defined in the type.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
