### PR TITLE
fix: binary link to generator

### DIFF
--- a/.changeset/fair-carrots-grow.md
+++ b/.changeset/fair-carrots-grow.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/generator': patch
 ---
 
-Fixes the link to the generator binary.
+[Fixed Issue] Now links to the correct generator binary.

--- a/.changeset/fair-carrots-grow.md
+++ b/.changeset/fair-carrots-grow.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/generator': patch
+---
+
+Fixes the link to the generator binary.

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -13,7 +13,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "generate-odata-client": "./dist/generator-cli.js"
+    "generate-odata-client": "./dist/cli.js"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR fixes the link to our generator binary, which was renamed and therefore the link needed to be changed as well.

- [x] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
- [x] If my change will be merged into the `main` branch (for v3), I've updated (V3-Upgrade-Guide.md)[./V3-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v3

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
