### PR TITLE
deserializer should load in batches with only function imports

### DIFF
--- a/packages/odata-common/src/request-builder/batch/batch-request-builder.ts
+++ b/packages/odata-common/src/request-builder/batch/batch-request-builder.ts
@@ -4,7 +4,11 @@ import { first } from '@sap-cloud-sdk/util';
 import { MethodRequestBuilder } from '../request-builder-base';
 import { ODataRequest } from '../../request/odata-request';
 import { ODataBatchRequestConfig } from '../../request/odata-batch-request-config';
-import { DefaultDeSerializers, DeSerializers } from '../../de-serializers';
+import {
+  defaultDeSerializers,
+  DefaultDeSerializers,
+  DeSerializers
+} from '../../de-serializers';
 import { EntityBase } from '../../entity-base';
 import { GetAllRequestBuilderBase } from '../get-all-request-builder-base';
 import { GetByKeyRequestBuilderBase } from '../get-by-key-request-builder-base';
@@ -44,9 +48,12 @@ export class BatchRequestBuilder<
     )[]
   ) {
     super(new ODataBatchRequestConfig(defaultBasePath));
-    this.deSerializers = first(
-      Object.values(this.getEntityToApiMap())
-    )?.deSerializers;
+
+    const entityApi = first(Object.values(this.getEntityToApiMap()));
+
+    this.deSerializers = entityApi
+      ? entityApi?.deSerializers
+      : (defaultDeSerializers as DeSerializersT);
   }
 
   withSubRequestPathType(subRequestPathType: BatchSubRequestPathType): this {

--- a/test-packages/e2e-tests/test/batch.spec.ts
+++ b/test-packages/e2e-tests/test/batch.spec.ts
@@ -3,6 +3,7 @@ import { DefaultDeSerializers } from '@sap-cloud-sdk/odata-v4';
 import {
   batch,
   changeset,
+  createTestEntityById,
   createTestEntityByIdReturnId,
   returnInt,
   returnSapCloudSdk
@@ -109,26 +110,24 @@ describe('batch', () => {
   });
 
   it('deserializer should load in batches with only function imports', async () => {
-    const myFunctionImport = returnSapCloudSdk as any;
+    const myOperationUnderTest = createTestEntityById;
     //     ^?
-
-    const inputs = [1, 2, 3];
-    const functions = inputs.map(x => changeset(myFunctionImport({ foo: x })));
+    const inputs = [77];
+    const functions = inputs.map(x => changeset(myOperationUnderTest({ id: x })));
     //      ^?
     const results = await batch(...functions)
       //  ^?
       .withSubRequestPathType('relativeToEntity')
       .execute(destination);
 
-    // const r = (results[0] as unknown as WriteResponse<DefaultDeSerializers>);
-    const r = results[0] as any;
+    const r = results[0];
     //    ^?
-    if (r && r.responses) {
-      const deSerializedTestEntity = r.responses[0].as(testEntityApi);
+    if (r && r.isWriteResponses()) {
+      const deSerializedTestEntity = r.responses[0].as?.(testEntityApi);
       //      ^?
       expect(deSerializedTestEntity).toBeDefined();
     } else {
-      throw new Error('unexpected');
+      throw new Error('unexpected branch');
     }
   });
 });

--- a/test-packages/e2e-tests/test/batch.spec.ts
+++ b/test-packages/e2e-tests/test/batch.spec.ts
@@ -15,7 +15,7 @@ import {
 } from './test-utils/test-entity-operations';
 
 const entityKey = 456;
-const entityKeysUsedInTests = [456, 1000, 1001];
+const entityKeysUsedInTests = [77, 456, 1000, 1001];
 const requestBuilder = testEntityApi.requestBuilder();
 
 async function deleteAllCreatedEntities() {
@@ -110,24 +110,20 @@ describe('batch', () => {
   });
 
   it('deserializer should load in batches with only function imports', async () => {
+    // See https://github.com/SAP/cloud-sdk-js/issues/3539 for the original issue
     const myOperationUnderTest = createTestEntityById;
-    //     ^?
     const inputs = [77];
     const functions = inputs.map(x => changeset(myOperationUnderTest({ id: x })));
-    //      ^?
     const results = await batch(...functions)
-      //  ^?
       .withSubRequestPathType('relativeToEntity')
       .execute(destination);
 
     const r = results[0];
-    //    ^?
     if (r && r.isWriteResponses()) {
       const deSerializedTestEntity = r.responses[0].as?.(testEntityApi);
-      //      ^?
       expect(deSerializedTestEntity).toBeDefined();
     } else {
-      throw new Error('unexpected branch');
+      throw new Error(`Result ${r} is not as expected.`);
     }
   });
 });


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
