### PR TITLE
chore: Return something on bail in retry middleware

### DIFF
--- a/packages/resilience/src/retry.ts
+++ b/packages/resilience/src/retry.ts
@@ -35,6 +35,8 @@ export function retry<ReturnType, ContextType extends Context>(
             }
             if (status.toString().startsWith('4')) {
               bail(new Error(`Request failed with status code ${status}`));
+              // We need to return something here but the actual value does not matter
+              return undefined as ReturnType;
             }
 
             throw error;


### PR DESCRIPTION
Without this return jest reported open handlers after the test finished.

Follow up for #3213
