### PR TITLE
chore: Move `mock.restore` to `afterEach`

### DIFF
--- a/packages/generator-common/src/compiler.spec.ts
+++ b/packages/generator-common/src/compiler.spec.ts
@@ -17,7 +17,7 @@ import {
 
 describe('compiler options', () => {
   const pathRootNodeModules = resolve(__dirname, '../../../node_modules');
-  beforeAll(() => {
+  beforeEach(() => {
     mock({
       [pathRootNodeModules]: mock.load(pathRootNodeModules),
       'config1/tsconfig.json': JSON.stringify({
@@ -42,7 +42,7 @@ describe('compiler options', () => {
     });
   });
 
-  afterAll(() => {
+  afterEach(() => {
     mock.restore();
   });
 
@@ -103,7 +103,7 @@ describe('compiler options', () => {
 });
 
 describe('compilation', () => {
-  beforeAll(async () => {
+  beforeEach(async () => {
     const rootNodeModules = resolve(__dirname, '../../../node_modules');
     const packageNodeModules = resolve(__dirname, '../node_modules');
     mock({
@@ -130,7 +130,7 @@ describe('compilation', () => {
     };
   }
 
-  afterAll(() => {
+  afterEach(() => {
     mock.restore();
   });
 

--- a/packages/generator-common/src/file-writer/copy-file.spec.ts
+++ b/packages/generator-common/src/file-writer/copy-file.spec.ts
@@ -3,6 +3,8 @@ import mock from 'mock-fs';
 import { copyFile } from './copy-file';
 
 describe('copyFile', () => {
+  afterEach(() => mock.restore());
+
   it('should copy file', async () => {
     const newContent = 'new';
     mock({
@@ -18,7 +20,6 @@ describe('copyFile', () => {
       encoding: 'utf-8'
     });
     expect(actual).toBe(newContent);
-    mock.restore();
   });
 
   it('should overwrite when overwrite is set', async () => {
@@ -37,7 +38,6 @@ describe('copyFile', () => {
       encoding: 'utf-8'
     });
     expect(actual).toBe(newContent);
-    mock.restore();
   });
 
   it('should not overwrite when overwrite is not set', async () => {
@@ -56,6 +56,5 @@ describe('copyFile', () => {
       encoding: 'utf-8'
     });
     expect(actual).toBe(oldContent);
-    mock.restore();
   });
 });

--- a/packages/generator/src/input-path-provider.spec.ts
+++ b/packages/generator/src/input-path-provider.spec.ts
@@ -3,6 +3,8 @@ import mock from 'mock-fs';
 import { swaggerPathForEdmx } from './input-path-provider';
 
 describe('swaggerPathForEdmx', () => {
+  afterEach(() => mock.restore());
+
   it('replaces path ending with .json', () => {
     mock({
       '/service-specs': {
@@ -13,7 +15,6 @@ describe('swaggerPathForEdmx', () => {
     expect(swaggerPathForEdmx('/service-specs/service.edmx')).toEqual(
       `${sep}service-specs${sep}service.json`
     );
-    mock.restore();
   });
 
   it('replaces path ending with .JSON', () => {
@@ -26,7 +27,6 @@ describe('swaggerPathForEdmx', () => {
     expect(swaggerPathForEdmx('/service-specs/service.edmx')).toEqual(
       `${sep}service-specs${sep}service.JSON`
     );
-    mock.restore();
   });
 
   it('returns undefined if there is no equally named json file', () => {
@@ -38,6 +38,5 @@ describe('swaggerPathForEdmx', () => {
       }
     });
     expect(swaggerPathForEdmx('/service-specs/service.edmx')).toBeUndefined();
-    mock.restore();
   });
 });

--- a/packages/openapi-generator/src/document-converter.spec.ts
+++ b/packages/openapi-generator/src/document-converter.spec.ts
@@ -137,6 +137,8 @@ describe('document-converter', () => {
   });
 
   describe('parseFileAsJson', () => {
+    afterEach(() => mock.restore());
+
     it('does not throw error for JSON or YAML files', async () => {
       const jsonContent = { test: 'test' };
       mock({
@@ -155,7 +157,6 @@ describe('document-converter', () => {
       expect(await parseFileAsJson('/path/spec.yml')).toStrictEqual(
         jsonContent
       );
-      mock.restore();
     });
 
     it('throws an error for non JSON or YAML files', async () => {
@@ -175,7 +176,6 @@ describe('document-converter', () => {
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         '"Could not parse OpenAPI specification at /path/other-extension.test. Only JSON and YAML files are allowed."'
       );
-      mock.restore();
     });
   });
 });

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -13,12 +13,12 @@ jest.mock('../../generator-common/internal', () => {
 const { readFile } = promises;
 
 describe('generator', () => {
-  afterAll(() => {
+  afterEach(() => {
     mock.restore();
   });
 
   describe('get input file paths', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       mock({
         root: {
           inputDir: {
@@ -40,11 +40,11 @@ describe('generator', () => {
       });
     });
 
-    const inputDir = 'root/inputDir';
-
-    afterAll(() => {
+    afterEach(() => {
       mock.restore();
     });
+
+    const inputDir = 'root/inputDir';
 
     it('should return an array with one file path for an input file', async () => {
       expect(
@@ -88,7 +88,7 @@ describe('generator', () => {
   });
 
   describe('creation of files', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
       mock.restore();
       const inputFile = resolve(
         __dirname,
@@ -127,7 +127,7 @@ describe('generator', () => {
     const outputPath = resolve('root', 'outputDir', 'mySpec');
     const inputPath = resolve('root', 'inputDir');
 
-    afterAll(() => {
+    afterEach(() => {
       jest.clearAllMocks();
       mock.restore();
     });
@@ -291,7 +291,7 @@ describe('generator', () => {
   });
 
   describe('overwrite', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       mock({
         specs: {
           'spec.json': JSON.stringify({
@@ -310,7 +310,7 @@ describe('generator', () => {
       });
     });
 
-    afterAll(() => {
+    afterEach(() => {
       mock.restore();
     });
 

--- a/packages/openapi-generator/src/options/options-per-service.spec.ts
+++ b/packages/openapi-generator/src/options/options-per-service.spec.ts
@@ -27,7 +27,7 @@ describe('getOriginalOptionsPerService', () => {
     }
   };
 
-  beforeAll(() => {
+  beforeEach(() => {
     mock({
       path: {
         'myConfig.json': JSON.stringify(config)
@@ -35,7 +35,7 @@ describe('getOriginalOptionsPerService', () => {
     });
   });
 
-  afterAll(() => {
+  afterEach(() => {
     mock.restore();
   });
 
@@ -91,7 +91,7 @@ describe('getServiceOptions', () => {
 });
 
 describe('getOptionsPerService', () => {
-  afterAll(() => {
+  afterEach(() => {
     mock.restore();
   });
 

--- a/packages/openapi-generator/src/options/tsconfig-json.spec.ts
+++ b/packages/openapi-generator/src/options/tsconfig-json.spec.ts
@@ -3,6 +3,10 @@ import { ParsedGeneratorOptions } from './generator-options';
 import { defaultTsConfig, tsconfigJson } from './tsconfig-json';
 
 describe('tsconfigJson', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
   it('returns the default tsconfig if transpilation is enabled', async () => {
     const tsConfig = await tsconfigJson({
       transpile: true
@@ -28,7 +32,6 @@ describe('tsconfigJson', () => {
       tsConfig: './path/customConfig.json'
     } as ParsedGeneratorOptions);
     expect(JSON.parse(tsConfig!)).toEqual(customConfig);
-    mock.restore();
   });
 
   it('returns custom config content if custom directory path is defined', async () => {
@@ -42,7 +45,6 @@ describe('tsconfigJson', () => {
       tsConfig: './path'
     } as ParsedGeneratorOptions);
     expect(JSON.parse(tsConfig!)).toEqual(customConfig);
-    mock.restore();
   });
 
   it('returns custom config content if custom file or directory does not exist', async () => {
@@ -54,6 +56,5 @@ describe('tsconfigJson', () => {
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       '"Could not read tsconfig.json at ./path."'
     );
-    mock.restore();
   });
 });

--- a/packages/test-util/src/test-destination-mocker.spec.ts
+++ b/packages/test-util/src/test-destination-mocker.spec.ts
@@ -18,7 +18,7 @@ describe('setTestDestinationInEnv', () => {
     name: 'envDestination'
   };
 
-  beforeAll(() => {
+  beforeEach(() => {
     mock({
       [pathRootNodeModules]: mock.load(pathRootNodeModules),
       'systems.json': JSON.stringify(systems),
@@ -26,11 +26,8 @@ describe('setTestDestinationInEnv', () => {
     });
   });
 
-  afterAll(() => {
-    mock.restore();
-  });
-
   afterEach(() => {
+    mock.restore();
     delete process.env['destinations'];
   });
 

--- a/scripts/check-public-api.spec.ts
+++ b/scripts/check-public-api.spec.ts
@@ -12,6 +12,8 @@ import {
 } from './check-public-api';
 
 describe('check-public-api', () => {
+  afterEach(() => mock.restore());
+
   it('checkIndexFileExists fails if index file is not in root', () => {
     mock({
       root: {
@@ -23,10 +25,11 @@ describe('check-public-api', () => {
     expect(() => checkIndexFileExists('root/index.ts')).toThrowError(
       'No index.ts file found in root.'
     );
-    mock.restore();
   });
 
   describe('exportAllInBarrel', () => {
+    afterEach(() => mock.restore());
+
     it('fails if internal.ts is not present in root', async () => {
       mock({
         src: {
@@ -39,7 +42,6 @@ describe('check-public-api', () => {
       await expect(() =>
         exportAllInBarrel('src', 'internal.ts')
       ).rejects.toThrowError("No 'internal.ts' file found in 'src'.");
-      mock.restore();
     });
 
     it('fails if a file is not exported in barrel file', async () => {
@@ -64,7 +66,6 @@ describe('check-public-api', () => {
       expect(errorSpy).toHaveBeenCalledWith(
         "'dir2' is not exported in 'dir1/index.ts'."
       );
-      mock.restore();
     });
   });
 
@@ -81,7 +82,6 @@ describe('check-public-api', () => {
       }
     });
     checkBarrelRecursive('dir1');
-    mock.restore();
   });
 
   it('typeDescriptorPaths finds the .d.ts files and excludes index.d.ts', () => {
@@ -101,7 +101,6 @@ describe('check-public-api', () => {
       'dir1/dir2/file3.d.ts',
       'dir1/file1.d.ts'
     ]);
-    mock.restore();
   });
 
   describe('parseTypeDefinitionFile', () => {
@@ -149,6 +148,8 @@ describe('check-public-api', () => {
   });
 
   describe('parseIndexFile', () => {
+    afterEach(() => mock.restore());
+
     it('parses referenced star imports', async () => {
       mock({
         'index.ts': "export * from './common';export * from './subdir/ref';",
@@ -165,27 +166,19 @@ describe('check-public-api', () => {
         'crossRefExport',
         'subdirRefExport'
       ]);
-
-      mock.restore();
     });
 
-    it('parses exports types correctly',async ()=>{
+    it('parses exports types correctly', async () => {
       mock({
-        'index.ts': "export * from './common';export type { namedExport } from './named';",
-        'common.ts':
-            "export type { commonExport } from './local'",
-        'named.ts':"export type { namedExport } from './local'"
+        'index.ts':
+          "export * from './common';export type { namedExport } from './named';",
+        'common.ts': "export type { commonExport } from './local'",
+        'named.ts': "export type { namedExport } from './local'"
       });
 
-      const result = await parseIndexFile('index.ts')
- expect(result).toEqual([
-   'namedExport',
-     'commonExport'
-
-      ]);
-
-      mock.restore();
-    })
+      const result = await parseIndexFile('index.ts');
+      expect(result).toEqual(['namedExport', 'commonExport']);
+    });
 
     it('ignores public re-exports', async () => {
       mock({
@@ -194,8 +187,6 @@ describe('check-public-api', () => {
       });
 
       await expect(parseIndexFile('index.ts')).resolves.toEqual(['local']);
-
-      mock.restore();
     });
 
     it('throws an error on internal re-exports', async () => {
@@ -207,8 +198,6 @@ describe('check-public-api', () => {
       await expect(parseIndexFile('index.ts')).rejects.toThrowError(
         "Re-exporting internal modules is not allowed. 'internal' exported in 'index.ts'."
       );
-
-      mock.restore();
     });
   });
 });

--- a/scripts/check-public-api.ts
+++ b/scripts/check-public-api.ts
@@ -112,33 +112,37 @@ function compareApisAndLog(
  * @param pathToPackage - Path to the package.
  */
 export async function checkApiOfPackage(pathToPackage: string): Promise<void> {
-  logger.info(`Check package: ${pathToPackage}`);
-  const { pathToSource, pathCompiled } = paths(pathToPackage);
-  mockFileSystem(pathToPackage);
-  await transpileDirectory(
-    pathToSource,
-    await getCompilerOptions(pathToPackage)
-  );
-  await checkBarrelRecursive(pathToSource);
+  try {
+    logger.info(`Check package: ${pathToPackage}`);
+    const { pathToSource, pathCompiled } = paths(pathToPackage);
+    mockFileSystem(pathToPackage);
+    await transpileDirectory(
+      pathToSource,
+      await getCompilerOptions(pathToPackage)
+    );
+    await checkBarrelRecursive(pathToSource);
 
-  const indexFilePath = join(pathToSource, 'index.ts');
-  checkIndexFileExists(indexFilePath);
+    const indexFilePath = join(pathToSource, 'index.ts');
+    checkIndexFileExists(indexFilePath);
 
-  const allExportedTypes = await parseTypeDefinitionFiles(pathCompiled);
-  const allExportedIndex = await parseIndexFile(indexFilePath);
+    const allExportedTypes = await parseTypeDefinitionFiles(pathCompiled);
+    const allExportedIndex = await parseIndexFile(indexFilePath);
 
-  const setsAreEqual = compareApisAndLog(
-    allExportedIndex,
-    allExportedTypes,
-    true
-  );
-  mock.restore();
-  if (!setsAreEqual) {
-    process.exit(1);
+    const setsAreEqual = compareApisAndLog(
+      allExportedIndex,
+      allExportedTypes,
+      true
+    );
+    mock.restore();
+    if (!setsAreEqual) {
+      process.exit(1);
+    }
+    logger.info(
+      `The index.ts of package ${pathToPackage} is in sync with the type annotations.`
+    );
+  } finally {
+    mock.restore();
   }
-  logger.info(
-    `The index.ts of package ${pathToPackage} is in sync with the type annotations.`
-  );
 }
 
 export function checkIndexFileExists(indexFilePath: string): void {

--- a/scripts/get-package-version.spec.ts
+++ b/scripts/get-package-version.spec.ts
@@ -1,9 +1,9 @@
-import mock from "mock-fs";
+import mock from 'mock-fs';
 import { resolve } from 'path';
-import { getPackageVersion } from "./get-package-version";
+import { getPackageVersion } from './get-package-version';
 
 describe('get package version', () => {
-  afterAll(() => {
+  afterEach(() => {
     mock.restore();
   });
 
@@ -12,7 +12,7 @@ describe('get package version', () => {
       'package.json': `{ "version": "1.2.3" }`
     });
     expect(getPackageVersion()).toBe('1.2.3');
-  })
+  });
 
   it('returns the version of a designated package json', () => {
     mock({
@@ -20,6 +20,6 @@ describe('get package version', () => {
         'package.json': `{ "version": "4.5.6" }`
       }
     });
-    expect(getPackageVersion( resolve('dir', 'package.json'))).toBe('4.5.6');
-  })
-})
+    expect(getPackageVersion(resolve('dir', 'package.json'))).toBe('4.5.6');
+  });
+});

--- a/test-packages/e2e-tests/test/generator-cli.spec.ts
+++ b/test-packages/e2e-tests/test/generator-cli.spec.ts
@@ -32,6 +32,7 @@ describe('generator-cli', () => {
     fs.removeSync(outputDir);
     mock.restore();
   });
+
   it('should fail if mandatory parameters are not there', async () => {
     try {
       await execa('npx', ['ts-node', pathToGenerator]);
@@ -41,6 +42,7 @@ describe('generator-cli', () => {
       );
     }
   }, 60000);
+
   it('should generate VDM if all arguments are there', async () => {
     mock({
       [inputDir]: mock.load(inputDir),
@@ -63,6 +65,7 @@ describe('generator-cli', () => {
     expect(entities).toContain('TestEntity.js');
     expect(entities).toContain('package.json');
   });
+
   it('should create options from a config file', () => {
     mock({ [pathToConfig]: mock.load(pathToConfig) });
     expect(createOptionsFromConfig(pathToConfig)).toEqual({
@@ -70,6 +73,7 @@ describe('generator-cli', () => {
       outputDir
     });
   });
+
   it('should generate VDM if there is a valid config file', async () => {
     const { inputDir: inputDirFromConfig, outputDir: outputDirFromConfig } =
       createOptionsFromConfig(pathToConfig) as {
@@ -100,6 +104,7 @@ describe('generator-cli', () => {
     expect(entities).toContain('TestEntity.js');
     expect(entities).toContain('package.json');
   });
+
   it('should set version when versionInPackageJson option is used', async () => {
     const { inputDir: inputDirFromConfig, outputDir: outputDirFromConfig } =
       createOptionsFromConfig(pathToConfig) as {
@@ -136,6 +141,7 @@ describe('generator-cli', () => {
     );
     expect(actualPackageJson.version).toEqual('42.23');
   });
+
   it('should throw a warning message for a deprecated option even when the generation is failed', async () => {
     // Use a broken service to stop the service generation early - we are only interested in the log statement
     try {
@@ -157,6 +163,7 @@ describe('generator-cli', () => {
       );
     }
   }, 60000);
+
   it('should throw a warning message for a deprecated option even when the generation is failed', async () => {
     // Use a broken service to stop the service generation early - we are only interested in the log statement
     try {


### PR DESCRIPTION
I struggled with flakey unit tests locally. After investigation, it seems that we should always call `mock.restore` in `afterEach` as calling it in the test function or in `afterAll` may obfuscate or introduce errors. See [here](https://stackoverflow.com/questions/68686034/jest-tests-failing-with-enoent-no-such-file-or-directory-referring-to-the-spec). This change made the tests WAY more consistent for me.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
