### PR TITLE
fix: update broken API doc links

### DIFF
--- a/packages/connectivity/README.md
+++ b/packages/connectivity/README.md
@@ -41,7 +41,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -53,7 +53,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/generator-common/README.md
+++ b/packages/generator-common/README.md
@@ -29,7 +29,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -60,7 +60,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/http-client/README.md
+++ b/packages/http-client/README.md
@@ -46,7 +46,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/mail-client/README.md
+++ b/packages/mail-client/README.md
@@ -44,7 +44,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/odata-common/README.md
+++ b/packages/odata-common/README.md
@@ -30,7 +30,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/odata-v2/README.md
+++ b/packages/odata-v2/README.md
@@ -28,7 +28,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/odata-v4/README.md
+++ b/packages/odata-v4/README.md
@@ -28,7 +28,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -143,7 +143,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -40,7 +40,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/temporal-de-serializers/README.md
+++ b/packages/temporal-de-serializers/README.md
@@ -48,7 +48,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/test-util/README.md
+++ b/packages/test-util/README.md
@@ -72,7 +72,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -45,7 +45,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)

--- a/scripts/COMMON-README-PART.md
+++ b/scripts/COMMON-README-PART.md
@@ -17,7 +17,7 @@ If you would like to contribute to the SAP Cloud SDK, please make yourself famil
 
 <br>
 
-- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/)
+- [SAP Cloud SDK Documentation portal](https://sap.github.io/cloud-sdk/api/latest)
 - [SAP Cloud SDK Documentation portal - Getting started guide](https://sap.github.io/cloud-sdk/docs/js/getting-started)
 - [SAP Cloud SDK Documentation portal - API documentation](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts)
 - [SAP Cloud SDK Documentation portal - Error handling](https://sap.github.io/cloud-sdk/docs/js/features/error-handling)


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes https://github.com/SAP/cloud-sdk-backlog/issues/889

this updates broken API doc links

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
