### PR TITLE
fix: API docs module section issues

### DIFF
--- a/packages/connectivity/src/scp-cf/destination/http-proxy-util.ts
+++ b/packages/connectivity/src/scp-cf/destination/http-proxy-util.ts
@@ -3,7 +3,7 @@ import { URL } from 'url';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { createLogger, sanitizeRecord } from '@sap-cloud-sdk/util';
-import { Protocol } from '../protocol';
+import { Protocol, ProtocolNamespace } from '../protocol';
 import { ProxyConfiguration } from '../connectivity-service-types';
 import { basicHeader } from '../authorization-header';
 import {
@@ -155,7 +155,7 @@ export function parseProxyEnv(
 
     const proxyConfig: ProxyConfiguration = {
       host: url.hostname,
-      protocol: Protocol.of(url.protocol)!,
+      protocol: ProtocolNamespace.of(url.protocol)!,
       port: getPort(url)
     };
 

--- a/packages/connectivity/src/scp-cf/destination/http-proxy-util.ts
+++ b/packages/connectivity/src/scp-cf/destination/http-proxy-util.ts
@@ -3,7 +3,7 @@ import { URL } from 'url';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { createLogger, sanitizeRecord } from '@sap-cloud-sdk/util';
-import { Protocol, ProtocolNamespace } from '../protocol';
+import { Protocol, getProtocol } from '../protocol';
 import { ProxyConfiguration } from '../connectivity-service-types';
 import { basicHeader } from '../authorization-header';
 import {
@@ -155,7 +155,7 @@ export function parseProxyEnv(
 
     const proxyConfig: ProxyConfiguration = {
       host: url.hostname,
-      protocol: ProtocolNamespace.of(url.protocol)!,
+      protocol: getProtocol(url.protocol)!,
       port: getPort(url)
     };
 

--- a/packages/connectivity/src/scp-cf/get-protocol.ts
+++ b/packages/connectivity/src/scp-cf/get-protocol.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@sap-cloud-sdk/util';
 import { Destination } from './destination/destination-service-types';
-import { Protocol, ProtocolNamespace } from './protocol';
+import { Protocol, getProtocol } from './protocol';
 
 const logger = createLogger({
   package: 'connectivity',
@@ -23,7 +23,7 @@ export function getProtocolOrDefault(destination: Destination): Protocol {
     );
     return Protocol.HTTPS;
   }
-  const casted = ProtocolNamespace.of(protocol[0]);
+  const casted = getProtocol(protocol[0]);
   if (casted) {
     return casted;
   }

--- a/packages/connectivity/src/scp-cf/get-protocol.ts
+++ b/packages/connectivity/src/scp-cf/get-protocol.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@sap-cloud-sdk/util';
 import { Destination } from './destination/destination-service-types';
-import { Protocol } from './protocol';
+import { Protocol, ProtocolNamespace } from './protocol';
 
 const logger = createLogger({
   package: 'connectivity',
@@ -23,7 +23,7 @@ export function getProtocolOrDefault(destination: Destination): Protocol {
     );
     return Protocol.HTTPS;
   }
-  const casted = Protocol.of(protocol[0]);
+  const casted = ProtocolNamespace.of(protocol[0]);
   if (casted) {
     return casted;
   }

--- a/packages/connectivity/src/scp-cf/protocol.ts
+++ b/packages/connectivity/src/scp-cf/protocol.ts
@@ -10,22 +10,18 @@ export enum Protocol {
 }
 /**
  * @internal
+ * Get {@link Protocol} from its string representation.
+ * @param protocol - Protocol as string, either 'http'/'https' or 'http:'/'https:'.
+ * @returns Either the matching protocol or undefined.
  */
-export namespace ProtocolNamespace {
-  /**
-   * Get {@link Protocol} from its string representation.
-   * @param protocol - Protocol as string, either 'http'/'https' or 'http:'/'https:'.
-   * @returns Either the matching protocol or undefined.
-   */
-  export function of(protocol: string): Protocol | undefined {
-    if (protocol.endsWith(':')) {
-      return of(protocol.slice(0, -1));
-    }
-    if (protocol.toLowerCase() === Protocol.HTTP) {
-      return Protocol.HTTP;
-    }
-    if (protocol.toLowerCase() === Protocol.HTTPS) {
-      return Protocol.HTTPS;
-    }
+export function getProtocol(protocol: string): Protocol | undefined {
+  if (protocol.endsWith(':')) {
+    return getProtocol(protocol.slice(0, -1));
+  }
+  if (protocol.toLowerCase() === Protocol.HTTP) {
+    return Protocol.HTTP;
+  }
+  if (protocol.toLowerCase() === Protocol.HTTPS) {
+    return Protocol.HTTPS;
   }
 }

--- a/packages/connectivity/src/scp-cf/protocol.ts
+++ b/packages/connectivity/src/scp-cf/protocol.ts
@@ -11,7 +11,7 @@ export enum Protocol {
 /**
  * @internal
  */
-export namespace Protocol {
+export namespace ProtocolNamespace {
   /**
    * Get {@link Protocol} from its string representation.
    * @param protocol - Protocol as string, either 'http'/'https' or 'http:'/'https:'.


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes [SAP/cloud-sdk-backlog#883](https://github.com/SAP/cloud-sdk-backlog/issues/883)


This fixes 2 issues in our API docs module section.
#### issue 1: The connectivity package has an internal layer that contains unnecessary list item [`Protocol`](https://sap.github.io/cloud-sdk/api/2.9.0/)
this comes from that typedoc wrongly recognizes the internal namespace [`Protocol`](https://github.com/SAP/cloud-sdk-js/blob/b7344eb5c737984de5dff3f0948e6e343e2ab15c/packages/connectivity/src/scp-cf/protocol.ts#L14) is exported instead it has `@internal` tag. That's because the same name enum [`Protocol`](https://github.com/SAP/cloud-sdk-js/blob/b7344eb5c737984de5dff3f0948e6e343e2ab15c/packages/connectivity/src/scp-cf/protocol.ts#L6) is exported in the same file then typedoc see the internal namespace as exported one. the namespace `Protocol` and the enum `Protocol` must have different names. ~~this changed the namespace name to the identifiable name `ProtocolNameSpace`.~~
**update**: Since the namespace is only used for the `of` method inside it, this extracts the function as a new function `getProtocol()` outside of the namespace and deletes it.
#### issue 2: The mail package does not follow the common naming scheme and instead shows a file path.
Currently, the mail package link is a file path [`mail-client/src`](https://sap.github.io/cloud-sdk/api/2.9.0/modules/mailclient_src) but this should be `@sap-cloud-sdk/mail-client`.
This comes from missing JSDoc annotations in the `index.ts`. It needs the annotations:
```
/**
 * [[include:mail-client/README.md]]
 * @packageDocumentation
 * @module @sap-cloud-sdk/mail-client
 */
```
**[Actually, this has already been added.](https://github.com/SAP/cloud-sdk-js/commit/838aaef7d280eb002d9abb563f483104c0a86da4)** The incorrect module name will be updated correctly.
<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
