### PR TITLE
improve: add explicit tests for `getSelect()`, `getExpand()` and `properties-util.ts`

### DIFF
--- a/packages/odata-common/src/properties-util.spec.ts
+++ b/packages/odata-common/src/properties-util.spec.ts
@@ -1,14 +1,30 @@
-import { commonEntityApi } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
-import { isNavigationProperty } from './properties-util';
+import {
+  CommonEntity,
+  commonEntityApi
+} from '@sap-cloud-sdk/test-services-odata-common/common-entity';
+import { nonEnumerable, isNavigationProperty } from './properties-util';
 
 describe('isNavigationProperty', () => {
+  it('returns false for non-enumerable property', () => {
+    nonEnumerable(CommonEntity, '_entityName');
+    expect(
+      Object.getOwnPropertyDescriptor(CommonEntity, '_entityName')?.enumerable
+    ).toBeFalsy();
+  });
+
   it('returns true for one to one navigation property', () => {
     expect(isNavigationProperty('toSingleLink', commonEntityApi.schema)).toBe(
       true
     );
   });
 
-  it('returns false for boolean property', () => {
+  it('returns true for one to many navigation property ', () => {
+    expect(isNavigationProperty('toMultiLink', commonEntityApi.schema)).toBe(
+      true
+    );
+  });
+
+  it('returns false for string property', () => {
     expect(isNavigationProperty('stringProperty', commonEntityApi.schema)).toBe(
       false
     );

--- a/packages/odata-common/src/properties-util.spec.ts
+++ b/packages/odata-common/src/properties-util.spec.ts
@@ -18,12 +18,6 @@ describe('isNavigationProperty', () => {
     );
   });
 
-  it('returns true for one to many navigation property ', () => {
-    expect(isNavigationProperty('toMultiLink', commonEntityApi.schema)).toBe(
-      true
-    );
-  });
-
   it('returns false for string property', () => {
     expect(isNavigationProperty('stringProperty', commonEntityApi.schema)).toBe(
       false

--- a/packages/odata-common/src/properties-util.spec.ts
+++ b/packages/odata-common/src/properties-util.spec.ts
@@ -4,14 +4,16 @@ import {
 } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 import { nonEnumerable, isNavigationProperty } from './properties-util';
 
-describe('isNavigationProperty', () => {
+describe('nonEnumerable', () => {
   it('returns false for non-enumerable property', () => {
     nonEnumerable(CommonEntity, '_entityName');
     expect(
       Object.getOwnPropertyDescriptor(CommonEntity, '_entityName')?.enumerable
     ).toBeFalsy();
   });
+});
 
+describe('isNavigationProperty', () => {
   it('returns true for one to one navigation property', () => {
     expect(isNavigationProperty('toSingleLink', commonEntityApi.schema)).toBe(
       true

--- a/packages/odata-v2/src/properties-util.spec.ts
+++ b/packages/odata-v2/src/properties-util.spec.ts
@@ -5,7 +5,7 @@ import {
 import {
   nonEnumerable,
   isNavigationProperty
-} from '@sap-cloud-sdk/odata-common/dist/properties-util';
+} from '@sap-cloud-sdk/odata-common/internal';
 const { testEntityApi } = testService();
 
 describe('properties-util', () => {

--- a/packages/odata-v2/src/properties-util.spec.ts
+++ b/packages/odata-v2/src/properties-util.spec.ts
@@ -16,21 +16,9 @@ describe('properties-util', () => {
     ).toBeFalsy();
   });
 
-  it('returns true for one to one navigation property ', () => {
-    expect(isNavigationProperty('toSingleLink', testEntityApi.schema)).toBe(
-      true
-    );
-  });
-
   it('returns true for one to many navigation property ', () => {
     expect(isNavigationProperty('toMultiLink', testEntityApi.schema)).toBe(
       true
-    );
-  });
-
-  it('returns false for string property', () => {
-    expect(isNavigationProperty('stringProperty', testEntityApi.schema)).toBe(
-      false
     );
   });
 });

--- a/packages/odata-v2/src/uri-conversion/get-expand.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-expand.spec.ts
@@ -1,62 +1,62 @@
 import {
-    testEntityApi,
-    testEntityMultiLinkApi,
-    testEntitySingleLinkApi
+  testEntityApi,
+  testEntityMultiLinkApi,
+  testEntitySingleLinkApi
 } from '../../test/test-util';
 import { getExpand } from './get-expand';
 
 describe('get expand', () => {
-    it('for first level expand without sub-query', () => {
-        expect(
-            getExpand([
-                testEntityApi.schema.ALL_FIELDS,
-                testEntityApi.schema.TO_SINGLE_LINK,
-                testEntityApi.schema.TO_MULTI_LINK
-            ]).expand
-        )
-            .toBe('to_SingleLink,to_MultiLink');
-    });
+  it('for first level expand without sub-query', () => {
+    expect(
+      getExpand([
+        testEntityApi.schema.ALL_FIELDS,
+        testEntityApi.schema.TO_SINGLE_LINK,
+        testEntityApi.schema.TO_MULTI_LINK
+      ]).expand
+    ).toBe('to_SingleLink,to_MultiLink');
+  });
 
-    it('for single link with sub-query', () => {
-        expect(getExpand([testExpandSingleLink.expand]).expand).toBe(
-            `${testExpandSingleLink.odataStr}`
-        );
-    });
+  it('for single link with sub-query', () => {
+    expect(getExpand([testExpandSingleLink.expand]).expand).toBe(
+      `${testExpandSingleLink.odataStr}`
+    );
+  });
 
-    it('for multi link with sub-query', () => {
-        expect(getExpand([testExpandMultiLink.expand]).expand).toBe(
-            `${testExpandMultiLink.odataStr}`
-        );
-    });
+  it('for multi link with sub-query', () => {
+    expect(getExpand([testExpandMultiLink.expand]).expand).toBe(
+      `${testExpandMultiLink.odataStr}`
+    );
+  });
 
-    it('for multi link with nested sub-query', () => {
-        expect(getExpand([testNestedExpandLink.expand]).expand).toBe(
-            `${testNestedExpandLink.odataStr}`
-        );
-    });
+  it('for multi link with a nested expansion', () => {
+    expect(getExpand([testNestedExpandLink.expand]).expand).toBe(
+      `${testNestedExpandLink.odataStr}`
+    );
+  });
 });
 
 const testExpandSingleLink = {
-    expand: testEntityApi.schema.TO_SINGLE_LINK.select(
-        testEntitySingleLinkApi.schema.STRING_PROPERTY,
-        testEntitySingleLinkApi.schema.BOOLEAN_PROPERTY
-    ),
-    odataStr: 'to_SingleLink'
+  expand: testEntityApi.schema.TO_SINGLE_LINK.select(
+    testEntitySingleLinkApi.schema.STRING_PROPERTY,
+    testEntitySingleLinkApi.schema.BOOLEAN_PROPERTY
+  ),
+  odataStr: 'to_SingleLink'
 };
 
 const testExpandMultiLink = {
-    expand: testEntityApi.schema.TO_MULTI_LINK.select(
-        testEntityMultiLinkApi.schema.STRING_PROPERTY,
-        testEntityMultiLinkApi.schema.BOOLEAN_PROPERTY,
-    ),
-    odataStr: `to_MultiLink`
+  expand: testEntityApi.schema.TO_MULTI_LINK.select(
+    testEntityMultiLinkApi.schema.STRING_PROPERTY,
+    testEntityMultiLinkApi.schema.BOOLEAN_PROPERTY
+  ),
+  odataStr: 'to_MultiLink'
 };
 
 const testNestedExpandLink = {
-    expand: testEntityApi.schema.TO_SINGLE_LINK.select(
-        testEntitySingleLinkApi.schema.TO_MULTI_LINK.select(
-            testEntityMultiLinkApi.schema.TO_MULTI_LINK
-        )
-    ),
-    odataStr: 'to_SingleLink,to_SingleLink/to_MultiLink,to_SingleLink/to_MultiLink/to_MultiLink'
-}
+  expand: testEntityApi.schema.TO_SINGLE_LINK.select(
+    testEntitySingleLinkApi.schema.TO_MULTI_LINK.select(
+      testEntityMultiLinkApi.schema.TO_MULTI_LINK
+    )
+  ),
+  odataStr:
+    'to_SingleLink,to_SingleLink/to_MultiLink,to_SingleLink/to_MultiLink/to_MultiLink'
+};

--- a/packages/odata-v2/src/uri-conversion/get-expand.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-expand.spec.ts
@@ -6,7 +6,7 @@ import {
 import { getExpand } from './get-expand';
 
 describe('get expand', () => {
-  it('should return all expand quey parameters except for a selection of all fields', () => {
+  it('should return all expand query parameters except for a selection of all fields', () => {
     expect(
       getExpand([
         testEntityApi.schema.ALL_FIELDS,
@@ -16,7 +16,7 @@ describe('get expand', () => {
     ).toBe('to_SingleLink,to_MultiLink');
   });
 
-  it('should return an expand query parameter for single link', () => {
+  it('should return an expand query parameter for single link with sub-query', () => {
     expect(getExpand([testExpandSingleLink.expand]).expand).toBe(
       `${testExpandSingleLink.odataStr}`
     );
@@ -28,7 +28,7 @@ describe('get expand', () => {
     );
   });
 
-  it('should return an expand query parameter for multi link with a nested expansion', () => {
+  it('should return expand query parameters for multi link with a nested expansion', () => {
     expect(getExpand([testNestedExpandLink.expand]).expand).toBe(
       `${testNestedExpandLink.odataStr}`
     );

--- a/packages/odata-v2/src/uri-conversion/get-expand.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-expand.spec.ts
@@ -6,7 +6,7 @@ import {
 import { getExpand } from './get-expand';
 
 describe('get expand', () => {
-  it('for first level expand without sub-query', () => {
+  it('should return all expand quey parameters except for a selection of all fields', () => {
     expect(
       getExpand([
         testEntityApi.schema.ALL_FIELDS,
@@ -16,19 +16,19 @@ describe('get expand', () => {
     ).toBe('to_SingleLink,to_MultiLink');
   });
 
-  it('for single link with sub-query', () => {
+  it('should return an expand query parameter for single link', () => {
     expect(getExpand([testExpandSingleLink.expand]).expand).toBe(
       `${testExpandSingleLink.odataStr}`
     );
   });
 
-  it('for multi link with sub-query', () => {
+  it('should return an expand query parameter for multi link with sub-query', () => {
     expect(getExpand([testExpandMultiLink.expand]).expand).toBe(
       `${testExpandMultiLink.odataStr}`
     );
   });
 
-  it('for multi link with a nested expansion', () => {
+  it('should return an expand query parameter for multi link with a nested expansion', () => {
     expect(getExpand([testNestedExpandLink.expand]).expand).toBe(
       `${testNestedExpandLink.odataStr}`
     );

--- a/packages/odata-v2/src/uri-conversion/get-expand.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-expand.spec.ts
@@ -1,13 +1,8 @@
-import { asc } from '@sap-cloud-sdk/odata-common';
 import {
     testEntityApi,
     testEntityMultiLinkApi,
     testEntitySingleLinkApi
 } from '../../test/test-util';
-import {
-    testEntityApi as testEntityApiV4,
-    testEntityMultiLinkApi as testEntityMultiLinkApiV4
-} from '../../../odata-v4/test/test-util';
 import { getExpand } from './get-expand';
 
 describe('get expand', () => {
@@ -19,51 +14,49 @@ describe('get expand', () => {
                 testEntityApi.schema.TO_MULTI_LINK
             ]).expand
         )
-            // `ALL_FIELDS` is ignored because the function doesn't cover the case, unlike the getExpand in v4.
-            // v2 `getExpand` only cares about an argument relating with class 'Link'.
-            // Class `AllFields` doesn't have any relationship with the 'Link' hence it's ignored.
-            // Unlikely, v4 `getExpand` returns '*' for 'ALL_FIELDS' because it cares about the `ALL_FIELDS` as well.      
             .toBe('to_SingleLink,to_MultiLink');
     });
 
     it('for single link with sub-query', () => {
         expect(getExpand([testExpandSingleLink.expand]).expand).toBe(
-            //subqueries are ignored because the function doesn't catch them, unlike the getExpand in v4.
             `${testExpandSingleLink.odataStr}`
         );
     });
 
     it('for multi link with sub-query', () => {
         expect(getExpand([testExpandMultiLink.expand]).expand).toBe(
-            // v2 uses type `Link` for 1:N relation ship. `Link` doesn't have `orderBy` method.
-            // Unlikely, OneToManyLink has OrderBy and other methods because the class has the methods.
             `${testExpandMultiLink.odataStr}`
         );
     });
-});
 
-const encodedSpace = encodeURIComponent(' ');
+    it('for multi link with nested sub-query', () => {
+        expect(getExpand([testNestedExpandLink.expand]).expand).toBe(
+            `${testNestedExpandLink.odataStr}`
+        );
+    });
+});
 
 const testExpandSingleLink = {
     expand: testEntityApi.schema.TO_SINGLE_LINK.select(
         testEntitySingleLinkApi.schema.STRING_PROPERTY,
         testEntitySingleLinkApi.schema.BOOLEAN_PROPERTY
     ),
-    // sub queries `($select=StringProperty,BooleanProperty)` are ignored. 
     odataStr: 'to_SingleLink'
 };
 
 const testExpandMultiLink = {
     expand: testEntityApi.schema.TO_MULTI_LINK.select(
         testEntityMultiLinkApi.schema.STRING_PROPERTY,
-        testEntityMultiLinkApi.schema.BOOLEAN_PROPERTY
-    )
-        // methods below thorws an error because class `Link` used in v2 doesn't have the methods.
-        // Unlikely v4 uses OneToManyLink has the methods hence methods below work in v4 but here v2.
-        .orderBy(asc(testEntityMultiLinkApi.schema.STRING_PROPERTY))
-        .filter(testEntityMultiLinkApi.schema.STRING_PROPERTY.equals('test'))
-        .top(1)
-        .skip(1),
-    // sub queries `($select=StringProperty,BooleanProperty;$filter=(StringProperty%20eq%20'test');$skip=1;$top=1;$orderby=StringProperty${encodedSpace}asc` are ignored. 
+        testEntityMultiLinkApi.schema.BOOLEAN_PROPERTY,
+    ),
     odataStr: `to_MultiLink`
 };
+
+const testNestedExpandLink = {
+    expand: testEntityApi.schema.TO_SINGLE_LINK.select(
+        testEntitySingleLinkApi.schema.TO_MULTI_LINK.select(
+            testEntityMultiLinkApi.schema.TO_MULTI_LINK
+        )
+    ),
+    odataStr: 'to_SingleLink,to_SingleLink/to_MultiLink,to_SingleLink/to_MultiLink/to_MultiLink'
+}

--- a/packages/odata-v2/src/uri-conversion/get-expand.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-expand.spec.ts
@@ -12,25 +12,31 @@ import { getExpand } from './get-expand';
 
 describe('get expand', () => {
     it('for first level expand without sub-query', () => {
-        // 'ALL_FIELDS' is ignored because the function doesn't cover the case unlike the getExpand in v4.
         expect(
             getExpand([
                 testEntityApi.schema.ALL_FIELDS,
                 testEntityApi.schema.TO_SINGLE_LINK,
                 testEntityApi.schema.TO_MULTI_LINK
             ]).expand
-        ).toBe('to_SingleLink,to_MultiLink');
+        )
+            // `ALL_FIELDS` is ignored because the function doesn't cover the case, unlike the getExpand in v4.
+            // v2 `getExpand` only cares about an argument relating with class 'Link'.
+            // Class `AllFields` doesn't have any relationship with the 'Link' hence it's ignored.
+            // Unlikely, v4 `getExpand` returns '*' for 'ALL_FIELDS' because it cares about the `ALL_FIELDS` as well.      
+            .toBe('to_SingleLink,to_MultiLink');
     });
-    // OneToOneLink
-    // sub-queries are igonred because the function doesn't catch them unlike the getExpand in v4.
+
     it('for single link with sub-query', () => {
         expect(getExpand([testExpandSingleLink.expand]).expand).toBe(
+            //subqueries are ignored because the function doesn't catch them, unlike the getExpand in v4.
             `${testExpandSingleLink.odataStr}`
         );
     });
-    // Link because OneToManyLink is for v4, not v2
+
     it('for multi link with sub-query', () => {
         expect(getExpand([testExpandMultiLink.expand]).expand).toBe(
+            // v2 uses type `Link` for 1:N relation ship. `Link` doesn't have `orderBy` method.
+            // Unlikely, OneToManyLink has OrderBy and other methods because the class has the methods.
             `${testExpandMultiLink.odataStr}`
         );
     });
@@ -43,29 +49,21 @@ const testExpandSingleLink = {
         testEntitySingleLinkApi.schema.STRING_PROPERTY,
         testEntitySingleLinkApi.schema.BOOLEAN_PROPERTY
     ),
+    // sub queries `($select=StringProperty,BooleanProperty)` are ignored. 
     odataStr: 'to_SingleLink'
-    // sub queries '($select=StringProperty,BooleanProperty)' are ignored
 };
 
 const testExpandMultiLink = {
     expand: testEntityApi.schema.TO_MULTI_LINK.select(
         testEntityMultiLinkApi.schema.STRING_PROPERTY,
         testEntityMultiLinkApi.schema.BOOLEAN_PROPERTY
-    ),
-    odataStr: `to_MultiLink($select=StringProperty,BooleanProperty;$filter=(StringProperty%20eq%20'test');$skip=1;$top=1;$orderby=StringProperty${encodedSpace}asc)`
-
-};
-
-// there are only clone, expand and select methods as query opitions. no orderBy and other queries are there
-testEntityApi.schema.TO_MULTI_LINK
-    .select(
-        testEntityMultiLinkApi.schema.STRING_PROPERTY,
-        testEntityMultiLinkApi.schema.BOOLEAN_PROPERTY
-    );  
-// orderBy, select, skip and top are there
-testEntityApiV4.schema.TO_MULTI_LINK
-    .select(
-        testEntityMultiLinkApiV4.schema.STRING_PROPERTY,
-        testEntityMultiLinkApiV4.schema.BOOLEAN_PROPERTY
     )
-    .orderBy(asc(testEntityMultiLinkApiV4.schema.STRING_PROPERTY));
+        // methods below thorws an error because class `Link` used in v2 doesn't have the methods.
+        // Unlikely v4 uses OneToManyLink has the methods hence methods below work in v4 but here v2.
+        .orderBy(asc(testEntityMultiLinkApi.schema.STRING_PROPERTY))
+        .filter(testEntityMultiLinkApi.schema.STRING_PROPERTY.equals('test'))
+        .top(1)
+        .skip(1),
+    // sub queries `($select=StringProperty,BooleanProperty;$filter=(StringProperty%20eq%20'test');$skip=1;$top=1;$orderby=StringProperty${encodedSpace}asc` are ignored. 
+    odataStr: `to_MultiLink`
+};

--- a/packages/odata-v2/src/uri-conversion/get-expand.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-expand.spec.ts
@@ -1,0 +1,71 @@
+import { asc } from '@sap-cloud-sdk/odata-common';
+import {
+    testEntityApi,
+    testEntityMultiLinkApi,
+    testEntitySingleLinkApi
+} from '../../test/test-util';
+import {
+    testEntityApi as testEntityApiV4,
+    testEntityMultiLinkApi as testEntityMultiLinkApiV4
+} from '../../../odata-v4/test/test-util';
+import { getExpand } from './get-expand';
+
+describe('get expand', () => {
+    it('for first level expand without sub-query', () => {
+        // 'ALL_FIELDS' is ignored because the function doesn't cover the case unlike the getExpand in v4.
+        expect(
+            getExpand([
+                testEntityApi.schema.ALL_FIELDS,
+                testEntityApi.schema.TO_SINGLE_LINK,
+                testEntityApi.schema.TO_MULTI_LINK
+            ]).expand
+        ).toBe('to_SingleLink,to_MultiLink');
+    });
+    // OneToOneLink
+    // sub-queries are igonred because the function doesn't catch them unlike the getExpand in v4.
+    it('for single link with sub-query', () => {
+        expect(getExpand([testExpandSingleLink.expand]).expand).toBe(
+            `${testExpandSingleLink.odataStr}`
+        );
+    });
+    // Link because OneToManyLink is for v4, not v2
+    it('for multi link with sub-query', () => {
+        expect(getExpand([testExpandMultiLink.expand]).expand).toBe(
+            `${testExpandMultiLink.odataStr}`
+        );
+    });
+});
+
+const encodedSpace = encodeURIComponent(' ');
+
+const testExpandSingleLink = {
+    expand: testEntityApi.schema.TO_SINGLE_LINK.select(
+        testEntitySingleLinkApi.schema.STRING_PROPERTY,
+        testEntitySingleLinkApi.schema.BOOLEAN_PROPERTY
+    ),
+    odataStr: 'to_SingleLink'
+    // sub queries '($select=StringProperty,BooleanProperty)' are ignored
+};
+
+const testExpandMultiLink = {
+    expand: testEntityApi.schema.TO_MULTI_LINK.select(
+        testEntityMultiLinkApi.schema.STRING_PROPERTY,
+        testEntityMultiLinkApi.schema.BOOLEAN_PROPERTY
+    ),
+    odataStr: `to_MultiLink($select=StringProperty,BooleanProperty;$filter=(StringProperty%20eq%20'test');$skip=1;$top=1;$orderby=StringProperty${encodedSpace}asc)`
+
+};
+
+// there are only clone, expand and select methods as query opitions. no orderBy and other queries are there
+testEntityApi.schema.TO_MULTI_LINK
+    .select(
+        testEntityMultiLinkApi.schema.STRING_PROPERTY,
+        testEntityMultiLinkApi.schema.BOOLEAN_PROPERTY
+    );  
+// orderBy, select, skip and top are there
+testEntityApiV4.schema.TO_MULTI_LINK
+    .select(
+        testEntityMultiLinkApiV4.schema.STRING_PROPERTY,
+        testEntityMultiLinkApiV4.schema.BOOLEAN_PROPERTY
+    )
+    .orderBy(asc(testEntityMultiLinkApiV4.schema.STRING_PROPERTY));

--- a/packages/odata-v2/src/uri-conversion/get-select.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-select.spec.ts
@@ -6,7 +6,7 @@ import {
 import { getSelect } from './get-select';
 
 describe('get select', () => {
-  it('should returns all properties that does not select any specific property', () => {
+  it('should return all properties that do not select any specific property', () => {
     expect(
       getSelect([
         testEntityApi.schema.ALL_FIELDS,

--- a/packages/odata-v2/src/uri-conversion/get-select.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-select.spec.ts
@@ -60,7 +60,7 @@ describe('get select', () => {
     ).toBe('to_MultiLink/StringProperty,to_MultiLink/BooleanProperty');
   });
 
-  it('returns all nested selected properties', () => {
+  it('returns a nested selected properties', () => {
     expect(
       getSelect([
         testEntityApi.schema.TO_SINGLE_LINK.select(

--- a/packages/odata-v2/src/uri-conversion/get-select.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-select.spec.ts
@@ -60,7 +60,7 @@ describe('get select', () => {
     ).toBe('to_MultiLink/StringProperty,to_MultiLink/BooleanProperty');
   });
 
-  it('returns all selected properties with a nested selection', () => {
+  it('returns all nested selected properties', () => {
     expect(
       getSelect([
         testEntityApi.schema.TO_SINGLE_LINK.select(

--- a/packages/odata-v2/src/uri-conversion/get-select.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-select.spec.ts
@@ -1,0 +1,60 @@
+import {
+    testEntityApi,
+    testEntityMultiLinkApi,
+    testEntitySingleLinkApi
+} from '../../test/test-util';
+import { getSelect } from "./get-select";
+
+describe('get select', () => {
+    it('all fields', () => {
+        expect(
+            getSelect([
+                testEntityApi.schema.ALL_FIELDS,
+                testEntityApi.schema.TO_SINGLE_LINK,
+                testEntityApi.schema.TO_MULTI_LINK
+            ]).select
+        ).toBe('*,to_SingleLink/*,to_MultiLink/*')
+    });
+
+    it('for single link with sub-query', () => {
+        expect(
+            getSelect([
+                testSingleLink.expand
+            ]).select
+        ).toBe('to_SingleLink/StringProperty,to_SingleLink/BooleanProperty')
+    });
+
+    it('for multi link with sub-query', () => {
+        expect(getSelect([testMultiLink.expand]).select).toBe(
+            // subqueries after `select` doesn't work because the methods doesn't exist in class `Link`
+            `${testMultiLink.odataStr}`
+        );
+    });
+
+});
+
+const encodedSpace = encodeURIComponent(' ');
+
+const testSingleLink = {
+    expand: testEntityApi.schema.TO_SINGLE_LINK.select(
+        testEntitySingleLinkApi.schema.STRING_PROPERTY,
+        testEntitySingleLinkApi.schema.BOOLEAN_PROPERTY
+    ),
+    odataStr: 'to_SingleLink($select=StringProperty,BooleanProperty)'
+};
+
+const testMultiLink = {
+    expand: testEntityApi.schema.TO_MULTI_LINK.select(
+        testEntityMultiLinkApi.schema.STRING_PROPERTY,
+        testEntityMultiLinkApi.schema.BOOLEAN_PROPERTY
+    )
+            // methods below thorws an error because class `Link` used in v2 doesn't have the methods.
+            // Unlikely v4 uses OneToManyLink has the methods hence methods below work in v4 but here v2.
+            .orderBy(asc(testEntityMultiLinkApi.schema.STRING_PROPERTY))
+            .filter(testEntityMultiLinkApi.schema.STRING_PROPERTY.equals('test'))
+            .top(1)
+            .skip(1),
+        // subqueries after `select` `to_MultiLink($select=StringProperty,BooleanProperty;$filter=(StringProperty%20eq%20'test');$skip=1;$top=1;$orderby=StringProperty${encodedSpace}asc)`are ignored
+        odataStr: 'to_MultiLink/StringProperty,to_MultiLink/BooleanProperty'
+        // 
+};

--- a/packages/odata-v2/src/uri-conversion/get-select.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-select.spec.ts
@@ -60,7 +60,7 @@ describe('get select', () => {
     ).toBe('to_MultiLink/StringProperty,to_MultiLink/BooleanProperty');
   });
 
-  it('returns a nested selected properties', () => {
+  it('returns a nested selected property', () => {
     expect(
       getSelect([
         testEntityApi.schema.TO_SINGLE_LINK.select(

--- a/packages/odata-v2/src/uri-conversion/get-select.ts
+++ b/packages/odata-v2/src/uri-conversion/get-select.ts
@@ -46,7 +46,6 @@ function getSelectsAsStrings<
 ): string[] {
   return selectables.reduce((select: string[], selectable) => {
     const fullFieldName = getPath(parent, selectable._fieldName);
-    const isSelectable = selectable instanceof Link
     if (selectable instanceof Link) {
       if (selectable._selects.length) {
         return getSelectsAsStrings(selectable._selects, select, fullFieldName);

--- a/packages/odata-v2/src/uri-conversion/get-select.ts
+++ b/packages/odata-v2/src/uri-conversion/get-select.ts
@@ -46,6 +46,7 @@ function getSelectsAsStrings<
 ): string[] {
   return selectables.reduce((select: string[], selectable) => {
     const fullFieldName = getPath(parent, selectable._fieldName);
+    const isSelectable = selectable instanceof Link
     if (selectable instanceof Link) {
       if (selectable._selects.length) {
         return getSelectsAsStrings(selectable._selects, select, fullFieldName);

--- a/packages/odata-v4/src/properties-util.spec.ts
+++ b/packages/odata-v4/src/properties-util.spec.ts
@@ -5,7 +5,7 @@ import {
 import {
   nonEnumerable,
   isNavigationProperty
-} from '@sap-cloud-sdk/odata-common/dist/properties-util';
+} from '@sap-cloud-sdk/odata-common/internal';
 const { testEntityApi } = testService();
 
 describe('properties-util', () => {

--- a/packages/odata-v4/src/properties-util.spec.ts
+++ b/packages/odata-v4/src/properties-util.spec.ts
@@ -16,21 +16,9 @@ describe('properties-util', () => {
     ).toBeFalsy();
   });
 
-  it('returns true for one to one navigation property ', () => {
-    expect(isNavigationProperty('toSingleLink', testEntityApi.schema)).toBe(
-      true
-    );
-  });
-
   it('returns true for one to many navigation property ', () => {
     expect(isNavigationProperty('toMultiLink', testEntityApi.schema)).toBe(
       true
-    );
-  });
-
-  it('returns false for string property', () => {
-    expect(isNavigationProperty('stringProperty', testEntityApi.schema)).toBe(
-      false
     );
   });
 });

--- a/packages/odata-v4/src/properties-util.spec.ts
+++ b/packages/odata-v4/src/properties-util.spec.ts
@@ -1,7 +1,7 @@
 import {
   TestEntity,
   testService
-} from '@sap-cloud-sdk/test-services-odata-v2/test-service';
+} from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import {
   nonEnumerable,
   isNavigationProperty

--- a/packages/odata-v4/src/uri-conversion/get-expand.spec.ts
+++ b/packages/odata-v4/src/uri-conversion/get-expand.spec.ts
@@ -7,7 +7,7 @@ import {
 import { getExpand } from './get-expand';
 
 describe('get expand', () => {
-  it('for first level expand without sub-query', () => {
+  it('should return all expand quey parameters', () => {
     expect(
       getExpand(
         [
@@ -20,19 +20,19 @@ describe('get expand', () => {
     ).toBe('*,to_SingleLink,to_MultiLink');
   });
 
-  it('for single link with sub-query', () => {
+  it('should return an expand query parameter for single link with sub-query', () => {
     expect(getExpand([testExpandSingleLink.expand], testEntityApi).expand).toBe(
       `${testExpandSingleLink.odataStr}`
     );
   });
 
-  it('for multi link with sub-query', () => {
+  it('should return an expand query parameter for multi link with sub-query', () => {
     expect(getExpand([testExpandMultiLink.expand], testEntityApi).expand).toBe(
       `${testExpandMultiLink.odataStr}`
     );
   });
 
-  it('for multi link with a nested expansion', () => {
+  it('should return an expand query parameter for multi link with a nested expansion', () => {
     expect(getExpand([testNestedExpandLink.expand], testEntityApi).expand).toBe(
       `${testNestedExpandLink.odataStr}`
     );

--- a/packages/odata-v4/src/uri-conversion/get-expand.spec.ts
+++ b/packages/odata-v4/src/uri-conversion/get-expand.spec.ts
@@ -7,7 +7,7 @@ import {
 import { getExpand } from './get-expand';
 
 describe('get expand', () => {
-  it('should return all expand quey parameters', () => {
+  it('should return all expand query parameters', () => {
     expect(
       getExpand(
         [

--- a/packages/odata-v4/src/uri-conversion/get-expand.spec.ts
+++ b/packages/odata-v4/src/uri-conversion/get-expand.spec.ts
@@ -32,7 +32,7 @@ describe('get expand', () => {
     );
   });
 
-  it('for multi link with nested sub-query', () => {
+  it('for multi link with a nested expansion', () => {
     expect(getExpand([testNestedExpandLink.expand], testEntityApi).expand).toBe(
       `${testNestedExpandLink.odataStr}`
     );
@@ -68,4 +68,4 @@ const testNestedExpandLink = {
     )
   ),
   odataStr: 'to_SingleLink($expand=to_SingleLink($expand=to_MultiLink1))'
-}
+};

--- a/packages/odata-v4/src/uri-conversion/get-expand.spec.ts
+++ b/packages/odata-v4/src/uri-conversion/get-expand.spec.ts
@@ -31,6 +31,12 @@ describe('get expand', () => {
       `${testExpandMultiLink.odataStr}`
     );
   });
+
+  it('for multi link with nested sub-query', () => {
+    expect(getExpand([testNestedExpandLink.expand], testEntityApi).expand).toBe(
+      `${testNestedExpandLink.odataStr}`
+    );
+  });
 });
 
 const encodedSpace = encodeURIComponent(' ');
@@ -54,3 +60,12 @@ const testExpandMultiLink = {
     .skip(1),
   odataStr: `to_MultiLink($select=StringProperty,BooleanProperty;$filter=(StringProperty%20eq%20'test');$skip=1;$top=1;$orderby=StringProperty${encodedSpace}asc)`
 };
+
+const testNestedExpandLink = {
+  expand: testEntityApi.schema.TO_SINGLE_LINK.expand(
+    testEntitySingleLinkApi.schema.TO_SINGLE_LINK.expand(
+      testEntityMultiLinkApi.schema.TO_MULTI_LINK_1
+    )
+  ),
+  odataStr: 'to_SingleLink($expand=to_SingleLink($expand=to_MultiLink1))'
+}

--- a/packages/odata-v4/src/uri-conversion/get-select.spec.ts
+++ b/packages/odata-v4/src/uri-conversion/get-select.spec.ts
@@ -13,7 +13,9 @@ describe('get select', () => {
         testEntityApi.customField('TEST_CUSTOM_PROPERTY'),
         testEntityApi.schema.COMPLEX_TYPE_COLLECTION_PROPERTY
       ]).select
-    ).toBe('StringProperty,ComplexTypeProperty,TEST_CUSTOM_PROPERTY,ComplexTypeCollectionProperty');
+    ).toBe(
+      'StringProperty,ComplexTypeProperty,TEST_CUSTOM_PROPERTY,ComplexTypeCollectionProperty'
+    );
   });
   it('should return only a selection of all fields', () => {
     expect(

--- a/packages/odata-v4/src/uri-conversion/get-select.spec.ts
+++ b/packages/odata-v4/src/uri-conversion/get-select.spec.ts
@@ -5,6 +5,7 @@ describe('get select', () => {
   it('should return a selection of all fields', () => {
     expect(getSelect([testEntityApi.schema.ALL_FIELDS]).select).toBe('*');
   });
+
   it('should return all selected properties', () => {
     expect(
       getSelect([
@@ -17,6 +18,7 @@ describe('get select', () => {
       'StringProperty,ComplexTypeProperty,TEST_CUSTOM_PROPERTY,ComplexTypeCollectionProperty'
     );
   });
+  
   it('should return only a selection of all fields', () => {
     expect(
       getSelect([

--- a/packages/odata-v4/src/uri-conversion/get-select.spec.ts
+++ b/packages/odata-v4/src/uri-conversion/get-select.spec.ts
@@ -18,7 +18,7 @@ describe('get select', () => {
       'StringProperty,ComplexTypeProperty,TEST_CUSTOM_PROPERTY,ComplexTypeCollectionProperty'
     );
   });
-  
+
   it('should return only a selection of all fields', () => {
     expect(
       getSelect([

--- a/packages/odata-v4/src/uri-conversion/get-select.spec.ts
+++ b/packages/odata-v4/src/uri-conversion/get-select.spec.ts
@@ -1,0 +1,61 @@
+import { asc } from '@sap-cloud-sdk/odata-common';
+import {
+    testEntityApi,
+    testEntityMultiLinkApi,
+    testEntitySingleLinkApi
+} from '../../test/test-util';
+import { getSelect } from "./get-select";
+
+describe('get select', () => {
+    it('all fields', () => {
+        expect(
+            getSelect([
+                testEntityApi.schema.ALL_FIELDS,
+                // 2 properties below aren't accepted because the acceptable argument type `Selectable` doesn't contain the 2 types unlike v2 `getSelect`
+                testEntityApi.schema.TO_SINGLE_LINK,
+                testEntityApi.schema.TO_MULTI_LINK
+            ]).select
+        ).toBe('*')
+    });
+    it('single link', () => {
+        expect(
+            getSelect([
+                //type `OneToOneLink` is not acceptable for type `Selectable`
+                testSingleLink.select
+            ]).select
+        ).toBe('to_SingleLink/StringProperty,to_SingleLink/BooleanProperty')
+    });
+
+    it('for multi link with sub-query', () => {
+        expect(
+            getSelect([
+                //type `OneToManyLink` is not acceptable for type `Selectable`
+                testMultiLink.select
+            ]).select
+        ).toBe(
+            `${testMultiLink.odataStr}`
+        );
+    });
+});
+
+const encodedSpace = encodeURIComponent(' ');
+
+const testSingleLink = {
+    select: testEntityApi.schema.TO_SINGLE_LINK.select(
+        testEntitySingleLinkApi.schema.STRING_PROPERTY,
+        testEntitySingleLinkApi.schema.BOOLEAN_PROPERTY
+    ),
+    odataStr: 'to_SingleLink($select=StringProperty,BooleanProperty)'
+};
+
+const testMultiLink = {
+    select: testEntityApi.schema.TO_MULTI_LINK.select(
+        testEntityMultiLinkApi.schema.STRING_PROPERTY,
+        testEntityMultiLinkApi.schema.BOOLEAN_PROPERTY
+    )
+        .orderBy(asc(testEntityMultiLinkApi.schema.STRING_PROPERTY))
+        .filter(testEntityMultiLinkApi.schema.STRING_PROPERTY.equals('test'))
+        .top(1)
+        .skip(1),
+    odataStr: `to_MultiLink($select=StringProperty,BooleanProperty;$filter=(StringProperty%20eq%20'test');$skip=1;$top=1;$orderby=StringProperty${encodedSpace}asc)`
+};

--- a/packages/odata-v4/src/uri-conversion/get-select.spec.ts
+++ b/packages/odata-v4/src/uri-conversion/get-select.spec.ts
@@ -1,61 +1,29 @@
-import { asc } from '@sap-cloud-sdk/odata-common';
-import {
-    testEntityApi,
-    testEntityMultiLinkApi,
-    testEntitySingleLinkApi
-} from '../../test/test-util';
-import { getSelect } from "./get-select";
+import { testEntityApi } from '../../test/test-util';
+import { getSelect } from './get-select';
 
 describe('get select', () => {
-    it('all fields', () => {
-        expect(
-            getSelect([
-                testEntityApi.schema.ALL_FIELDS,
-                // 2 properties below aren't accepted because the acceptable argument type `Selectable` doesn't contain the 2 types unlike v2 `getSelect`
-                testEntityApi.schema.TO_SINGLE_LINK,
-                testEntityApi.schema.TO_MULTI_LINK
-            ]).select
-        ).toBe('*')
-    });
-    it('single link', () => {
-        expect(
-            getSelect([
-                //type `OneToOneLink` is not acceptable for type `Selectable`
-                testSingleLink.select
-            ]).select
-        ).toBe('to_SingleLink/StringProperty,to_SingleLink/BooleanProperty')
-    });
-
-    it('for multi link with sub-query', () => {
-        expect(
-            getSelect([
-                //type `OneToManyLink` is not acceptable for type `Selectable`
-                testMultiLink.select
-            ]).select
-        ).toBe(
-            `${testMultiLink.odataStr}`
-        );
-    });
+  it('all fields', () => {
+    expect(getSelect([testEntityApi.schema.ALL_FIELDS]).select).toBe('*');
+  });
+  it('should return all selected propertiesmj', () => {
+    expect(
+      getSelect([
+        testEntityApi.schema.STRING_PROPERTY,
+        testEntityApi.schema.COMPLEX_TYPE_PROPERTY,
+        testEntityApi.customField('TEST_CUSTOM_PROPERTY'),
+        testEntityApi.schema.COMPLEX_TYPE_COLLECTION_PROPERTY
+      ]).select
+    ).toBe('StringProperty,BooleanProperty');
+  });
+  it('ignore', () => {
+    expect(
+      getSelect([
+        testEntityApi.schema.ALL_FIELDS,
+        testEntityApi.schema.STRING_PROPERTY,
+        testEntityApi.schema.COMPLEX_TYPE_PROPERTY,
+        testEntityApi.customField('TEST_CUSTOM_PROPERTY'),
+        testEntityApi.schema.COMPLEX_TYPE_COLLECTION_PROPERTY
+      ]).select
+    ).toBe('*');
+  });
 });
-
-const encodedSpace = encodeURIComponent(' ');
-
-const testSingleLink = {
-    select: testEntityApi.schema.TO_SINGLE_LINK.select(
-        testEntitySingleLinkApi.schema.STRING_PROPERTY,
-        testEntitySingleLinkApi.schema.BOOLEAN_PROPERTY
-    ),
-    odataStr: 'to_SingleLink($select=StringProperty,BooleanProperty)'
-};
-
-const testMultiLink = {
-    select: testEntityApi.schema.TO_MULTI_LINK.select(
-        testEntityMultiLinkApi.schema.STRING_PROPERTY,
-        testEntityMultiLinkApi.schema.BOOLEAN_PROPERTY
-    )
-        .orderBy(asc(testEntityMultiLinkApi.schema.STRING_PROPERTY))
-        .filter(testEntityMultiLinkApi.schema.STRING_PROPERTY.equals('test'))
-        .top(1)
-        .skip(1),
-    odataStr: `to_MultiLink($select=StringProperty,BooleanProperty;$filter=(StringProperty%20eq%20'test');$skip=1;$top=1;$orderby=StringProperty${encodedSpace}asc)`
-};

--- a/packages/odata-v4/src/uri-conversion/get-select.spec.ts
+++ b/packages/odata-v4/src/uri-conversion/get-select.spec.ts
@@ -2,10 +2,10 @@ import { testEntityApi } from '../../test/test-util';
 import { getSelect } from './get-select';
 
 describe('get select', () => {
-  it('all fields', () => {
+  it('should return a selection of all fields', () => {
     expect(getSelect([testEntityApi.schema.ALL_FIELDS]).select).toBe('*');
   });
-  it('should return all selected propertiesmj', () => {
+  it('should return all selected properties', () => {
     expect(
       getSelect([
         testEntityApi.schema.STRING_PROPERTY,
@@ -13,9 +13,9 @@ describe('get select', () => {
         testEntityApi.customField('TEST_CUSTOM_PROPERTY'),
         testEntityApi.schema.COMPLEX_TYPE_COLLECTION_PROPERTY
       ]).select
-    ).toBe('StringProperty,BooleanProperty');
+    ).toBe('StringProperty,ComplexTypeProperty,TEST_CUSTOM_PROPERTY,ComplexTypeCollectionProperty');
   });
-  it('ignore', () => {
+  it('should return only a selection of all fields', () => {
     expect(
       getSelect([
         testEntityApi.schema.ALL_FIELDS,


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#463.

this adds explicit tests for `getSelect()`, `getExpand()` and also `properties-util.ts`

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
