### PR TITLE
chore: Allow Manual Canary Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
       matrix:
         node-version: [18]
     steps:
+      - name: Show input from user
+        run: echo "Canary release flag ${{ github.event.inputs.canary-release }}"
       - uses: actions/checkout@v3
       - run: git fetch --depth=1
       - uses: actions/setup-node@v3
@@ -119,7 +121,7 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   canary-release-pre-check:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.canary-release == true || github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.canary-release == true || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     outputs:
       skip: ${{ steps.date-check.outputs.skip }}


### PR DESCRIPTION
I wanted to get my release after the #3252 was merged. However the release was skipped. I remembered that we do it only every 24hours so I did a manual trigger which should overwrite this.

However I think the `boolean` os not taken correctly from the event intputs see [here](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) and [here](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)

This PR changes this.
