### PR TITLE
fix: Update Request Builder filters out updates to null

### DIFF
--- a/.changeset/odata-v2-update-string-null.md
+++ b/.changeset/odata-v2-update-string-null.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/odata-v2': patch
+---
+
+[Fixed Issue] Allow to update OData v2 entities to null. Fixes [3204](https://github.com/SAP/cloud-sdk-js/issues/3204).

--- a/.changeset/odata-v2-update-string-null.md
+++ b/.changeset/odata-v2-update-string-null.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/odata-v2': patch
 ---
 
-[Fixed Issue] Allow to update OData v2 entities to null. Fixes [3204](https://github.com/SAP/cloud-sdk-js/issues/3204).
+[Fixed Issue] Allow to update OData v2 entities to `null`. Fixes [3204](https://github.com/SAP/cloud-sdk-js/issues/3204).

--- a/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
@@ -63,7 +63,8 @@ describe('UpdateRequestBuilder', () => {
     entity.booleanProperty = false;
     const requestBody = {
       Int32Property: entity.int32Property,
-      BooleanProperty: false
+      BooleanProperty: false,
+      StringProperty: null
     };
 
     mockUpdateRequest(
@@ -91,7 +92,9 @@ describe('UpdateRequestBuilder', () => {
 
     const requestBody = {
       Int32Property: entity.int32Property,
-      SomeCustomField: customFieldVal
+      SomeCustomField: customFieldVal,
+      StringProperty: null,
+      BooleanProperty: null
     };
 
     mockUpdateRequest(
@@ -233,22 +236,25 @@ describe('UpdateRequestBuilder', () => {
     expect(actual).toEqual(entity);
   });
 
-  it('update request excludes ignored properties', async () => {
-    const entity = createTestEntity();
+  // fixme: unclear how to handle this test case
+  // it('update request excludes ignored properties', async () => {
+  //   const entity = createTestEntity();
 
-    const scope = nock(/.*/).patch(/.*/).reply(500);
+  //   const scope = nock(/.*/).patch(/.*/).reply(500);
 
-    const actual = await new UpdateRequestBuilder(testEntityApi, entity)
-      .setIgnoredFields(testEntityApi.schema.INT_32_PROPERTY)
-      .execute(defaultDestination);
+  //   const actual = await new UpdateRequestBuilder(testEntityApi, entity)
+  //     .setIgnoredFields(testEntityApi.schema.INT_32_PROPERTY)
+  //     .execute(defaultDestination);
 
-    expect(scope.isDone()).toBe(false);
-    expect(actual).toEqual(entity);
-  });
+  //   expect(scope.isDone()).toBe(false);
+  //   expect(actual).toEqual(entity);
+  // });
 
   it('update request should contain version identifier when set on entity', async () => {
     const entity = createTestEntity().setVersionIdentifier('not-a-star');
-    const requestBody = { Int32Property: entity.int32Property };
+    const requestBody = { Int32Property: entity.int32Property,
+      StringProperty: null,
+      BooleanProperty: null };
 
     mockUpdateRequest(
       {
@@ -271,7 +277,9 @@ describe('UpdateRequestBuilder', () => {
 
   it('update request should contain version identifier when set on request', async () => {
     const entity = createTestEntity().setVersionIdentifier('not-a-star');
-    const requestBody = { Int32Property: entity.int32Property };
+    const requestBody = { Int32Property: entity.int32Property,
+      StringProperty: null,
+      BooleanProperty: null };
     const customVersionIdentifier = 'custom-version-identifier';
 
     mockUpdateRequest(
@@ -296,7 +304,9 @@ describe('UpdateRequestBuilder', () => {
 
   it('should ignore version identifier', async () => {
     const entity = createTestEntity().setVersionIdentifier('not-a-star');
-    const requestBody = { Int32Property: entity.int32Property };
+    const requestBody = { Int32Property: entity.int32Property,
+      StringProperty: null,
+      BooleanProperty: null };
 
     mockUpdateRequest(
       {
@@ -344,7 +354,9 @@ describe('UpdateRequestBuilder', () => {
     const eTag = 'someEtag';
 
     const entity = createTestEntity().setVersionIdentifier('not-a-star');
-    const requestBody = { Int32Property: entity.int32Property };
+    const requestBody = { Int32Property: entity.int32Property,
+      StringProperty: null,
+      BooleanProperty: null };
 
     mockUpdateRequest(
       {
@@ -415,7 +427,8 @@ describe('UpdateRequestBuilder', () => {
       entity.booleanProperty = false;
       const requestBody = {
         Int32Property: entity.int32Property,
-        BooleanProperty: false
+        BooleanProperty: false,
+        StringProperty: null
       };
       const response = { d: requestBody };
 

--- a/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
@@ -141,16 +141,23 @@ describe('UpdateRequestBuilder', () => {
   });
 
   it('update request is executed when nullable string is set to null', async () => {
-    const entity = createTestEntity();
+    // Given: Entity with only key properties and one nullable string property which has non-null value
+    const keyPropGuid = uuid();
+    const keyPropString = 'stringId';
+    const stringProp = 'some value';
 
-    const requestBody = {
-      Int32Property: 125,
-      StringProperty: null
-    };
+    const entity = testEntityApi
+      .entityBuilder()
+      .keyPropertyGuid(keyPropGuid)
+      .keyPropertyString(keyPropString)
+      .stringProperty(stringProp)
+      .build();
 
     const scope = mockUpdateRequest(
       {
-        body: requestBody,
+        body: {
+          StringProperty: null
+        },
         path: testEntityResourcePath(
           entity.keyPropertyGuid,
           entity.keyPropertyString
@@ -159,13 +166,17 @@ describe('UpdateRequestBuilder', () => {
       testEntityApi
     );
 
+    // When: We update the nullable string property value to null
     entity.stringProperty = null;
 
     const actual = await new UpdateRequestBuilder(
       testEntityApi,
       entity
     ).execute(defaultDestination);
+
+    // Then: We expect the update to happen (http request is sent) and the value of the property to be null
     expect(actual).toEqual(entity.setOrInitializeRemoteState());
+    expect(actual.stringProperty).toBeNull();
     expect(scope.isDone()).toBe(true);
   });
 

--- a/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
@@ -236,25 +236,33 @@ describe('UpdateRequestBuilder', () => {
     expect(actual).toEqual(entity);
   });
 
-  // fixme: unclear how to handle this test case
-  // it('update request excludes ignored properties', async () => {
-  //   const entity = createTestEntity();
+  it('update request excludes ignored properties', async () => {
+    const keyPropGuid = uuid();
+    const keyPropString = 'stringId';
 
-  //   const scope = nock(/.*/).patch(/.*/).reply(500);
+    const entity = testEntityApi
+      .entityBuilder()
+      .keyPropertyGuid(keyPropGuid)
+      .keyPropertyString(keyPropString)
+      .build();
 
-  //   const actual = await new UpdateRequestBuilder(testEntityApi, entity)
-  //     .setIgnoredFields(testEntityApi.schema.INT_32_PROPERTY)
-  //     .execute(defaultDestination);
+    const scope = nock(/.*/).patch(/.*/).reply(500);
 
-  //   expect(scope.isDone()).toBe(false);
-  //   expect(actual).toEqual(entity);
-  // });
+    const actual = await new UpdateRequestBuilder(testEntityApi, entity)
+      .setIgnoredFields(testEntityApi.schema.INT_32_PROPERTY)
+      .execute(defaultDestination);
+
+    expect(scope.isDone()).toBe(false);
+    expect(actual).toEqual(entity);
+  });
 
   it('update request should contain version identifier when set on entity', async () => {
     const entity = createTestEntity().setVersionIdentifier('not-a-star');
-    const requestBody = { Int32Property: entity.int32Property,
+    const requestBody = {
+      Int32Property: entity.int32Property,
       StringProperty: null,
-      BooleanProperty: null };
+      BooleanProperty: null
+    };
 
     mockUpdateRequest(
       {
@@ -277,9 +285,11 @@ describe('UpdateRequestBuilder', () => {
 
   it('update request should contain version identifier when set on request', async () => {
     const entity = createTestEntity().setVersionIdentifier('not-a-star');
-    const requestBody = { Int32Property: entity.int32Property,
+    const requestBody = {
+      Int32Property: entity.int32Property,
       StringProperty: null,
-      BooleanProperty: null };
+      BooleanProperty: null
+    };
     const customVersionIdentifier = 'custom-version-identifier';
 
     mockUpdateRequest(
@@ -304,9 +314,11 @@ describe('UpdateRequestBuilder', () => {
 
   it('should ignore version identifier', async () => {
     const entity = createTestEntity().setVersionIdentifier('not-a-star');
-    const requestBody = { Int32Property: entity.int32Property,
+    const requestBody = {
+      Int32Property: entity.int32Property,
       StringProperty: null,
-      BooleanProperty: null };
+      BooleanProperty: null
+    };
 
     mockUpdateRequest(
       {
@@ -354,9 +366,11 @@ describe('UpdateRequestBuilder', () => {
     const eTag = 'someEtag';
 
     const entity = createTestEntity().setVersionIdentifier('not-a-star');
-    const requestBody = { Int32Property: entity.int32Property,
+    const requestBody = {
+      Int32Property: entity.int32Property,
       StringProperty: null,
-      BooleanProperty: null };
+      BooleanProperty: null
+    };
 
     mockUpdateRequest(
       {

--- a/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
@@ -29,6 +29,19 @@ function createTestEntity() {
     .build();
 }
 
+function createTestEntityWithStringProperty() {
+  const keyPropGuid = uuid();
+  const keyPropString = 'stringId';
+  const stringProp = 'some value';
+
+  return testEntityApi
+    .entityBuilder()
+    .keyPropertyGuid(keyPropGuid)
+    .keyPropertyString(keyPropString)
+    .stringProperty(stringProp)
+    .build();
+}
+
 describe('UpdateRequestBuilder', () => {
   afterEach(() => {
     nock.cleanAll();
@@ -145,16 +158,7 @@ describe('UpdateRequestBuilder', () => {
 
   it('executes the update when nullable string is set to null', async () => {
     // Given: Entity with only key properties and one nullable string property which has non-null value
-    const keyPropGuid = uuid();
-    const keyPropString = 'stringId';
-    const stringProp = 'some value';
-
-    const entity = testEntityApi
-      .entityBuilder()
-      .keyPropertyGuid(keyPropGuid)
-      .keyPropertyString(keyPropString)
-      .stringProperty(stringProp)
-      .build();
+    const entity = createTestEntityWithStringProperty();
 
     const scope = mockUpdateRequest(
       {
@@ -185,16 +189,7 @@ describe('UpdateRequestBuilder', () => {
 
   it('executes the update when nullable string is set to undefined', async () => {
     // Given: Entity with only key properties and one nullable string property which has non-null value
-    const keyPropGuid = uuid();
-    const keyPropString = 'stringId';
-    const stringProp = 'some value';
-
-    const entity = testEntityApi
-      .entityBuilder()
-      .keyPropertyGuid(keyPropGuid)
-      .keyPropertyString(keyPropString)
-      .stringProperty(stringProp)
-      .build();
+    const entity = createTestEntityWithStringProperty();
 
     const scope = mockUpdateRequest(
       {

--- a/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
@@ -1,6 +1,6 @@
+import { createLogger } from '@sap-cloud-sdk/util';
 import nock from 'nock';
 import { v4 as uuid } from 'uuid';
-import { createLogger } from '@sap-cloud-sdk/util';
 import {
   defaultDestination,
   mockUpdateRequest
@@ -138,6 +138,35 @@ describe('UpdateRequestBuilder', () => {
       entity
     ).execute(defaultDestination);
     expect(actual).toEqual(entity.setOrInitializeRemoteState());
+  });
+
+  it('update request is executed when nullable string is set to null', async () => {
+    const entity = createTestEntity();
+
+    const requestBody = {
+      Int32Property: 125,
+      StringProperty: null
+    };
+
+    const scope = mockUpdateRequest(
+      {
+        body: requestBody,
+        path: testEntityResourcePath(
+          entity.keyPropertyGuid,
+          entity.keyPropertyString
+        )
+      },
+      testEntityApi
+    );
+
+    entity.stringProperty = null;
+
+    const actual = await new UpdateRequestBuilder(
+      testEntityApi,
+      entity
+    ).execute(defaultDestination);
+    expect(actual).toEqual(entity.setOrInitializeRemoteState());
+    expect(scope.isDone()).toBe(true);
   });
 
   it('update request sends the whole entity when using PUT', async () => {

--- a/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
@@ -143,7 +143,7 @@ describe('UpdateRequestBuilder', () => {
     expect(actual).toEqual(entity.setOrInitializeRemoteState());
   });
 
-  it('update request is executed when nullable string is set to null', async () => {
+  it('executes the update when nullable string is set to null', async () => {
     // Given: Entity with only key properties and one nullable string property which has non-null value
     const keyPropGuid = uuid();
     const keyPropString = 'stringId';
@@ -180,6 +180,46 @@ describe('UpdateRequestBuilder', () => {
     // Then: We expect the update to happen (http request is sent) and the value of the property to be null
     expect(actual).toEqual(entity.setOrInitializeRemoteState());
     expect(actual.stringProperty).toBeNull();
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('executes the update when nullable string is set to undefined', async () => {
+    // Given: Entity with only key properties and one nullable string property which has non-null value
+    const keyPropGuid = uuid();
+    const keyPropString = 'stringId';
+    const stringProp = 'some value';
+
+    const entity = testEntityApi
+      .entityBuilder()
+      .keyPropertyGuid(keyPropGuid)
+      .keyPropertyString(keyPropString)
+      .stringProperty(stringProp)
+      .build();
+
+    const scope = mockUpdateRequest(
+      {
+        body: {
+          StringProperty: null
+        },
+        path: testEntityResourcePath(
+          entity.keyPropertyGuid,
+          entity.keyPropertyString
+        )
+      },
+      testEntityApi
+    );
+
+    // When: We update the nullable string property value to undefined
+    entity.stringProperty = undefined;
+
+    const actual = await new UpdateRequestBuilder(
+      testEntityApi,
+      entity
+    ).execute(defaultDestination);
+
+    // Then: We expect the update to happen (http request is sent) and the value of the property to be null
+    expect(actual).toEqual(entity.setOrInitializeRemoteState());
+    expect(actual.stringProperty).toBeUndefined();
     expect(scope.isDone()).toBe(true);
   });
 

--- a/packages/odata-v2/src/request-builder/update-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/update-request-builder.ts
@@ -117,6 +117,8 @@ function removeNavPropsAndComplexTypes(
   body: Record<string, any>
 ): Record<string, any> {
   return removePropertyOnCondition(
+    // Special handling for null values because 'typeof null' is 'object', but we don't want to filter null values here.
+    // See this issue for more info: https://github.com/SAP/cloud-sdk-js/issues/3204
     ([, val]) => val !== null && typeof val === 'object',
     body
   );

--- a/packages/odata-v2/src/request-builder/update-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/update-request-builder.ts
@@ -116,5 +116,8 @@ function warnIfNavigation<
 function removeNavPropsAndComplexTypes(
   body: Record<string, any>
 ): Record<string, any> {
-  return removePropertyOnCondition(([, val]) => typeof val === 'object', body);
+  return removePropertyOnCondition(
+    ([, val]) => val !== null && typeof val === 'object',
+    body
+  );
 }


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Relates to https://github.com/SAP/cloud-sdk-backlog/issues/1003.

- [x] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
- [x] If my change will be merged into the `main` branch (for v3), I've updated (V3-Upgrade-Guide.md)[./V3-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v3

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
