### PR TITLE
fix: fix circuit breaker export

### DIFF
--- a/.changeset/tricky-suits-appear.md
+++ b/.changeset/tricky-suits-appear.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/resilience': patch
+---
+
+[Compatibility Note] Deprecate erroneously exposed `circuitBreakerHttp()` function in favor of `circuitBreaker()`.

--- a/packages/http-client/src/csrf-token-middleware.spec.ts
+++ b/packages/http-client/src/csrf-token-middleware.spec.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 import axios from 'axios';
-import { circuitBreakerHttp, timeout } from '@sap-cloud-sdk/resilience';
+import { circuitBreaker, timeout } from '@sap-cloud-sdk/resilience';
 import { circuitBreakers } from '@sap-cloud-sdk/resilience/internal';
 import { csrf } from './csrf-token-middleware';
 import { executeHttpRequest } from './http-client';
@@ -206,7 +206,7 @@ describe('CSRF middleware', () => {
       {
         method: 'POST',
         url: 'some/path',
-        middleware: [csrf({ middleware: [circuitBreakerHttp()] })]
+        middleware: [csrf({ middleware: [circuitBreaker()] })]
       },
       { fetchCsrfToken: false }
     );

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -9,7 +9,7 @@ import { timeout } from '@sap-cloud-sdk/resilience';
 import * as jwt123 from 'jsonwebtoken';
 import {
   circuitBreakers,
-  circuitBreakerHttp
+  circuitBreaker
 } from '@sap-cloud-sdk/resilience/internal';
 import { responseWithPublicKey } from '../../connectivity/src/scp-cf/jwt.spec';
 import {
@@ -435,7 +435,7 @@ describe('generic http client', () => {
             {
               method: 'post',
               url: 'test-cb',
-              middleware: [circuitBreakerHttp()]
+              middleware: [circuitBreaker()]
             },
             {
               fetchCsrfToken: false
@@ -491,7 +491,7 @@ describe('generic http client', () => {
           {
             url: 'test-fail',
             method: 'get',
-            middleware: [changeUrlMiddleware, circuitBreakerHttp()]
+            middleware: [changeUrlMiddleware, circuitBreaker()]
           }
         )
       ).resolves.not.toThrow();

--- a/packages/resilience/src/circuit-breaker.spec.ts
+++ b/packages/resilience/src/circuit-breaker.spec.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/named
 import axios, { AxiosResponse, RawAxiosRequestConfig } from 'axios';
 import nock from 'nock';
-import { circuitBreakerHttp, circuitBreakers } from './circuit-breaker';
+import { circuitBreakers, circuitBreaker } from './circuit-breaker';
 import { MiddlewareContext, executeWithMiddleware } from './middleware';
 
 describe('circuit-breaker', () => {
@@ -35,7 +35,7 @@ describe('circuit-breaker', () => {
           RawAxiosRequestConfig,
           AxiosResponse,
           MiddlewareContext<RawAxiosRequestConfig>
-        >([circuitBreakerHttp()], {
+        >([circuitBreaker()], {
           context,
           fn: request,
           fnArgument: requestConfig
@@ -51,7 +51,7 @@ describe('circuit-breaker', () => {
         RawAxiosRequestConfig,
         AxiosResponse,
         MiddlewareContext<RawAxiosRequestConfig>
-      >([circuitBreakerHttp()], {
+      >([circuitBreaker()], {
         context,
         fn: request,
         fnArgument: requestConfig
@@ -88,7 +88,7 @@ describe('circuit-breaker', () => {
           RawAxiosRequestConfig,
           AxiosResponse,
           MiddlewareContext<RawAxiosRequestConfig>
-        >([circuitBreakerHttp()], {
+        >([circuitBreaker()], {
           context,
           fn: request,
           fnArgument: requestConfig
@@ -117,7 +117,7 @@ describe('circuit-breaker', () => {
       RawAxiosRequestConfig,
       AxiosResponse,
       MiddlewareContext<RawAxiosRequestConfig>
-    >([circuitBreakerHttp()], {
+    >([circuitBreaker()], {
       context,
       fn: request,
       fnArgument: requestConfig
@@ -126,7 +126,7 @@ describe('circuit-breaker', () => {
       RawAxiosRequestConfig,
       AxiosResponse,
       MiddlewareContext<RawAxiosRequestConfig>
-    >([circuitBreakerHttp()], {
+    >([circuitBreaker()], {
       context: { ...context, tenantId: 'tenant2' },
       fn: request,
       fnArgument: requestConfig
@@ -167,7 +167,7 @@ describe('circuit-breaker', () => {
       RawAxiosRequestConfig,
       AxiosResponse,
       MiddlewareContext<RawAxiosRequestConfig>
-    >([circuitBreakerHttp()], {
+    >([circuitBreaker()], {
       context: context(requestConfigPath1),
       fn: request,
       fnArgument: requestConfigPath1
@@ -176,7 +176,7 @@ describe('circuit-breaker', () => {
       RawAxiosRequestConfig,
       AxiosResponse,
       MiddlewareContext<RawAxiosRequestConfig>
-    >([circuitBreakerHttp()], {
+    >([circuitBreaker()], {
       context: context(requestConfigPath2),
       fn: request,
       fnArgument: requestConfigPath2
@@ -213,7 +213,7 @@ describe('circuit-breaker', () => {
           RawAxiosRequestConfig,
           AxiosResponse,
           MiddlewareContext<RawAxiosRequestConfig>
-        >([circuitBreakerHttp()], {
+        >([circuitBreaker()], {
           context,
           fn: request,
           fnArgument: requestConfig

--- a/packages/resilience/src/circuit-breaker.ts
+++ b/packages/resilience/src/circuit-breaker.ts
@@ -42,18 +42,25 @@ function circuitBreakerKeyBuilder<
  * Helper method to build a circuit breaker middleware.
  * @returns The middleware adding a circuit breaker to the function.
  */
-export function circuitBreakerHttp<
+export function circuitBreaker<
   ArgumentT,
   ReturnT,
   ContextT extends MiddlewareContext<ArgumentT>
 >(): Middleware<ArgumentT, ReturnT, ContextT> {
-  return circuitBreaker<ArgumentT, ReturnT, ContextT>(
+  return circuitBreakerGeneric<ArgumentT, ReturnT, ContextT>(
     circuitBreakerKeyBuilder,
     httpErrorFilter
   );
 }
 
-function circuitBreaker<
+/**
+ * @deprecated Since v3.0.1. Use `{@link circuitBreaker}` instead.
+ * Helper method to build a circuit breaker middleware.
+ * @returns The middleware adding a circuit breaker to the function.
+ */
+export const circuitBreakerHttp = circuitBreaker;
+
+function circuitBreakerGeneric<
   ArgumentT,
   ReturnT,
   ContextT extends MiddlewareContext<ArgumentT>

--- a/packages/resilience/src/index.ts
+++ b/packages/resilience/src/index.ts
@@ -6,7 +6,7 @@
 
 export { timeout } from './timeout';
 export { retry } from './retry';
-export { circuitBreakerHttp } from './circuit-breaker';
+export { circuitBreakerHttp, circuitBreaker } from './circuit-breaker';
 export type { Middleware, MiddlewareFunction } from './middleware';
 export { MiddlewareOptions, MiddlewareContext } from './middleware';
 export { ResilienceOptions, resilience } from './resilience';

--- a/packages/resilience/src/resilience.spec.ts
+++ b/packages/resilience/src/resilience.spec.ts
@@ -195,13 +195,13 @@ describe('combined resilience features', () => {
 
   it('throws an error when retry is less than 1', async () => {
     expect(() => resilience({ retry: -2 })).toThrowError(
-      'Retry count value is invalid.'
+      'Number of retries must be greater or equal to 0.'
     );
   });
 
   it('throws an error when timeout is less or equal to 0', async () => {
     expect(() => resilience({ timeout: 0 })).toThrowError(
-      'Timeout value is invalid.'
+      'Timeout must be greater than 0.'
     );
   });
 });

--- a/packages/resilience/src/resilience.ts
+++ b/packages/resilience/src/resilience.ts
@@ -8,19 +8,19 @@ import type { Middleware } from './middleware';
  */
 export interface ResilienceOptions {
   /**
-   * Option for Retry Middleware.
+   * Option for retry middleware.
    * False by default. If set to true, the number of retries is 3.
    * Assign a different value to set custom number of reties.
    */
   retry?: boolean | number;
   /**
-   * Option for Timeout Middleware.
+   * Option for timeout middleware.
    * True by default, with a 10000 milliseconds timeout.
    * Assign a different value to set a custom timeout.
    */
   timeout?: boolean | number;
   /**
-   * Option for CircuitBreaker Middleware.
+   * Option for circuit breaker middleware.
    * True by default. Set false to disable.
    */
   circuitBreaker?: boolean;
@@ -34,7 +34,7 @@ const defaultResilienceOptions: ResilienceOptions = {
 
 /**
  * Return the resilience middleware functions as an array.
- * By default, Timeout and Circuit Breaker are enabled and Retry is disabled.
+ * By default, timeout and circuit breaker are enabled and retry is disabled.
  * This behavior can be overridden by adjusting the resilience options {@link ResilienceOptions}.
  * @param options - Resilience Options.
  * @returns Array of middleware functions.

--- a/packages/resilience/src/resilience.ts
+++ b/packages/resilience/src/resilience.ts
@@ -1,6 +1,6 @@
 import { timeout } from './timeout';
 import { retry } from './retry';
-import { circuitBreakerHttp } from './circuit-breaker';
+import { circuitBreaker } from './circuit-breaker';
 import { MiddlewareContext } from './middleware';
 import type { Middleware } from './middleware';
 /**
@@ -53,7 +53,7 @@ export function resilience<
   }
 
   if (resilienceOption.circuitBreaker) {
-    middlewares.push(circuitBreakerHttp());
+    middlewares.push(circuitBreaker());
   }
 
   if (typeof resilienceOption.timeout === 'number') {

--- a/packages/resilience/src/retry.ts
+++ b/packages/resilience/src/retry.ts
@@ -12,11 +12,11 @@ const logger = createLogger({
   messageContext: 'retry'
 });
 
-const defaultRetryCount = 3;
+const defaultRetries = 3;
 
 /**
  * Helper method to build a retry middleware.
- * @param retryCount - Number of retry attempts. Default value is 3.
+ * @param retries - Number of retry attempts. Default value is 3.
  * @returns The middleware adding a retry to the function.
  */
 export function retry<
@@ -24,10 +24,10 @@ export function retry<
   ReturnType,
   ContextType extends MiddlewareContext<ArgumentType>
 >(
-  retryCount: number = defaultRetryCount
+  retries: number = defaultRetries
 ): Middleware<ArgumentType, ReturnType, ContextType> {
-  if (retryCount < 0) {
-    throw new Error('Retry count value is invalid.');
+  if (retries < 0) {
+    throw new Error('Number of retries must be greater or equal to 0.');
   }
 
   return function (
@@ -55,7 +55,7 @@ export function retry<
             throw error;
           }
         },
-        { retries: retryCount }
+        { retries }
       );
   };
 }

--- a/packages/resilience/src/timeout.ts
+++ b/packages/resilience/src/timeout.ts
@@ -26,7 +26,7 @@ export function timeout<
   timeoutValue: number = defaultTimeout
 ): Middleware<ArgumentType, ReturnType, ContextType> {
   if (timeoutValue <= 0) {
-    throw new Error('Timeout value is invalid.');
+    throw new Error('Timeout must be greater than 0.');
   }
   if (timeoutValue < 10) {
     logger.warn(


### PR DESCRIPTION
We named the `circuitBreaker()` function `circuitBreakerHttp()` by error. This PR deprecates the erroneous name and replaces it with the corrected one.