### PR TITLE
chore: Adjust log level of generator

### DIFF
--- a/packages/generator/src/cli.ts
+++ b/packages/generator/src/cli.ts
@@ -9,8 +9,6 @@ const logger = createLogger({
   messageContext: 'cli'
 });
 
-logger.info('Parsing args...');
-
 generate(parseCmdArgs(process.argv.slice(2)))
   .then(() => logger.info('Generation of services finished successfully.'))
   .catch(err => {

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -75,7 +75,7 @@ export async function generate(
     setLogLevel('verbose', logger);
   }
 
-  logger.verbose(`Parsed Options: ${JSON.stringify(options, null, 2)}`);
+  logger.verbose(`Parsed Options: ${JSON.stringify(parsedOptions, null, 2)}`);
 
   return generateWithParsedOptions(parsedOptions);
 }

--- a/packages/generator/src/service-name-formatter.spec.ts
+++ b/packages/generator/src/service-name-formatter.spec.ts
@@ -100,7 +100,7 @@ describe('name-formatter', () => {
         skipValidation: true
       });
       const logger = createLogger('service-name-formatter');
-      const logSpy = jest.spyOn(logger, 'info');
+      const logSpy = jest.spyOn(logger, 'warn');
       formatter.originalToEntityClassName('SomeEntity');
       formatter.originalToEntityClassName('SomeEntity');
       expect(logSpy).toHaveBeenCalledWith(

--- a/packages/generator/src/service-name-formatter.ts
+++ b/packages/generator/src/service-name-formatter.ts
@@ -120,10 +120,9 @@ export class ServiceNameFormatter {
     uniqueName: string;
   }): void {
     if (uniqueName !== transformedName) {
-      const message = `A naming conflict appears for service ${this.serviceName} in container '${originalContainerTypeName}'.
-The conflict resolution is: ${transformedName} -> ${uniqueName}.`;
+      const message = `A naming conflict appears for service ${this.serviceName} in container '${originalContainerTypeName}'. The conflict resolution is: ${transformedName} -> ${uniqueName}.`;
       if (this.skipValidation) {
-        logger.info(message);
+        logger.warn(message);
       } else {
         throw new Error(`${message}
 If you are ok with this change execute the generator with the '--skipValidation' option.`);


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#1071.

Remove the `parsing args` log statement. Keep the `successful` generated line so that at least one line is printed when everything worked out.

Also set one info level to warn to be a bit more consistent with other warning messages.
