### PR TITLE
chore: Release Major Canary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
           date=`date +%Y%m%d%H%M%S`
           rm -f .changeset/*.md
-          cp canary-release-changeset.md .changeset
+          cp major-release-changeset.md .changeset
           yarn changeset pre enter ${date}
           yarn changeset version
           yarn changeset pre exit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,9 @@ jobs:
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
           date=`date +%Y%m%d%H%M%S`
           rm -f .changeset/*.md
-          cp major-release-changeset.md .changeset
+          echo "project_version=$(cat package.json | jq '.version' | tr -d '"')" >> $GITHUB_ENV
+          [[ "${{ env.project_version }}" = 3* ]] && cp canary-release-changeset.md .changeset
+          [[ "${{ env.project_version }}" = 2* ]] && cp major-release-changeset.md .changeset
           yarn changeset pre enter ${date}
           yarn changeset version
           yarn changeset pre exit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,9 +153,10 @@ jobs:
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
           date=`date +%Y%m%d%H%M%S`
           rm -f .changeset/*.md
-          echo "project_version=$(cat package.json | jq '.version' | tr -d '"')" >> $GITHUB_ENV
-          [[ "${{ env.project_version }}" = 3* ]] && cp canary-release-changeset.md .changeset
-          [[ "${{ env.project_version }}" = 2* ]] && cp major-release-changeset.md .changeset
+          project_version=$(cat package.json | jq '.version' | tr -d '"')
+          echo The project version is: $project_version
+          [[ $project_version == 3* ]] && cp canary-release-changeset.md .changeset          
+          [[ $project_version == 2* ]] && cp major-release-changeset.md .changeset
           yarn changeset pre enter ${date}
           yarn changeset version
           yarn changeset pre exit

--- a/major-release-changeset.md
+++ b/major-release-changeset.md
@@ -1,0 +1,25 @@
+---
+'@sap-cloud-sdk/connectivity': major
+'@sap-cloud-sdk/eslint-config': major
+'@sap-cloud-sdk/generator': major
+'@sap-cloud-sdk/generator-common': major
+'@sap-cloud-sdk/http-client': major
+'@sap-cloud-sdk/odata-common': major
+'@sap-cloud-sdk/odata-v2': major
+'@sap-cloud-sdk/odata-v4': major
+'@sap-cloud-sdk/openapi': major
+'@sap-cloud-sdk/openapi-generator': major
+'@sap-cloud-sdk/temporal-de-serializers': major
+'@sap-cloud-sdk/test-util': major
+'@sap-cloud-sdk/util': major
+'@sap-cloud-sdk/e2e-tests': major
+'@sap-cloud-sdk/integration-tests': major
+'@sap-cloud-sdk/test-services-e2e': major
+'@sap-cloud-sdk/test-services-odata-common': major
+'@sap-cloud-sdk/test-services-odata-v2': major
+'@sap-cloud-sdk/test-services-odata-v4': major
+'@sap-cloud-sdk/test-services-openapi': major
+'@sap-cloud-sdk/type-tests': major
+---
+
+Canary release


### PR DESCRIPTION
Tackel prerelease problem introducing a 3.0.0 prerelease version. Currently the `next` tag points to a version 2.11.0-20221220 which fine in principle: https://www.npmjs.com/package/@sap-cloud-sdk/util?activeTab=versions

However, in the dependencies the changeset bumps to the next version which is 2.12.0. This is however a valid version two release now. Since it is missleading to use version 2.X.Y for version 3 prereleases this change will release a version 3.0.0-20221220 with the tag next. 