### PR TITLE
chore: Fix v2-main bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
-          ref: 'main'
+          ref: 'v2-main'
       - uses: actions/setup-node@v3
         with:
           node-version: 14


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

- [x] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
