### PR TITLE
chore: Add manual workflow trigger

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -7,6 +7,7 @@ on:
       - 'v*-main'
     paths:
       - 'knowledge-base/api-reference/**'
+  workflow_dispatch:
 
 jobs:
   push-to-documentation-branch:


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

This adds the workflow_dispatch property to this workflow on v2-main and enables that it can be manually triggered from the Actions tab.

- [x] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
