### PR TITLE
chore: Fix Nightly Next Release

### DIFF
--- a/.github/workflows/next-build-nightly.yml
+++ b/.github/workflows/next-build-nightly.yml
@@ -127,7 +127,10 @@ jobs:
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
           date=`date +%Y%m%d%H%M%S`
           rm -f .changeset/*.md
-          cp canary-release-changeset.md .changeset
+          project_version=$(cat package.json | jq '.version' | tr -d '"')
+          echo The project version is: $project_version
+          [[ $project_version == 3* ]] && cp canary-release-changeset.md .changeset          
+          [[ $project_version == 2* ]] && cp major-release-changeset.md .changeset
           yarn changeset pre enter ${date}
           yarn changeset version
           yarn changeset pre exit

--- a/major-release-changeset.md
+++ b/major-release-changeset.md
@@ -1,0 +1,25 @@
+---
+'@sap-cloud-sdk/connectivity': major
+'@sap-cloud-sdk/eslint-config': major
+'@sap-cloud-sdk/generator': major
+'@sap-cloud-sdk/generator-common': major
+'@sap-cloud-sdk/http-client': major
+'@sap-cloud-sdk/odata-common': major
+'@sap-cloud-sdk/odata-v2': major
+'@sap-cloud-sdk/odata-v4': major
+'@sap-cloud-sdk/openapi': major
+'@sap-cloud-sdk/openapi-generator': major
+'@sap-cloud-sdk/temporal-de-serializers': major
+'@sap-cloud-sdk/test-util': major
+'@sap-cloud-sdk/util': major
+'@sap-cloud-sdk/e2e-tests': major
+'@sap-cloud-sdk/integration-tests': major
+'@sap-cloud-sdk/test-services-e2e': major
+'@sap-cloud-sdk/test-services-odata-common': major
+'@sap-cloud-sdk/test-services-odata-v2': major
+'@sap-cloud-sdk/test-services-odata-v4': major
+'@sap-cloud-sdk/test-services-openapi': major
+'@sap-cloud-sdk/type-tests': major
+---
+
+Canary release


### PR DESCRIPTION
The nightly run kept adding version with 2.11.0-123456 as next release:

https://github.com/SAP/cloud-sdk-js/actions/runs/3784638566

 This PR fixes that. I found it strange that the next release was not triggered from a file on the new `main`branch. The change should be the same as in the build file right now:

https://github.com/SAP/cloud-sdk-js/blob/e3444b46d19af40c4671b575c5b27918991558a3/.github/workflows/build.yml#L160