### PR TITLE
feat: set global transport

### DIFF
--- a/.changeset/slow-emus-drum.md
+++ b/.changeset/slow-emus-drum.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/util': minor
 ---
 
-[New Functionality] Add method `setGlobalTransports` to support implementation of setting custom transport globally.
+[New Functionality] Add method `setGlobalTransports` to support setting custom transport globally.

--- a/.changeset/slow-emus-drum.md
+++ b/.changeset/slow-emus-drum.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/util': minor
+---
+
+[New Functionality] Add method `setGlobalTransports` to support implementation of setting custom transport globally.

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -39,7 +39,8 @@
     "logform": "^2.4.2",
     "promise.allsettled": "^1.0.4",
     "voca": "^1.4.0",
-    "winston": "^3.8.1"
+    "winston": "^3.8.1",
+    "winston-transport": "^4.5.0"
   },
   "devDependencies": {
     "nock": "^13.2.9",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "nock": "^13.2.9",
-    "typescript": "~4.7.4"
+    "typescript": "~4.7.4",
+    "mock-fs": "^5.1.4"
   }
 }

--- a/packages/util/src/logger/cloud-sdk-logger.spec.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.spec.ts
@@ -253,7 +253,7 @@ describe('Cloud SDK Logger', () => {
   describe('set global transport', () => {
     beforeEach(() => {
       logger = createLogger(messageContext);
-    })
+    });
     it('should replace all transpots in all active loggers with the global transport', async () => {
       const consoleSpy = jest.spyOn(process.stdout, 'write');
       const rootNodeModules = path.resolve(
@@ -281,14 +281,26 @@ describe('Cloud SDK Logger', () => {
       expect(defaultExceptionLogger?.transports).toHaveLength(1);
       expect(defaultExceptionLogger?.transports).toContainEqual(fileTransport);
 
-      logger.info('info logs only in test.log');
-      logger.error('error logs only in test.log');
-      logger.verbose('verbose error logs nowhere')
+      logger.error(
+        'logs error only in test.log because the level is less than info'
+      );
+      logger.info(
+        'logs info only in test.log because the level is equal to info'
+      );
+      logger.verbose(
+        'logs verbose nowhere because the level is higher than info'
+      );
       expect(consoleSpy).not.toBeCalled();
       const log = await fs.promises.readFile('test.log', { encoding: 'utf-8' });
-      expect(log).toMatch(/info logs only in test.log/);
-      expect(log).toMatch(/error logs only in test.log/);
-      expect(log).not.toMatch(/verbose error logs nowhere/)
+      expect(log).toMatch(
+        /logs error only in test.log because the level is less than info/
+      );
+      expect(log).toMatch(
+        /logs info only in test.log because the level is equal to info/
+      );
+      expect(log).not.toMatch(
+        /logs verbose nowhere because the level is higher than info/
+      );
       mock.restore();
     });
     it('should accept multiple transports', () => {

--- a/packages/util/src/logger/cloud-sdk-logger.spec.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.spec.ts
@@ -252,8 +252,8 @@ describe('Cloud SDK Logger', () => {
 
   describe('set global transport', () => {
     it('should replace all transpots in all active loggers with the global transport', async () => {
-    const customLogger = createLogger(messageContext);
-    const consoleSpy = jest.spyOn(process.stdout, 'write');
+      const customLogger = createLogger(messageContext);
+      const consoleSpy = jest.spyOn(process.stdout, 'write');
       const rootNodeModules = path.resolve(
         __dirname,
         '../../../../node_modules'

--- a/packages/util/src/logger/cloud-sdk-logger.spec.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.spec.ts
@@ -254,7 +254,7 @@ describe('Cloud SDK Logger', () => {
     beforeEach(() => {
       logger = createLogger(messageContext);
     });
-    it('should replace all transpots in all active loggers with the global transport', async () => {
+    it('should replace all transports in all active loggers with the global transport', async () => {
       const consoleSpy = jest.spyOn(process.stdout, 'write');
       const rootNodeModules = path.resolve(
         __dirname,

--- a/packages/util/src/logger/cloud-sdk-logger.spec.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.spec.ts
@@ -303,12 +303,6 @@ describe('Cloud SDK Logger', () => {
       );
       mock.restore();
     });
-    it('should accept multiple transports', () => {
-      const httpTransport = new transports.Http();
-      const streamTransport = new transports.Console();
-      setGlobalTransports(httpTransport, streamTransport);
-      expect(logger?.transports).toHaveLength(2);
-    });
     it('should accept an array with multiple transports', () => {
       const httpTransport = new transports.Http();
       const streamTransport = new transports.Console();

--- a/packages/util/src/logger/cloud-sdk-logger.spec.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.spec.ts
@@ -251,7 +251,7 @@ describe('Cloud SDK Logger', () => {
   });
 
   describe('set global transport', () => {
-    const logger = createLogger(messageContext);
+    const customLogger = createLogger(messageContext);
     const httpTransport = new transports.Http();
     const streamTransport = new transports.Console();
 
@@ -270,18 +270,20 @@ describe('Cloud SDK Logger', () => {
         level: 'info'
       });
       const defaultLogger = getLogger('cloud-sdk-logger');
-      const defaultExceptionLogger = getLogger('sap-cloud-sdk-exception-logger');
+      const defaultExceptionLogger = getLogger(
+        'sap-cloud-sdk-exception-logger'
+      );
 
       setGlobalTransports(fileTransport);
 
-      expect(logger?.transports).toHaveLength(1);
-      expect(logger?.transports).toContainEqual(fileTransport);
+      expect(customLogger?.transports).toHaveLength(1);
+      expect(customLogger?.transports).toContainEqual(fileTransport);
       expect(defaultLogger?.transports).toHaveLength(1);
       expect(defaultLogger?.transports).toContainEqual(fileTransport);
       expect(defaultExceptionLogger?.transports).toHaveLength(1);
       expect(defaultExceptionLogger?.transports).toContainEqual(fileTransport);
 
-      logger.info('logs only in test.log');
+      customLogger.info('logs only in test.log');
       expect(consoleSpy).not.toBeCalled();
       const log = await fs.promises.readFile('test.log', { encoding: 'utf-8' });
       expect(log).toMatch(/logs only in test.log/);
@@ -289,11 +291,11 @@ describe('Cloud SDK Logger', () => {
     });
     it('should accept multiple transports', () => {
       setGlobalTransports(httpTransport, streamTransport);
-      expect(logger?.transports).toHaveLength(2);
+      expect(customLogger?.transports).toHaveLength(2);
     });
     it('should accept an array with multiple transports', () => {
       setGlobalTransports([httpTransport, streamTransport]);
-      expect(logger?.transports).toHaveLength(2);
+      expect(customLogger?.transports).toHaveLength(2);
     });
   });
 

--- a/packages/util/src/logger/cloud-sdk-logger.spec.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.spec.ts
@@ -251,12 +251,9 @@ describe('Cloud SDK Logger', () => {
   });
 
   describe('set global transport', () => {
-    const customLogger = createLogger(messageContext);
-    const httpTransport = new transports.Http();
-    const streamTransport = new transports.Console();
-
     it('should replace all transpots in all active loggers with the global transport', async () => {
-      const consoleSpy = jest.spyOn(process.stdout, 'write');
+    const customLogger = createLogger(messageContext);
+    const consoleSpy = jest.spyOn(process.stdout, 'write');
       const rootNodeModules = path.resolve(
         __dirname,
         '../../../../node_modules'
@@ -275,7 +272,6 @@ describe('Cloud SDK Logger', () => {
       );
 
       setGlobalTransports(fileTransport);
-
       expect(customLogger?.transports).toHaveLength(1);
       expect(customLogger?.transports).toContainEqual(fileTransport);
       expect(defaultLogger?.transports).toHaveLength(1);
@@ -290,12 +286,18 @@ describe('Cloud SDK Logger', () => {
       mock.restore();
     });
     it('should accept multiple transports', () => {
+      logger = createLogger(messageContext);
+      const httpTransport = new transports.Http();
+      const streamTransport = new transports.Console();
       setGlobalTransports(httpTransport, streamTransport);
-      expect(customLogger?.transports).toHaveLength(2);
+      expect(logger?.transports).toHaveLength(2);
     });
     it('should accept an array with multiple transports', () => {
+      logger = createLogger(messageContext);
+      const httpTransport = new transports.Http();
+      const streamTransport = new transports.Console();
       setGlobalTransports([httpTransport, streamTransport]);
-      expect(customLogger?.transports).toHaveLength(2);
+      expect(logger?.transports).toHaveLength(2);
     });
   });
 

--- a/packages/util/src/logger/cloud-sdk-logger.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.ts
@@ -206,7 +206,7 @@ export function getGlobalLogLevel(): string | undefined {
 
 /**
  * Change the global transport of the container which will set default transport for all active loggers.
- * e.g., to set the global transport call `addTransporstGlobally(httpTransport)`.
+ * e.g., to set the global transport call `setGlobalTransports(httpTransport)`.
  * @param customTransports - The transport to set the global transport to. Both array and varargs are supported.
  */
 export function setGlobalTransports(

--- a/packages/util/src/logger/cloud-sdk-logger.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.ts
@@ -5,6 +5,7 @@ import {
   LoggerOptions as WinstonLoggerOptions,
   transports
 } from 'winston';
+import TransportStream from 'winston-transport';
 import { kibana, local } from './format';
 
 const loggerReference = 'sap-cloud-sdk-logger';
@@ -201,6 +202,10 @@ export function setGlobalLogLevel(level: LogLevel): void {
  */
 export function getGlobalLogLevel(): string | undefined {
   return container.options.level;
+}
+
+export function setGlobalTransport(transport:TransportStream){
+  container.loggers.forEach(logger => logger.transports.push(transport));
 }
 
 /**

--- a/packages/util/src/logger/cloud-sdk-logger.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.ts
@@ -212,17 +212,11 @@ export function setGlobalTransports(
   customTransports: TransportStream | TransportStream[]
 ): void {
   container.options.transports = customTransports;
-  const isArray = (
-    transport: TransportStream | TransportStream[]
-  ): transport is TransportStream[] =>
-    Array.isArray(customTransports as TransportStream[]);
   container.loggers.forEach(logger => {
     logger.clear();
-    if (isArray(customTransports)) {
-      customTransports.forEach(transport => logger.add(transport));
-    } else {
-      logger.add(customTransports);
-    }
+    return Array.isArray(customTransports)
+      ? customTransports.forEach(transport => logger.add(transport))
+      : logger.add(customTransports);
   });
 }
 

--- a/packages/util/src/logger/cloud-sdk-logger.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.ts
@@ -206,7 +206,7 @@ export function getGlobalLogLevel(): string | undefined {
 /**
  * Change the global transport of the container which will set default transport for all active loggers.
  * e.g., to set the global transport call `setGlobalTransports(httpTransport)`.
- * @param customTransports - The transport to set the global transport to. Both single transport and an array with multiple transpots are supported.
+ * @param customTransports - The transport to set the global transport to. Both single transport and an array with multiple transports are supported.
  */
 export function setGlobalTransports(
   customTransports: TransportStream | TransportStream[]

--- a/packages/util/src/logger/cloud-sdk-logger.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.ts
@@ -6,7 +6,6 @@ import {
   transports
 } from 'winston';
 import TransportStream from 'winston-transport';
-import { transformVariadicArgumentToArray } from '../array';
 import { kibana, local } from './format';
 const loggerReference = 'sap-cloud-sdk-logger';
 const exceptionLoggerId = 'sap-cloud-sdk-exception-logger';
@@ -207,22 +206,23 @@ export function getGlobalLogLevel(): string | undefined {
 /**
  * Change the global transport of the container which will set default transport for all active loggers.
  * e.g., to set the global transport call `setGlobalTransports(httpTransport)`.
- * @param customTransports - The transport to set the global transport to. Both array and varargs are supported.
+ * @param customTransports - The transport to set the global transport to. Both single transport and an array with multiple transpots are supported.
  */
 export function setGlobalTransports(
-  ...customTransports: TransportStream[]
-): void;
-export function setGlobalTransports(customTransports: TransportStream[]): void;
-/* eslint-disable jsdoc/require-jsdoc */
-export function setGlobalTransports(
-  first: TransportStream | TransportStream[],
-  ...rest: TransportStream[]
+  customTransports: TransportStream | TransportStream[]
 ): void {
-  const customTransports = transformVariadicArgumentToArray(first, rest);
   container.options.transports = customTransports;
+  const isArray = (
+    transport: TransportStream | TransportStream[]
+  ): transport is TransportStream[] =>
+    Array.isArray(customTransports as TransportStream[]);
   container.loggers.forEach(logger => {
     logger.clear();
-    customTransports.forEach(transport => logger.add(transport));
+    if (isArray(customTransports)) {
+      customTransports.forEach(transport => logger.add(transport));
+    } else {
+      logger.add(customTransports);
+    }
   });
 }
 


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes [#367](https://github.com/SAP/cloud-sdk-backlog/issues/367)

This added a new method that enables users to set transport globally. When the user sets the global transport, all transports in all loggers including default loggers are replaced with the global transport.

example
```
const fileTransport = new winston.transports.File({
  filename: "info.log",
  level: "info",
});
const httpTransport = new winston.transports.Http({
  host: "localhost",
  port: 8080,
});
setGlobalTransports([fileTransport, streamTransport]);
```

#### Changes

- made a new method `setGlobalTransports()` that sets transports globally
- added tests for the new function
- added dependency for the new function

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
