### PR TITLE
chore: Fix nightly `next` release

### DIFF
--- a/.github/workflows/next-build-nightly.yml
+++ b/.github/workflows/next-build-nightly.yml
@@ -1,0 +1,136 @@
+name: next-build-nightly
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          - ref: 'main'
+      - run: git fetch --depth=1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ubuntu-latest-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --ignore-engines --frozen-lockfile
+      - run: yarn test:unit
+        env:
+          SANDBOX_TOKEN: ${{ secrets.API_HUB_SANDBOX_TOKEN }}
+      - run: yarn test:integration
+      - run: yarn test:self
+      - run: yarn test:type
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          - ref: 'main'
+      - run: git fetch --depth=1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v1.1
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+        name: Static Code Check
+      - run: yarn check:test-service
+        name: Test Service Version Check
+      - run: yarn check:dependencies
+        name: Undeclared dependency Check
+      - run: yarn check:public-api
+        name: Check public api
+      - run: yarn test:self
+        name: Self tests for tools
+      - run: yarn check:circular
+        name: Circular dependency Check
+      - run: yarn doc
+        name: API Doc Check
+      - run: yarn check:license
+        name: License Check
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          - ref: 'main'
+      - run: git fetch --depth=1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn test:e2e
+  canary-release-pre-check:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.date-check.outputs.skip }}
+    needs: [tests, checks, e2e-tests]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          - ref: 'main'
+      - run: git fetch --depth=1
+      - id: date-check
+        name: Check if latest commit is within 24 hrs
+        run: echo '::set-output name=skip::false'
+  canary-release:
+    if: ${{ needs.canary-release-pre-check.outputs.skip == 'false' }}
+    runs-on: ubuntu-latest
+    needs: [ canary-release-pre-check ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          - ref: 'main'
+      - run: git fetch --depth=1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - name: Canary Release
+        run: |
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
+          date=`date +%Y%m%d%H%M%S`
+          rm -f .changeset/*.md
+          cp canary-release-changeset.md .changeset
+          yarn changeset pre enter ${date}
+          yarn changeset version
+          yarn changeset pre exit
+          yarn changeset publish --tag next
+        env:
+          NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

When using `v2-main` branch as default branch, the nightly job pipeline should also be located on the `v2-branch`

- [x] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
- [x] If my change will be merged into the `main` branch (for v3), I've updated (V3-Upgrade-Guide.md)[./V3-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v3

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
