### PR TITLE
chore: Add Deprecation for Openapi Generator Options

### DIFF
--- a/packages/openapi-generator/src/options/generator-options.ts
+++ b/packages/openapi-generator/src/options/generator-options.ts
@@ -67,6 +67,7 @@ export interface GeneratorOptions {
    */
   packageJson?: boolean;
   /**
+   * @deprecated Since v2.13.0. Use the `include` option to add a custom package.json
    * License name to be used on the generated `package.json`. Only considered if 'packageJson' is enabled.
    */
   licenseInPackageJson?: string;
@@ -83,6 +84,7 @@ export interface GeneratorOptions {
   optionsPerService?: string;
   // TODO remove packageVersion in version 3.0
   /**
+   * @deprecated Since v2.13.0. Use the `include` option to add a custom package.json
    * Internal option used to adjust the version in the generated package.json. Will not be used in the future.
    */
   packageVersion?: string;

--- a/packages/openapi-generator/src/options/generator-options.ts
+++ b/packages/openapi-generator/src/options/generator-options.ts
@@ -67,7 +67,7 @@ export interface GeneratorOptions {
    */
   packageJson?: boolean;
   /**
-   * @deprecated Since v2.13.0. Use the `include` option to add a custom package.json
+   * @deprecated Since v2.13.0. Use the `include` option to add a custom package.json.
    * License name to be used on the generated `package.json`. Only considered if 'packageJson' is enabled.
    */
   licenseInPackageJson?: string;
@@ -84,7 +84,7 @@ export interface GeneratorOptions {
   optionsPerService?: string;
   // TODO remove packageVersion in version 3.0
   /**
-   * @deprecated Since v2.13.0. Use the `include` option to add a custom package.json
+   * @deprecated Since v2.13.0. Use the `include` option to add a custom package.json.
    * Internal option used to adjust the version in the generated package.json. Will not be used in the future.
    */
   packageVersion?: string;

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -106,7 +106,7 @@ export const generatorOptions = {
       "License to be used on the generated package.json. Only considered if 'packageJson' is enabled.",
     coerce: (input?: string): string | undefined =>
       typeof input !== 'undefined' ? input : undefined,
-    deprecated: 'Since v2.13.0. Use the `include` option to add a custom package.json'
+    deprecated: 'Since v2.13.0. Use the `include` option to add a custom package.json.'
   },
   verbose: {
     boolean: true,
@@ -133,7 +133,7 @@ export const generatorOptions = {
     description: 'Set the version in the generated package.json.',
     default: '1.0.0',
     hidden: true,
-    deprecated: 'Since v2.13.0. Use the `include` option to add a custom package.json'
+    deprecated: 'Since v2.13.0. Use the `include` option to add a custom package.json.'
   },
   readme: {
     boolean: true,

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -105,7 +105,8 @@ export const generatorOptions = {
     description:
       "License to be used on the generated package.json. Only considered if 'packageJson' is enabled.",
     coerce: (input?: string): string | undefined =>
-      typeof input !== 'undefined' ? input : undefined
+      typeof input !== 'undefined' ? input : undefined,
+    deprecated: 'Since v2.13.0. Use the `include` option to add a custom package.json'
   },
   verbose: {
     boolean: true,
@@ -131,7 +132,8 @@ export const generatorOptions = {
     string: true,
     description: 'Set the version in the generated package.json.',
     default: '1.0.0',
-    hidden: true
+    hidden: true,
+    deprecated: 'Since v2.13.0. Use the `include` option to add a custom package.json'
   },
   readme: {
     boolean: true,

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -106,7 +106,8 @@ export const generatorOptions = {
       "License to be used on the generated package.json. Only considered if 'packageJson' is enabled.",
     coerce: (input?: string): string | undefined =>
       typeof input !== 'undefined' ? input : undefined,
-    deprecated: 'Since v2.13.0. Use the `include` option to add a custom package.json.'
+    deprecated:
+      'Since v2.13.0. Use the `include` option to add a custom package.json.'
   },
   verbose: {
     boolean: true,
@@ -133,7 +134,8 @@ export const generatorOptions = {
     description: 'Set the version in the generated package.json.',
     default: '1.0.0',
     hidden: true,
-    deprecated: 'Since v2.13.0. Use the `include` option to add a custom package.json.'
+    deprecated:
+      'Since v2.13.0. Use the `include` option to add a custom package.json.'
   },
   readme: {
     boolean: true,


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Relates SAP/cloud-sdk-backlog#978.

Adds the deprecation also to the OpenApi options - they were partially hidden but it is always nicer to do that.