### PR TITLE
fix: send certs only for MTLS authentication

### DIFF
--- a/.changeset/light-radios-sparkle.md
+++ b/.changeset/light-radios-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Fixed Issue] Stop adding certificates when sending requests to a destination, if the authentication type does not require a certificate.

--- a/.changeset/many-hairs-build.md
+++ b/.changeset/many-hairs-build.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Compatibility Note] When making a request to a destination that has a certificate in its defintion, the certificate is only added, if it is needed for the according authentication type. That way, `ClientCertificateAuthentication` will have a certificate in the request, while `OAuth2SAMLBearerAssertion` does not. Previously, the certificate would be added regardless.

--- a/packages/connectivity/src/http-agent/http-agent.spec.ts
+++ b/packages/connectivity/src/http-agent/http-agent.spec.ts
@@ -154,6 +154,30 @@ describe('createAgent', () => {
     );
   });
 
+  it("does not return an agent for destinations with authentication types that have a certificate but don't use MTLS", () => {
+    const destination: Destination = {
+      url: 'https://destination.example.com',
+      authentication: 'OAuth2SAMLBearerAssertion',
+      keyStoreName: 'cert.p12',
+      keyStorePassword: 'password',
+      certificates: [
+        {
+          name: 'cert.p12',
+          content: 'base64string',
+          type: 'CERTIFICATE'
+        }
+      ]
+    };
+
+    const expectedOptions = {
+      rejectUnauthorized: true
+    };
+
+    expect(getAgentConfig(destination)['httpsAgent']['options']).toMatchObject(
+      expectedOptions
+    );
+  });
+
   it('throws an error if the format is not supported', () => {
     const destination: Destination = {
       url: 'https://destination.example.com',

--- a/packages/connectivity/src/http-agent/http-agent.ts
+++ b/packages/connectivity/src/http-agent/http-agent.ts
@@ -122,6 +122,7 @@ function getKeyStoreOption(destination: Destination): Record<string, any> {
   if (
     destination.keyStoreName &&
     destination.keyStorePassword &&
+    // Only add certificates, when using MTLS (https://github.com/SAP/cloud-sdk-js/issues/3544)
     destination.authentication === 'ClientCertificateAuthentication'
   ) {
     const certificate = selectCertificate(destination);

--- a/packages/connectivity/src/http-agent/http-agent.ts
+++ b/packages/connectivity/src/http-agent/http-agent.ts
@@ -119,7 +119,11 @@ function getTrustStoreOptions(destination: Destination): Record<string, any> {
  * @returns Options, which can be used later by tls.createSecureContext() e.g. pfx and passphrase or an empty object, if the protocol is not 'https:' or no client information are in the definition.
  */
 function getKeyStoreOption(destination: Destination): Record<string, any> {
-  if (destination.keyStoreName && destination.keyStorePassword) {
+  if (
+    destination.keyStoreName &&
+    destination.keyStorePassword &&
+    destination.authentication === 'ClientCertificateAuthentication'
+  ) {
     const certificate = selectCertificate(destination);
 
     logger.debug(`Certificate with name "${certificate.name}" selected.`);


### PR DESCRIPTION
Relates to #3544 

- [x] I know which base branch I chose for this PR, as the default branch is `v2-main` now, which is not for v3 development.
- [x] If my change will be merged into the `main` branch (for v3), I've updated (V3-Upgrade-Guide.md)[./V3-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v3

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
