### PR TITLE
chore: Don't run dependency check as part of compile

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,9 @@
   ],
   "pipeline": {
     "compile": {
-      "dependsOn": ["^compile", "check:dependencies"]
+      "dependsOn": [
+        "^compile"
+      ]
     },
     "test": {
       "dependsOn": ["^compile", "^generate"]


### PR DESCRIPTION
This speeds up the build process and dependency check is still run as part of the pipeline.

<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

- [ ] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
- [ ] If my change will be merged into the `main` branch (for v3), I've updated (V3-Upgrade-Guide.md)[./V3-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v3

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
