### PR TITLE
Configure dependabot to update axios on v3 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,6 @@ updates:
       # execa v6 needs ESM, see https://github.com/sindresorhus/execa/releases/tag/v6.0.0, we'll stay on v5 until we can use ESM
       - dependency-name: 'execa'
         update-types: ['version-update:semver-major']
-      # axios v1 needs ESM
-      - dependency-name: 'axios'
-        update-types: ['version-update:semver-major']
   - package-ecosystem: npm
     target-branch: v2-main
     directory: '/'
@@ -39,7 +36,7 @@ updates:
       # execa v6 needs ESM, see https://github.com/sindresorhus/execa/releases/tag/v6.0.0, we'll stay on v5 until we can use ESM
       - dependency-name: 'execa'
         update-types: ['version-update:semver-major']
-      # axios v1 needs ESM
+      # axios v1 needs node 16
       - dependency-name: 'axios'
         update-types: ['version-update:semver-major']
   - package-ecosystem: github-actions


### PR DESCRIPTION
Should be merged after https://github.com/SAP/cloud-sdk-js/pull/3154

- [x] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
- [x] If my change will be merged into the `main` branch (for v3), I've updated (V3-Upgrade-Guide.md)[./V3-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v3
