### PR TITLE
chore: Configure lint to not allow enums

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,13 @@ module.exports = {
     }
   ],
   rules: {
-    radix: 'off'
+    radix: 'off',
+    'no-restricted-syntax': [
+      'error',
+      {
+        'selector': 'TSEnumDeclaration',
+        'message': 'Enums are weird in TypeScript. Prefer union types or const objects instead.'
+      },
+    ]
   }
 };


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

We got rid of enums in 0bc120593d66f6dc198d27f58e0ceb4547625cfa because we learned that they behave in unexpected ways in TypeScript and don't add much value. This lint rule will make us aware of this in the future in case someone accidentally wants to introduce new enums.

- [x] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
- [x] If my change will be merged into the `main` branch (for v3), I've updated (V3-Upgrade-Guide.md)[./V3-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v3

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
