### PR TITLE
fix: a readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This package contains all Cloud Foundry connectivity service related methods lik
 To install the SAP Cloud SDK conectivity in your project, run:
 
 ```bash
-$ npm install @sap-cloud-sdk/conectivity
+$ npm install @sap-cloud-sdk/connectivity
 ```
 
 ### @sap-cloud-sdk/odata-v2


### PR DESCRIPTION
npm package name correction: @sap-cloud-sdk/conectivity to @sap-cloud-sdk/connectivity

Typo correction in npm package name

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
