### PR TITLE
chore: Improve destination cache tests

### DIFF
--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -70,6 +70,7 @@ export async function generateWithParsedOptions(
   }
 
   if (options.clearOutputDir) {
+    // function rm was added in node version 14 and is the preferred method to use.
     const rm = promisesFs.rm || promisesFs.rmdir;
     const forceOption =
       typeof promisesFs.rm === 'undefined' ? {} : { force: true };

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -71,7 +71,9 @@ export async function generateWithParsedOptions(
 
   if (options.clearOutputDir) {
     const rm = promisesFs.rm || promisesFs.rmdir;
-    await rm(options.outputDir, { recursive: true });
+    const forceOption =
+      typeof promisesFs.rm === 'undefined' ? {} : { force: true };
+    await rm(options.outputDir, { recursive: true, ...forceOption });
   }
   const inputFilePaths = await getInputFilePaths(options.input);
 


### PR DESCRIPTION
We have a customer issue, where destination are chaced forever, I just double checked the tests we have and I guess this is not the case - perhaps the token lifetime on the customer side is too long. Since I went over the test I made some small improvements.