### PR TITLE
chore: Add link API Reference to ReleaseNotes

### DIFF
--- a/scripts/add-changelog.ts
+++ b/scripts/add-changelog.ts
@@ -12,13 +12,14 @@ function getChangelogWithVersion(v = currentSdkVersion): string {
   const [, olderLogs] = changelog.split(`${unixEOL}# ${v}`);
   let logs = olderLogs.split(`${unixEOL}# `)[0];
   logs = unixEOL + logs.slice(logs.indexOf(`${unixEOL}##`) + 1);
+  logs = logs.replace(/## /g,'### ',)
 
   const date = new Date();
   const day = date.toLocaleString('default', { day: '2-digit' });
   const month = date.toLocaleString('default', { month: 'long' });
   const year = date.getFullYear();
 
-  const headerWithVersion = `${unixEOL}# ${v} [Core Modules] - ${month} ${day}, ${year}`
+  const headerWithVersion = `${unixEOL}## ${v} [Core Modules] - ${month} ${day}, ${year}`
   const apiReferenceLink= `**API Reference:** [${v}](https://sap.github.io/cloud-sdk/api/${v})`;
 
   return [headerWithVersion,apiReferenceLink,logs].join(unixEOL);

--- a/scripts/add-changelog.ts
+++ b/scripts/add-changelog.ts
@@ -18,8 +18,10 @@ function getChangelogWithVersion(v = currentSdkVersion): string {
   const month = date.toLocaleString('default', { month: 'long' });
   const year = date.getFullYear();
 
-  const logsWithVersion = `${unixEOL}# ${v} [Core Modules] - ${month} ${day}, ${year}${unixEOL}${logs}`;
-  return logsWithVersion;
+  const headerWithVersion = `${unixEOL}# ${v} [Core Modules] - ${month} ${day}, ${year}`
+  const apiReferenceLink= `**API Reference:** [${v}](https://sap.github.io/cloud-sdk/api/${v})`;
+
+  return [headerWithVersion,apiReferenceLink,logs].join(unixEOL);
 }
 
 export function addCurrentChangelog(): void {


### PR DESCRIPTION
Relates SAP/cloud-sdk-backlog#841.

As in the title. Added replacement of `##` to `###` to mathc style in target document:https://raw.githubusercontent.com/SAP/cloud-sdk/main/docs-js/release-notes.mdx
