### PR TITLE
chore: trigger canary release nightly or on demand

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,19 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14
+      - name: Check if latest commit is within 24 hrs
+        run: |
+          lastCommitDate=$(git --no-pager log -n 1 main --pretty=format:"%at")
+          curDate=$(date +%s)
+          dateDiff=$(expr $curDate - $lastCommitDate)
+          echo $lastCommitDate, $curDate, $dateDiff
+
+          if [[ $dateDiff -gt 86400 ]]
+          then
+              echo 'No new commit found on ${{ github.ref }} within the last 24 hrs.'
+              echo 'Canceling the canary release...'
+              curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel
+          fi
       - uses: actions/cache@v3
         id: cache
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
     - cron: '0 1 * * *'
   workflow_dispatch:
     inputs:
-      canary-relase:
+      canary-release:
         description: 'Canary release after build'
         type: boolean
         required: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,14 +118,17 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-  canary-release:
+  canary-release-pre-check:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.canary-release == true || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.date-check.outputs.skip }}
     needs: [tests, checks, e2e-tests]
     steps:
       - uses: actions/checkout@v3
       - run: git fetch --depth=1
-      - name: Check if latest commit is within 24 hrs
+      - id: date-check
+        name: Check if latest commit is within 24 hrs
         run: |
           lastCommitDate=$(git --no-pager log -n 1 main --pretty=format:"%at")
           curDate=$(date +%s)
@@ -135,9 +138,17 @@ jobs:
           if [[ $dateDiff -gt 86400 ]]
           then
               echo 'No new commit found on ${{ github.ref }} within the last 24 hrs.'
-              echo 'Canceling the canary release...'
-              curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel
+              echo '::set-output name=skip::true'
+          else
+              echo '::set-output name=skip::false'
           fi
+  canary-release:
+    if: ${{ needs.canary-release-pre-check.outputs.skip == 'false' }}
+    runs-on: ubuntu-latest
+    needs: [canary-release-pre-check]
+    steps:
+      - uses: actions/checkout@v3
+      - run: git fetch --depth=1
       - uses: actions/setup-node@v3
         with:
           node-version: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,14 @@ on:
     tags: ['v*']
     paths-ignore:
       - 'docs/**'
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+    inputs:
+      canary-relase:
+        description: 'Canary release after build'
+        type: boolean
+        required: false
 
 jobs:
   tests:
@@ -111,7 +119,7 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   canary-release:
-    if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v2')
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.canary-release == true || github.event_name == 'schedule' }
     runs-on: ubuntu-latest
     needs: [tests, checks, e2e-tests]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,9 +125,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: git fetch --depth=1
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
       - name: Check if latest commit is within 24 hrs
         run: |
           lastCommitDate=$(git --no-pager log -n 1 main --pretty=format:"%at")
@@ -141,6 +138,9 @@ jobs:
               echo 'Canceling the canary release...'
               curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/cancel
           fi
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
       - uses: actions/cache@v3
         id: cache
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   canary-release:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.canary-release == true || github.event_name == 'schedule' }
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.canary-release == true || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     needs: [tests, checks, e2e-tests]
     steps:


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#836.

I changed the trigger event for the canary release to `schedule` and `workflow_dispatch`.

`workflow_dispatch`: The input `canary-release` variable will switch on/off the canary release.

Please double-check the `schedule` time to make it work with the nightly e2e test.

As required, the canary release (for both `schedule` and `workflow_dispatch`) will only happen if the `canary-release-pre-check` was successful, i.e., there were new commits during the last 24 hrs. Otherwise, after running all checks and tests, the actual `canary-release` workflow will be skipped. See [passing job outputs to another job](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-defining-outputs-for-a-job).


