### PR TITLE
chore: Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,17 @@ updates:
       timezone: 'Europe/Berlin'
     open-pull-requests-limit: 10
     ignore:
+      # We only want to do major node updates on purpose, so don't create dependabot PRs for major versions
       - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
+      # chalk v5 needs ESM, see https://github.com/chalk/chalk/releases/tag/v5.0.0, we'll stay on v4 until we can use ESM
+      - dependency-name: 'chalk'
+        update-types: ['version-update:semver-major']
+      # execa v6 needs ESM, see https://github.com/sindresorhus/execa/releases/tag/v6.0.0, we'll stay on v5 until we can use ESM
+      - dependency-name: 'execa'
+        update-types: ['version-update:semver-major']
+      # axios v1 needs ESM
+      - dependency-name: 'axios'
         update-types: ['version-update:semver-major']
   - package-ecosystem: npm
     target-branch: v2-main
@@ -20,7 +30,17 @@ updates:
       timezone: 'Europe/Berlin'
     open-pull-requests-limit: 10
     ignore:
+      # We only want to do major node updates on purpose, so don't create dependabot PRs for major versions
       - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
+      # chalk v5 needs ESM, see https://github.com/chalk/chalk/releases/tag/v5.0.0, we'll stay on v4 until we can use ESM
+      - dependency-name: 'chalk'
+        update-types: ['version-update:semver-major']
+      # execa v6 needs ESM, see https://github.com/sindresorhus/execa/releases/tag/v6.0.0, we'll stay on v5 until we can use ESM
+      - dependency-name: 'execa'
+        update-types: ['version-update:semver-major']
+      # axios v1 needs ESM
+      - dependency-name: 'axios'
         update-types: ['version-update:semver-major']
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
Ignore major dependabot updates for chalk, execa and axios because new versions require ESM which we don't use yet.

- [x] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
- [x] If my change will be merged into the `main` branch (for v3), I've updated (V3-Upgrade-Guide.md)[./V3-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v3

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
