### PR TITLE
chore: Fix `next` version release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
           dateDiff=$(expr $curDate - $lastCommitDate)
           echo $lastCommitDate, $curDate, $dateDiff
 
-          if [[ inputs.canary-release != true && $dateDiff -gt 86400 ]]
+          if [[ ${{ inputs.canary-release }} != true && $dateDiff -gt 86400 ]]
           then
               echo 'No new commit found on ${{ github.ref }} within the last 24 hrs.'
               echo '::set-output name=skip::true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
           dateDiff=$(expr $curDate - $lastCommitDate)
           echo $lastCommitDate, $curDate, $dateDiff
 
-          if [[ $dateDiff -gt 86400 ]]
+          if [[ inputs.canary-release != true && $dateDiff -gt 86400 ]]
           then
               echo 'No new commit found on ${{ github.ref }} within the last 24 hrs.'
               echo '::set-output name=skip::true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
           dateDiff=$(expr $curDate - $lastCommitDate)
           echo $lastCommitDate, $curDate, $dateDiff
 
-          if [[ ${{ inputs.canary-release }} != true && $dateDiff -gt 86400 ]]
+          if [[ ${{ inputs.canary-release != true }} && $dateDiff -gt 86400 ]]
           then
               echo 'No new commit found on ${{ github.ref }} within the last 24 hrs.'
               echo '::set-output name=skip::true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,19 +129,7 @@ jobs:
       - run: git fetch --depth=1
       - id: date-check
         name: Check if latest commit is within 24 hrs
-        run: |
-          lastCommitDate=$(git --no-pager log -n 1 main --pretty=format:"%at")
-          curDate=$(date +%s)
-          dateDiff=$(expr $curDate - $lastCommitDate)
-          echo $lastCommitDate, $curDate, $dateDiff
-
-          if [[ ${{ inputs.canary-release != true }} && $dateDiff -gt 86400 ]]
-          then
-              echo 'No new commit found on ${{ github.ref }} within the last 24 hrs.'
-              echo '::set-output name=skip::true'
-          else
-              echo '::set-output name=skip::false'
-          fi
+        run: echo '::set-output name=skip::false'
   canary-release:
     if: ${{ needs.canary-release-pre-check.outputs.skip == 'false' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

This git command does not work even locally: `git --no-pager log -n 1 main --pretty=format:"%at"`
It might be related to non-default branch.
As it does not bring much value anyways, I'll remove this check.

- [ ] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
- [ ] If my change will be merged into the `main` branch (for v3), I've updated (V3-Upgrade-Guide.md)[./V3-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v3

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
