### PR TITLE
Configure ci for sdk v3

### DIFF
--- a/.github/workflows/build-v3.yml
+++ b/.github/workflows/build-v3.yml
@@ -51,7 +51,7 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --ignore-engines --frozen-lockfile
       - run: yarn lint
         name: Static Code Check
       - run: yarn check:test-service
@@ -83,5 +83,5 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --ignore-engines --frozen-lockfile
       - run: yarn test:e2e

--- a/.github/workflows/build-v3.yml
+++ b/.github/workflows/build-v3.yml
@@ -1,0 +1,87 @@
+name: build v3
+
+on:
+  pull_request:
+    branches: ['main']
+  push:
+    branches: ['main']
+    paths-ignore:
+      - 'docs/**'
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - run: git fetch --depth=1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ubuntu-latest-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --ignore-engines --frozen-lockfile
+      - run: yarn test:unit
+        env:
+          SANDBOX_TOKEN: ${{ secrets.API_HUB_SANDBOX_TOKEN }}
+      - run: yarn test:integration
+      - run: yarn test:self
+      - run: yarn test:type
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: git fetch --depth=1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v1.1
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+        name: Static Code Check
+      - run: yarn check:test-service
+        name: Test Service Version Check
+      - run: yarn check:dependencies
+        name: Undeclared dependency Check
+      - run: yarn check:public-api
+        name: Check public api
+      - run: yarn test:self
+        name: Self tests for tools
+      - run: yarn check:circular
+        name: Circular dependency Check
+      - run: yarn doc
+        name: API Doc Check
+      - run: yarn check:license
+        name: License Check
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: git fetch --depth=1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn test:e2e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 name: build
 
 on:
-  pull_request: ~
+  pull_request:
+    branches: ['v2-main']
   push:
     branches: ['v2-main']
     tags: ['v*']


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Configure CI runs for `main` and `v2-main` branches separately. This allows us to only run nodejs 18 for main where we don't need to care for older versions and allows us to do other tweaks to the build as long as v3 is not yet released.

- [x] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
- [x] If my change will be merged into the `main` branch (for v3), I've updated (V3-Upgrade-Guide.md)[./V3-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v3

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
