### PR TITLE
chore!: Replace enum `IsolationStrategy` with string literal union type

### DIFF
--- a/.changeset/purple-ties-lie.md
+++ b/.changeset/purple-ties-lie.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': major
+---
+
+[Compatibility Note] The enum `IsolationStrategy` was replaced with a string literal union type of the same name. Use 'tenant' and 'tenant-user' instead of `IsolationStrategy.Tenant` and `IsolationStrategy.Tenant_User`.

--- a/.changeset/yellow-schools-watch.md
+++ b/.changeset/yellow-schools-watch.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': major
+---
+
+[Improvement] Replace `IsolationStrategy` enum with union type.

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
@@ -181,7 +181,7 @@ describe('destination cache', () => {
       );
     });
 
-    it('retrieved subscriber destinations are cached with tenant id using "Tenant_User" isolation type by default ', async () => {
+    it("retrieved subscriber destinations are cached with tenant id using 'tenant-user' isolation type by default", async () => {
       await getDestination({
         destinationName: 'SubscriberDest',
         jwt: subscriberUserJwt,
@@ -315,7 +315,7 @@ describe('destination cache', () => {
       ).rejects.toThrowError(/Failed to fetch \w+ destinations./);
     }, 15000);
 
-    it('uses cache with isolation strategy Tenant if no JWT is provided', async () => {
+    it("uses cache with isolation strategy 'tenant' if no JWT is provided", async () => {
       await destinationCache.cacheRetrievedDestination(
         decodeJwt(providerServiceToken),
         destinationOne,
@@ -328,7 +328,7 @@ describe('destination cache', () => {
       expect(actual).toEqual(destinationOne);
     });
 
-    it('uses cache with isolation strategy Tenant and iss ', async () => {
+    it("uses cache with isolation strategy 'tenant' and 'iss' set", async () => {
       await destinationCache
         .getCacheInstance()
         .set(`${TestTenants.SUBSCRIBER_ONLY_ISS}::${destinationOne.name}`, {
@@ -358,7 +358,7 @@ describe('destination cache', () => {
       expect(actual).toEqual(destinationOne);
     });
 
-    it('enables cache if isolation strategy Tenant is provided', async () => {
+    it("enables cache if isolation strategy 'tenant' is provided", async () => {
       await destinationCache.cacheRetrievedDestination(
         decodeJwt(providerServiceToken),
         destinationOne,
@@ -400,7 +400,7 @@ describe('destination cache', () => {
         })
       ).rejects.toThrowError(/Failed to fetch \w+ destinations./);
       expect(warn).toBeCalledWith(
-        'Cannot get cache key. Isolation strategy Tenant is used, but tenant id is undefined.'
+        "Could not build destination cache key. Isolation strategy 'tenant' is used, but tenant id is undefined in JWT."
       );
     }, 15000);
 
@@ -417,7 +417,7 @@ describe('destination cache', () => {
         })
       ).rejects.toThrowError(/Failed to fetch \w+ destinations./);
       expect(warn).toBeCalledWith(
-        'Cannot get cache key. Isolation strategy TenantUser is used, but tenant id or user id is undefined.'
+        "Could not build destination cache key. Isolation strategy 'tenant-user' is used, but tenant id or user id is undefined in JWT."
       );
     }, 15000);
   });
@@ -672,7 +672,7 @@ describe('destination cache', () => {
       expect(actual).toEqual(parsedDestination);
     });
 
-    it('should return cached provider destination from cache after checking for remote subscriber destination when subscriberFirst is specified and destinations are Tenant isolated', async () => {
+    it('should return cached provider destination from cache after checking for remote subscriber destination when subscriberFirst is specified and destinations are tenant isolated', async () => {
       mockServiceBindings();
       mockVerifyJwt();
       mockServiceToken();
@@ -736,7 +736,7 @@ describe('destination cache', () => {
       expect([actual1, actual2]).toEqual(expected);
     });
 
-    it('should not hit cache when Tenant_User is chosen but user id is missing', async () => {
+    it("should not hit cache when 'tenant-user' is chosen but user id is missing", async () => {
       const dummyJwt = { zid: 'tenant' };
       await destinationCache.cacheRetrievedDestination(
         dummyJwt,
@@ -760,7 +760,7 @@ describe('destination cache', () => {
       expect([actual1, actual2]).toEqual(expected);
     });
 
-    it('should not hit cache when Tenant is chosen but tenant id is missing', async () => {
+    it("should not hit cache when 'tenant' is chosen but tenant id is missing", async () => {
       const dummyJwt = { user_id: 'user' };
       await destinationCache.cacheRetrievedDestination(
         dummyJwt,
@@ -879,13 +879,13 @@ describe('destination cache', () => {
 });
 
 describe('get destination cache key', () => {
-  it('should shown warning, when Tenant_User is chosen, but user id is missing', () => {
+  it("should shown warning, when 'tenant-user' is chosen, but user id is missing", () => {
     const logger = createLogger('destination-cache');
     const warn = jest.spyOn(logger, 'warn');
 
     getDestinationCacheKey({ zid: 'tenant' }, 'dest');
     expect(warn).toBeCalledWith(
-      'Cannot get cache key. Isolation strategy TenantUser is used, but tenant id or user id is undefined.'
+      "Could not build destination cache key. Isolation strategy 'tenant-user' is used, but tenant id or user id is undefined in JWT."
     );
   });
 });

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
@@ -166,7 +166,7 @@ describe('destination cache', () => {
         destinationName: 'ProviderDest',
         jwt: providerUserJwt,
         useCache: true,
-        isolationStrategy: IsolationStrategy.Tenant_User,
+        isolationStrategy: 'tenant-user',
         iasToXsuaaTokenExchange: false
       });
       const cacheKeys = Object.keys(
@@ -176,7 +176,7 @@ describe('destination cache', () => {
         getDestinationCacheKey(
           providerUserPayload,
           'ProviderDest',
-          IsolationStrategy.Tenant_User
+          'tenant-user'
         )
       );
     });
@@ -190,10 +190,10 @@ describe('destination cache', () => {
         iasToXsuaaTokenExchange: false
       });
 
-      const c1 = await getSubscriberCache(IsolationStrategy.Tenant);
-      const c2 = await getProviderCache(IsolationStrategy.Tenant);
-      const c5 = await getSubscriberCache(IsolationStrategy.Tenant_User);
-      const c6 = await getProviderCache(IsolationStrategy.Tenant_User);
+      const c1 = await getSubscriberCache('tenant');
+      const c2 = await getProviderCache('tenant');
+      const c5 = await getSubscriberCache('tenant-user');
+      const c6 = await getProviderCache('tenant-user');
 
       expect(c1).toBeUndefined();
       expect(c2).toBeUndefined();
@@ -207,13 +207,13 @@ describe('destination cache', () => {
         destinationName: 'SubscriberDest',
         jwt: subscriberUserJwt,
         useCache: true,
-        isolationStrategy: IsolationStrategy.Tenant,
+        isolationStrategy: 'tenant',
         cacheVerificationKeys: false,
         iasToXsuaaTokenExchange: false
       });
 
-      const c1 = await getSubscriberCache(IsolationStrategy.Tenant);
-      const c2 = await getProviderCache(IsolationStrategy.Tenant);
+      const c1 = await getSubscriberCache('tenant');
+      const c2 = await getProviderCache('tenant');
 
       expect(c1!.url).toBe('https://subscriber.example');
       expect(c2).toBeUndefined();
@@ -224,14 +224,14 @@ describe('destination cache', () => {
         destinationName: 'ProviderDest',
         jwt: subscriberUserJwt,
         useCache: true,
-        isolationStrategy: IsolationStrategy.Tenant,
+        isolationStrategy: 'tenant',
         cacheVerificationKeys: false,
         selectionStrategy: alwaysProvider,
         iasToXsuaaTokenExchange: false
       });
 
-      const c1 = await getSubscriberCache(IsolationStrategy.Tenant);
-      const c2 = await getProviderCache(IsolationStrategy.Tenant);
+      const c1 = await getSubscriberCache('tenant');
+      const c2 = await getProviderCache('tenant');
 
       expect(c1).toBeUndefined();
       expect(c2!.url).toBe('https://provider.example');
@@ -243,14 +243,14 @@ describe('destination cache', () => {
         destinationName: 'SubscriberDest',
         jwt: subscriberUserJwt,
         useCache: true,
-        isolationStrategy: IsolationStrategy.Tenant,
+        isolationStrategy: 'tenant',
         cacheVerificationKeys: false,
         selectionStrategy: alwaysSubscriber,
         iasToXsuaaTokenExchange: false
       });
 
-      const c1 = await getSubscriberCache(IsolationStrategy.Tenant);
-      const c2 = await getProviderCache(IsolationStrategy.Tenant);
+      const c1 = await getSubscriberCache('tenant');
+      const c2 = await getProviderCache('tenant');
 
       expect(c1!.url).toBe('https://subscriber.example');
       expect(c2).toBeUndefined();
@@ -262,14 +262,14 @@ describe('destination cache', () => {
         destinationName: 'ANY',
         jwt: subscriberUserJwt,
         useCache: true,
-        isolationStrategy: IsolationStrategy.Tenant,
+        isolationStrategy: 'tenant',
         cacheVerificationKeys: false,
         selectionStrategy: alwaysSubscriber,
         iasToXsuaaTokenExchange: false
       });
 
-      const c1 = await getSubscriberCache(IsolationStrategy.Tenant);
-      const c2 = await getProviderCache(IsolationStrategy.Tenant);
+      const c1 = await getSubscriberCache('tenant');
+      const c2 = await getProviderCache('tenant');
 
       expect(c1).toBeUndefined();
       expect(c2).toBeUndefined();
@@ -281,20 +281,14 @@ describe('destination cache', () => {
         destinationName: 'SubscriberDest2',
         jwt: subscriberUserJwt,
         useCache: true,
-        isolationStrategy: IsolationStrategy.Tenant,
+        isolationStrategy: 'tenant',
         cacheVerificationKeys: false,
         selectionStrategy: alwaysSubscriber,
         iasToXsuaaTokenExchange: false
       });
 
-      const c1 = await getSubscriberCache(
-        IsolationStrategy.Tenant,
-        'SubscriberDest'
-      );
-      const c2 = await getSubscriberCache(
-        IsolationStrategy.Tenant,
-        'SubscriberDest2'
-      );
+      const c1 = await getSubscriberCache('tenant', 'SubscriberDest');
+      const c2 = await getSubscriberCache('tenant', 'SubscriberDest2');
 
       expect(c1).toBeUndefined();
       expect(c2!.url).toBe('https://subscriber2.example');
@@ -314,7 +308,7 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         { user_id: 'user', zid: 'tenant' },
         destinationOne,
-        IsolationStrategy.Tenant
+        'tenant'
       );
       await expect(
         getDestination({ destinationName: destName })
@@ -325,7 +319,7 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         decodeJwt(providerServiceToken),
         destinationOne,
-        IsolationStrategy.Tenant
+        'tenant'
       );
       const actual = await getDestination({
         destinationName: destName,
@@ -353,7 +347,7 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         decodeJwt(subscriberUserJwt),
         destinationOne,
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
       const actual = await getDestination({
         destinationName: destName,
@@ -368,11 +362,11 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         decodeJwt(providerServiceToken),
         destinationOne,
-        IsolationStrategy.Tenant
+        'tenant'
       );
       const actual = await getDestination({
         destinationName: destName,
-        isolationStrategy: IsolationStrategy.Tenant,
+        isolationStrategy: 'tenant',
         iasToXsuaaTokenExchange: false
       });
       expect(actual).toEqual(destinationOne);
@@ -382,11 +376,11 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         decodeJwt(subscriberUserJwt),
         destinationOne,
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
       const actual = await getDestination({
         destinationName: destName,
-        isolationStrategy: IsolationStrategy.Tenant_User,
+        isolationStrategy: 'tenant-user',
         jwt: subscriberUserJwt,
         iasToXsuaaTokenExchange: false
       });
@@ -400,7 +394,7 @@ describe('destination cache', () => {
       await expect(
         getDestination({
           destinationName: destName,
-          isolationStrategy: IsolationStrategy.Tenant,
+          isolationStrategy: 'tenant',
           jwt: signedJwt({ user_id: 'onlyUserInJwt' }),
           iasToXsuaaTokenExchange: false
         })
@@ -417,7 +411,7 @@ describe('destination cache', () => {
       await expect(
         getDestination({
           destinationName: destName,
-          isolationStrategy: IsolationStrategy.Tenant_User,
+          isolationStrategy: 'tenant-user',
           jwt: subscriberServiceToken,
           iasToXsuaaTokenExchange: false
         })
@@ -484,7 +478,7 @@ describe('destination cache', () => {
           zid: 'provider'
         }),
         destinationFromCache?.name,
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
       httpMocks.forEach(mock => expect(mock.isDone()).toBe(true));
     });
@@ -545,7 +539,7 @@ describe('destination cache', () => {
           zid: 'provider'
         }),
         expected.name,
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
       httpMocks.forEach(mock => expect(mock.isDone()).toBe(true));
     });
@@ -611,7 +605,7 @@ describe('destination cache', () => {
           zid: 'provider'
         }),
         expected.name,
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
     });
 
@@ -631,14 +625,14 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         decodeJwt(subscriberUserJwt),
         parsedDestination,
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
 
       const actual = await getDestination({
         destinationName: 'SubscriberDest',
         jwt: subscriberUserJwt,
         useCache: true,
-        isolationStrategy: IsolationStrategy.Tenant_User,
+        isolationStrategy: 'tenant-user',
         cacheVerificationKeys: false,
         iasToXsuaaTokenExchange: false
       });
@@ -662,14 +656,14 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         decodeJwt(providerServiceToken),
         parsedDestination,
-        IsolationStrategy.Tenant
+        'tenant'
       );
 
       const actual = await getDestination({
         destinationName: 'ProviderDest',
         jwt: providerUserJwt,
         useCache: true,
-        isolationStrategy: IsolationStrategy.Tenant,
+        isolationStrategy: 'tenant',
         selectionStrategy: alwaysProvider,
         cacheVerificationKeys: false,
         iasToXsuaaTokenExchange: false
@@ -694,7 +688,7 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         decodeJwt(providerUserJwt),
         parsedDestination,
-        IsolationStrategy.Tenant
+        'tenant'
       );
 
       const httpMocks = [
@@ -706,7 +700,7 @@ describe('destination cache', () => {
         destinationName: 'ProviderDest',
         jwt: subscriberUserJwt,
         useCache: true,
-        isolationStrategy: IsolationStrategy.Tenant,
+        isolationStrategy: 'tenant',
         selectionStrategy: subscriberFirst,
         cacheVerificationKeys: false,
         iasToXsuaaTokenExchange: false
@@ -723,18 +717,18 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         dummyJwt,
         destinationOne,
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
 
       const actual1 = await destinationCache.retrieveDestinationFromCache(
         dummyJwt,
         'destToCache1',
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
       const actual2 = await destinationCache.retrieveDestinationFromCache(
         dummyJwt,
         'destToCache1',
-        IsolationStrategy.Tenant
+        'tenant'
       );
 
       const expected = [destinationOne, undefined];
@@ -747,18 +741,18 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         dummyJwt,
         destinationOne,
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
 
       const actual1 = await destinationCache.retrieveDestinationFromCache(
         dummyJwt,
         'destToCache1',
-        IsolationStrategy.Tenant
+        'tenant'
       );
       const actual2 = await destinationCache.retrieveDestinationFromCache(
         dummyJwt,
         'destToCache1',
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
 
       const expected = [undefined, undefined];
@@ -771,17 +765,17 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         dummyJwt,
         destinationOne,
-        IsolationStrategy.Tenant
+        'tenant'
       );
       const actual1 = await destinationCache.retrieveDestinationFromCache(
         dummyJwt,
         'destToCache1',
-        IsolationStrategy.Tenant
+        'tenant'
       );
       const actual2 = await destinationCache.retrieveDestinationFromCache(
         dummyJwt,
         'destToCache1',
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
 
       const expected = [undefined, undefined];
@@ -795,13 +789,13 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         dummyJwt,
         destinationOne,
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
       const minutesToExpire = 6;
       const actualBefore = await destinationCache.retrieveDestinationFromCache(
         dummyJwt,
         'destToCache1',
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
       expect(actualBefore).toBeDefined();
 
@@ -810,7 +804,7 @@ describe('destination cache', () => {
       const actualAfter = await destinationCache.retrieveDestinationFromCache(
         dummyJwt,
         'destToCache1',
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
 
       expect(actualAfter).toBeUndefined();
@@ -831,13 +825,13 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         dummyJwt,
         destination,
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
       const retrieveDestination = () =>
         destinationCache.retrieveDestinationFromCache(
           dummyJwt,
           destination.name!,
-          IsolationStrategy.Tenant_User
+          'tenant-user'
         );
 
       await expect(retrieveDestination()).resolves.toEqual(destination);
@@ -862,7 +856,7 @@ describe('destination cache', () => {
       await destinationCache.cacheRetrievedDestination(
         { user_id: 'user', zid: 'tenant' },
         destinationOne,
-        IsolationStrategy.Tenant_User
+        'tenant-user'
       );
 
       expect(setSpy).toHaveBeenCalled();
@@ -871,7 +865,7 @@ describe('destination cache', () => {
         destinationCache.retrieveDestinationFromCache(
           { user_id: 'user', zid: 'tenant' },
           'destToCache1',
-          IsolationStrategy.Tenant_User
+          'tenant-user'
         );
 
       await expect(retrieveDestination()).resolves.toEqual(destinationOne);

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.ts
@@ -12,8 +12,8 @@ const logger = createLogger({
 });
 
 /**
- * Enumerator that selects the isolation type of destination in cache.
- * The used isolation strategy is either `Tenant` or `Tenant_User` because we want to get results for subaccount and provider tenants which rules out no-isolation or user isolation.
+ * Represents the isolation strategy in the destination cache.
+ * The available strategies are isolation by tenant or isolation by tenant and user.
  */
 export type IsolationStrategy = 'tenant' | 'tenant-user';
 
@@ -193,7 +193,7 @@ function getTenantCacheKey(
     return `${tenant}::${destinationName}`;
   }
   logger.warn(
-    "Could not build destination cache key. Isolation strategy 'tenant' is used, but tenant id is undefined."
+    "Could not build destination cache key. Isolation strategy 'tenant' is used, but tenant id is undefined in JWT."
   );
 }
 
@@ -206,7 +206,7 @@ function getTenantUserCacheKey(
     return `${user}:${tenant}:${destinationName}`;
   }
   logger.warn(
-    "Could not build destination cache key. Isolation strategy 'user-tenant' is used, but tenant id or user id is undefined in JWT."
+    "Could not build destination cache key. Isolation strategy 'tenant-user' is used, but tenant id or user id is undefined in JWT."
   );
 }
 

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.ts
@@ -157,8 +157,8 @@ export const DestinationCache = (
 
 /**
  * Calculates a cache key based on the jwt and destination name for the given isolation strategy.
- * Cache keys for strategies are non-overlapping, i.e. using a cache key for strategy {@link IsolationStrategy.Tenant}
- * will not result in a cache hit for a destination that has been cached with strategy {@link IsolationStrategy.Tenant_User}.
+ * Cache keys for strategies are non-overlapping, i.e. using a cache key for strategy {@link 'tenant'}
+ * will not result in a cache hit for a destination that has been cached with strategy {@link 'tenant-user'}.
  * @param decodedJwt - The decoded JWT of the current request.
  * @param destinationName - The name of the destination.
  * @param isolationStrategy - The strategy used to isolate cache entries.

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
@@ -10,7 +10,6 @@ import {
   xsuaaBindingMock
 } from '../../../../../test-resources/test/test-util';
 import { getDestination } from './destination-accessor';
-import { IsolationStrategy } from './destination-cache';
 import {
   DestinationWithName,
   registerDestination,
@@ -95,7 +94,7 @@ describe('register-destination', () => {
   it('cache if tenant if you want', async () => {
     await registerDestination(testDestination, {
       jwt: subscriberUserJwt,
-      isolationStrategy: IsolationStrategy.Tenant
+      isolationStrategy: 'tenant'
     });
     await expect(
       registerDestinationCache
@@ -141,7 +140,7 @@ describe('register-destination', () => {
     const actual = await getDestination({
       destinationName: 'FORWARD-TOKEN-DESTINATION',
       jwt: fullToken,
-      isolationStrategy: IsolationStrategy.Tenant
+      isolationStrategy: 'tenant'
     });
     expect(actual?.authTokens![0].expiresIn).toEqual('1234');
     expect(actual?.authTokens![0].value).toEqual(fullToken);

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
@@ -10,7 +10,7 @@ import {
 } from './http-proxy-util';
 import { Destination } from './destination-service-types';
 import type { DestinationFetchOptions } from './destination-accessor-types';
-import { destinationCache, IsolationStrategy } from './destination-cache';
+import { destinationCache } from './destination-cache';
 import { decodedJwtOrZid } from './destination-from-registration';
 import { serviceToDestinationTransformers } from './service-binding-to-destination';
 
@@ -50,7 +50,7 @@ export async function destinationForServiceBinding(
     const fromCache = await destinationCache.retrieveDestinationFromCache(
       options.jwt || decodedJwtOrZid().subaccountid,
       serviceInstanceName,
-      IsolationStrategy.Tenant
+      'tenant'
     );
     if (fromCache) {
       return fromCache;
@@ -74,7 +74,7 @@ export async function destinationForServiceBinding(
     await destinationCache.cacheRetrievedDestination(
       options.jwt || decodedJwtOrZid().subaccountid,
       destWithProxy,
-      IsolationStrategy.Tenant
+      'tenant'
     );
   }
 

--- a/packages/connectivity/src/scp-cf/destination/destination-service-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-cache.ts
@@ -1,16 +1,14 @@
 import { JwtPayload } from '../jsonwebtoken-type';
 import { Cache } from '../cache';
 import { Destination } from './destination-service-types';
-import { getDestinationCacheKey, IsolationStrategy } from './destination-cache';
+import { getDestinationCacheKey } from './destination-cache';
 
 const DestinationServiceCache = (cache: Cache<Destination[]>) => ({
   retrieveDestinationsFromCache: (
     targetUrl: string,
     decodedJwt: JwtPayload
   ): Destination[] | undefined =>
-    cache.get(
-      getDestinationCacheKey(decodedJwt, targetUrl, IsolationStrategy.Tenant)
-    ),
+    cache.get(getDestinationCacheKey(decodedJwt, targetUrl, 'tenant')),
   cacheRetrievedDestinations: (
     destinationServiceUri: string,
     decodedJwt: JwtPayload,
@@ -19,7 +17,7 @@ const DestinationServiceCache = (cache: Cache<Destination[]>) => ({
     const key = getDestinationCacheKey(
       decodedJwt,
       destinationServiceUri,
-      IsolationStrategy.Tenant
+      'tenant'
     );
     cache.set(key, { entry: destinations });
   },

--- a/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
@@ -227,7 +227,7 @@ export interface DestinationCertificate {
 export type DestinationRetrievalOptions = CachingOptions & {
   /**
    * The isolation strategy used for caching destinations. For the available options, see {@link IsolationStrategy}.
-   * By default, IsolationStrategy.Tenant_User is set.
+   * By default, 'tenant-user' is set.
    */
   isolationStrategy?: IsolationStrategy;
   /**

--- a/test-packages/integration-tests/test/cache.spec.ts
+++ b/test-packages/integration-tests/test/cache.spec.ts
@@ -1,10 +1,6 @@
 import jwt from 'jsonwebtoken';
 import nock from 'nock';
-import {
-  Destination,
-  getDestination,
-  IsolationStrategy
-} from '@sap-cloud-sdk/connectivity';
+import { Destination, getDestination } from '@sap-cloud-sdk/connectivity';
 import {
   destinationCache,
   destinationServiceCache,
@@ -120,14 +116,14 @@ describe('CacheDestination & CacheClientCredentialToken', () => {
     const destinationRequestTenantUser = await getDestination({
       destinationName: 'FINAL-DESTINATION',
       useCache: true,
-      isolationStrategy: IsolationStrategy.Tenant_User
+      isolationStrategy: 'tenant-user'
     });
     expect(destinationRequestTenantUser).not.toBeNull();
 
     const destinationRequestTenant = await getDestination({
       destinationName: 'FINAL-DESTINATION',
       useCache: true,
-      isolationStrategy: IsolationStrategy.Tenant
+      isolationStrategy: 'tenant'
     });
     expect(destinationRequestTenant).not.toBeNull();
   });
@@ -147,7 +143,7 @@ describe('CacheDestination & CacheClientCredentialToken', () => {
       destinationName: 'FINAL-DESTINATION-AUTH-FLOW',
       useCache: true,
       jwt: providerUserToken,
-      isolationStrategy: IsolationStrategy.Tenant_User
+      isolationStrategy: 'tenant-user'
     });
     expect(cache).not.toBeNull();
     expect(cache).toEqual(directCall);
@@ -157,7 +153,7 @@ describe('CacheDestination & CacheClientCredentialToken', () => {
         destinationName: 'FINAL-DESTINATION-AUTH-FLOW',
         useCache: true,
         jwt: providerUserToken,
-        isolationStrategy: IsolationStrategy.Tenant_User
+        isolationStrategy: 'tenant-user'
       })
     ).rejects.toThrowError(/Nock: No match for request/);
   }, 600000);
@@ -167,7 +163,7 @@ describe('CacheDestination & CacheClientCredentialToken', () => {
     await getDestination({
       destinationName: 'FINAL-DESTINATION',
       useCache: true,
-      isolationStrategy: IsolationStrategy.Tenant
+      isolationStrategy: 'tenant'
     });
   }
 
@@ -193,7 +189,7 @@ describe('CacheDestination & CacheClientCredentialToken', () => {
       destinationName: 'FINAL-DESTINATION-AUTH-FLOW',
       useCache: true,
       jwt: providerUserToken,
-      isolationStrategy: IsolationStrategy.Tenant_User
+      isolationStrategy: 'tenant-user'
     });
   }
 });


### PR DESCRIPTION
Replacing enum with strings.

Relates to SAP/cloud-sdk-backlog#1014.

- [ ] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
- [x] If my change will be merged into the `main` branch (for v3), I've updated (V3-Upgrade-Guide.md)[./V3-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v3

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
