### PR TITLE
chore: add tests for using `appendPath`

### DIFF
--- a/packages/odata-v2/src/request-builder/create-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/create-request-builder.spec.ts
@@ -235,7 +235,7 @@ describe('CreateRequestBuilder', () => {
     const testEntity = testEntityApi
       .entityBuilder()
       .stringProperty(stringProp)
-      .withCustomFields( { [customPropKey]: customPropVal } )
+      .withCustomFields({ [customPropKey]: customPropVal })
       .build();
 
     const body = { StringProperty: stringProp, customPropKey: customPropVal };

--- a/packages/odata-v2/src/request-builder/create-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/create-request-builder.spec.ts
@@ -227,6 +227,36 @@ describe('CreateRequestBuilder', () => {
     testPostRequestOutcome(actual, childEntity.setOrInitializeRemoteState());
   });
 
+  it('should build append custom URLs', async () => {
+    const stringProp = 'str';
+    const customPropKey = 'customPropKey';
+    const customPropVal = 'customPropVal';
+
+    const testEntity = testEntityApi
+      .entityBuilder()
+      .stringProperty(stringProp)
+      .withCustomFields( { [customPropKey]: customPropVal } )
+      .build();
+
+    const body = { StringProperty: stringProp, customPropKey: customPropVal };
+
+    mockCreateRequest(
+      {
+        body,
+        path: 'A_TestEntity/$links/to_MultiLink'
+      },
+      testEntityApi
+    );
+
+    const actual = await testEntityApi
+      .requestBuilder()
+      .create(testEntity)
+      .appendPath('/$links', '/to_MultiLink')
+      .executeRaw(defaultDestination);
+
+    expect(actual.data.d.customPropKey).toEqual(customPropVal);
+  });
+
   it('throws an error when request execution fails', async () => {
     mockCreateRequest(
       {

--- a/test-packages/integration-tests/test/test-data/batch-sub-requests.ts
+++ b/test-packages/integration-tests/test/test-data/batch-sub-requests.ts
@@ -79,7 +79,7 @@ export const createRequestWithAppendPath = testEntityApi
     testEntityApi
       .entityBuilder()
       .stringProperty('stringProp')
-      .withCustomFields( { customPropKey: 'customPropVal' } )
+      .withCustomFields({ customPropKey: 'customPropVal' })
       .build()
   )
   .appendPath('/$links', '/to_MultiLink');

--- a/test-packages/integration-tests/test/test-data/batch-sub-requests.ts
+++ b/test-packages/integration-tests/test/test-data/batch-sub-requests.ts
@@ -72,3 +72,14 @@ export const deleteRequest = testEntityApi
       .build()
   )
   .ignoreVersionIdentifier();
+
+export const createRequestWithAppendPath = testEntityApi
+  .requestBuilder()
+  .create(
+    testEntityApi
+      .entityBuilder()
+      .stringProperty('stringProp')
+      .withCustomFields( { customPropKey: 'customPropVal' } )
+      .build()
+  )
+  .appendPath('/$links', '/to_MultiLink');

--- a/test-packages/integration-tests/test/test-data/batch/changeset-request.ts
+++ b/test-packages/integration-tests/test/test-data/batch/changeset-request.ts
@@ -56,6 +56,16 @@ const deleteTestEntity = [
   ''
 ];
 
+const createTestEntityWithAppendPath = [
+  ...changesetHeader(),
+  '',
+  'POST /sap/opu/odata/sap/API_TEST_SRV/A_TestEntity/\\$links/to_MultiLink HTTP/1\\.1',
+  ...requestHeader(),
+  '',
+  '{"StringProperty":"stringProp","customPropKey":"customPropVal"}',
+  ''
+];
+
 export const singleChangesetRequest = [
   'Content-Type: multipart/mixed; boundary=changeset_.*',
   '',
@@ -75,5 +85,13 @@ export const multiChangesetRequest = [
   ...putTestEntity,
   '--changeset_.*',
   ...deleteTestEntity,
+  '--changeset_.*'
+];
+
+export const singleChangesetRequestWithCustomUrl = [
+  'Content-Type: multipart/mixed; boundary=changeset_.*',
+  '',
+  '--changeset_.*',
+  ...createTestEntityWithAppendPath,
   '--changeset_.*'
 ];

--- a/test-packages/integration-tests/test/test-data/batch/requests.ts
+++ b/test-packages/integration-tests/test/test-data/batch/requests.ts
@@ -1,8 +1,9 @@
 import { webEOL } from '@sap-cloud-sdk/util';
 import {
-    multiChangesetRequest,
-    singleChangesetRequest, singleChangesetRequestWithCustomUrl
-} from "./changeset-request";
+  multiChangesetRequest,
+  singleChangesetRequest,
+  singleChangesetRequestWithCustomUrl
+} from './changeset-request';
 import { getAllRequest, getByKeyRequest } from './retrieve-request';
 
 export const multiRetrieveRequest = () =>

--- a/test-packages/integration-tests/test/test-data/batch/requests.ts
+++ b/test-packages/integration-tests/test/test-data/batch/requests.ts
@@ -1,8 +1,8 @@
 import { webEOL } from '@sap-cloud-sdk/util';
 import {
-  multiChangesetRequest,
-  singleChangesetRequest
-} from './changeset-request';
+    multiChangesetRequest,
+    singleChangesetRequest, singleChangesetRequestWithCustomUrl
+} from "./changeset-request";
 import { getAllRequest, getByKeyRequest } from './retrieve-request';
 
 export const multiRetrieveRequest = () =>
@@ -20,6 +20,8 @@ export const multiChangesetBatchRequest = () =>
     ...singleChangesetRequest,
     '--batch_.*',
     ...multiChangesetRequest,
+    '--batch_.*',
+    ...singleChangesetRequestWithCustomUrl,
     '--batch_.*'
   ].join(webEOL);
 

--- a/test-packages/integration-tests/test/v2/batch.spec.ts
+++ b/test-packages/integration-tests/test/v2/batch.spec.ts
@@ -8,13 +8,13 @@ import { basicHeader } from '@sap-cloud-sdk/connectivity/internal';
 import { ErrorResponse } from '@sap-cloud-sdk/odata-common';
 import {
   createAsChildOfRequest,
-  createRequest,
+  createRequest, createRequestWithAppendPath,
   deleteRequest,
   getAllRequest,
   getByKeyRequest,
   patchRequest,
   putRequest
-} from '../test-data/batch-sub-requests';
+} from "../test-data/batch-sub-requests";
 import {
   mixedBatchRequest,
   mixedErrorRequest,
@@ -94,7 +94,11 @@ describe('Batch', () => {
 
     const request = batch(
       changeset(createRequest),
-      changeset(createAsChildOfRequest, patchRequest, putRequest, deleteRequest)
+      changeset(createAsChildOfRequest, patchRequest, putRequest, deleteRequest),
+      // When `appendPath` is used, `execute` is disabled and only `executeRaw` can be used, as the response type is unknown.
+      // We have to use "as any" for "fixing" the compile time error.
+      // For runtime, batch write response does not know entity type anyways, so it does not hurt.
+      changeset(createRequestWithAppendPath as any)
     ).execute(destination);
     await expect(request).resolves.not.toThrow();
   });

--- a/test-packages/integration-tests/test/v2/batch.spec.ts
+++ b/test-packages/integration-tests/test/v2/batch.spec.ts
@@ -8,13 +8,14 @@ import { basicHeader } from '@sap-cloud-sdk/connectivity/internal';
 import { ErrorResponse } from '@sap-cloud-sdk/odata-common';
 import {
   createAsChildOfRequest,
-  createRequest, createRequestWithAppendPath,
+  createRequest,
+  createRequestWithAppendPath,
   deleteRequest,
   getAllRequest,
   getByKeyRequest,
   patchRequest,
   putRequest
-} from "../test-data/batch-sub-requests";
+} from '../test-data/batch-sub-requests';
 import {
   mixedBatchRequest,
   mixedErrorRequest,
@@ -94,7 +95,12 @@ describe('Batch', () => {
 
     const request = batch(
       changeset(createRequest),
-      changeset(createAsChildOfRequest, patchRequest, putRequest, deleteRequest),
+      changeset(
+        createAsChildOfRequest,
+        patchRequest,
+        putRequest,
+        deleteRequest
+      ),
       // When `appendPath` is used, `execute` is disabled and only `executeRaw` can be used, as the response type is unknown.
       // We have to use "as any" for "fixing" the compile time error.
       // For runtime, batch write response does not know entity type anyways, so it does not hurt.


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Related to: https://github.com/SAP/cloud-sdk-backlog/issues/943

Added some tests for using `appendPath`:
- with create requests
- with batch requests

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
