### PR TITLE
Improve error messages in ts compiler

### DIFF
--- a/packages/generator-common/src/compiler.ts
+++ b/packages/generator-common/src/compiler.ts
@@ -65,18 +65,20 @@ export async function transpileDirectory(
 
 function getErrorList(diagnostics: Diagnostic[]): string[] {
   return diagnostics.map(diagnostic => {
+    const text =
+      typeof diagnostic.messageText === 'string'
+        ? diagnostic.messageText
+        : diagnostic.messageText.messageText;
+
     if (diagnostic.file) {
       const { lineNumber, linePosition } = findPositions(
         diagnostic.file.statements,
         diagnostic.start
       );
 
-      return `${diagnostic.file.fileName}:${lineNumber}:${linePosition} - error TS${diagnostic.code}: ${diagnostic.messageText}`;
+      return `${diagnostic.file.fileName}:${lineNumber}:${linePosition} - error TS${diagnostic.code}: ${text}`;
     }
-    const text =
-      typeof diagnostic.messageText === 'string'
-        ? diagnostic.messageText
-        : diagnostic.messageText.messageText;
+
     return `error TS${diagnostic.code}: ${text}`;
   });
 }


### PR DESCRIPTION
In some cases our compiler created error messages such as:

```
Caused by:
Error: Compilation Errors:
.../Foo.ts:2:772 - error TS7053: [object Object]
```

This commit fixes that by selecting the string property if the object containing the error is not a string.
