### PR TITLE
Update build jobs default to node 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1.1
       - uses: actions/cache@v3
@@ -85,7 +85,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - uses: actions/cache@v3
         id: cache
         with:

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -15,7 +15,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - run: yarn install --frozen-lockfile
       - run: yarn test:unit --continue -- -- -- --json --outputFile=unit-test-output.json
       - run: yarn test:integration -- -- -- --json --outputFile=int-test-output.json

--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -16,7 +16,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - uses: actions/cache@v3
         id: cache
         with:


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

- [ ] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
- [ ] If my change will be merged into the `main` branch (for v3), I've updated (V3-Upgrade-Guide.md)[./V3-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v3

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
