### PR TITLE
chore: reexpose openapi generator options

### DIFF
--- a/packages/generator/src/options/options.ts
+++ b/packages/generator/src/options/options.ts
@@ -6,7 +6,7 @@ import {
 } from '@sap-cloud-sdk/generator-common/internal';
 
 /**
- * Options to configure the client generation when using the generator programmatically.
+ * Options to configure OData client generation when using the generator programmatically.
  */
 export interface GeneratorOptions extends CommonGeneratorOptions {
   /**
@@ -18,6 +18,7 @@ export interface GeneratorOptions extends CommonGeneratorOptions {
    */
   transpilationProcesses?: number;
 }
+
 /**
  * @internal
  * Represents the parsed generator options.

--- a/packages/openapi-generator/src/cli-parser.ts
+++ b/packages/openapi-generator/src/cli-parser.ts
@@ -1,15 +1,12 @@
-import {
-  CommonGeneratorOptions,
-  parseCmdArgsBuilder
-} from '@sap-cloud-sdk/generator-common/internal';
-import { cliOptions } from './options';
+import { parseCmdArgsBuilder } from '@sap-cloud-sdk/generator-common/internal';
+import { cliOptions, GeneratorOptions } from './options';
 
 const commandText =
   'OpenAPI Client Code Generator. Generates typed clients from OpenAPI files for usage with the SAP Cloud SDK for JavaScript.';
 /**
  * @internal
  */
-export const parseCmdArgs = parseCmdArgsBuilder<CommonGeneratorOptions>({
+export const parseCmdArgs = parseCmdArgsBuilder<GeneratorOptions>({
   commandText,
   cliOptions
 });

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -18,7 +18,6 @@ import {
   CreateFileOptions,
   readPrettierConfig,
   parseOptions,
-  CommonGeneratorOptions,
   writeOptionsPerService,
   getOptionsPerService,
   getRelPathWithPosixSeparator,
@@ -33,7 +32,12 @@ import { OpenApiDocument } from './openapi-types';
 import { parseOpenApiDocument } from './parser/document';
 import { convertOpenApiSpec } from './document-converter';
 import { sdkMetadata } from './sdk-metadata';
-import { cliOptions, ParsedGeneratorOptions, tsconfigJson } from './options';
+import {
+  cliOptions,
+  GeneratorOptions,
+  ParsedGeneratorOptions,
+  tsconfigJson
+} from './options';
 
 const { mkdir } = promisesFs;
 const logger = createLogger('openapi-generator');
@@ -44,7 +48,7 @@ const logger = createLogger('openapi-generator');
  * @param options - Options to configure generation.
  */
 export async function generate(
-  options: CommonGeneratorOptions & { config?: string }
+  options: GeneratorOptions & { config?: string }
 ): Promise<void> {
   const parsedOptions = parseOptions(cliOptions, options);
   if (parsedOptions.verbose) {

--- a/packages/openapi-generator/src/index.ts
+++ b/packages/openapi-generator/src/index.ts
@@ -5,3 +5,4 @@
  */
 
 export { generate } from './generator';
+export { GeneratorOptions } from './options';

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -7,6 +7,11 @@ import {
 } from '@sap-cloud-sdk/generator-common/internal';
 
 /**
+ * Options to configure OData client generation when using the generator programmatically.
+ */
+export type GeneratorOptions = CommonGeneratorOptions;
+
+/**
  * @internal
  * Represents the parsed generator options.
  */
@@ -17,4 +22,4 @@ export type ParsedGeneratorOptions = ParsedOptions<typeof cliOptions>;
  */
 export const cliOptions = {
   ...getCommonCliOptions('OpenApi')
-} as const satisfies Options<CommonGeneratorOptions>;
+} as const satisfies Options<GeneratorOptions>;

--- a/test-packages/test-services-openapi/generate-openapi-services.ts
+++ b/test-packages/test-services-openapi/generate-openapi-services.ts
@@ -1,10 +1,9 @@
 import { resolve } from 'path';
 import { createLogger } from '@sap-cloud-sdk/util';
-import { generate } from '@sap-cloud-sdk/openapi-generator';
-import { CommonGeneratorOptions } from '@sap-cloud-sdk/generator-common';
+import { generate, GeneratorOptions } from '@sap-cloud-sdk/openapi-generator';
 
 const logger = createLogger('generate-openapi-services');
-const generatorConfigOpenApi: Partial<CommonGeneratorOptions> = {
+const generatorConfigOpenApi: Partial<GeneratorOptions> = {
   clearOutputDir: false,
   transpile: true,
   packageJson: true,

--- a/test-packages/test-services-openapi/package.json
+++ b/test-packages/test-services-openapi/package.json
@@ -21,7 +21,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@sap-cloud-sdk/generator-common": "^2.11.0",
     "@sap-cloud-sdk/openapi-generator": "^2.11.0",
     "@sap-cloud-sdk/util": "^2.11.0"
   }


### PR DESCRIPTION
I noticed that the `GeneratorOptions` type disappeared, probably when merging the OData and OpenAPI options. In this PR we reexpose the Options from the OpenAPI generator.