### PR TITLE
chore: download stats action

### DIFF
--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -14,7 +14,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - uses: actions/cache@v3
         id: cache
         with:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -20,7 +20,7 @@ jobs:
           ref: 'main'
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - run: yarn install --frozen-lockfile
       - name: Setup git
         run: |

--- a/.github/workflows/downloads.yml
+++ b/.github/workflows/downloads.yml
@@ -13,7 +13,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - uses: actions/cache@v3
         id: cache
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - uses: actions/cache@v3
         id: cache
         with:

--- a/.github/workflows/memory-tests.yml
+++ b/.github/workflows/memory-tests.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - uses: actions/cache@v3
         id: cache
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
           ref: 'main'
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - run: yarn install --frozen-lockfile
       - name: Legacy Release
         if: startsWith(github.ref, 'refs/tags/v1') || startsWith(github.ref, 'refs/tags/v2')

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -15,7 +15,7 @@ jobs:
       - run: git fetch --depth=1
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
       - run: yarn install --frozen-lockfile
       - run: yarn test:unit --continue -- -- -- --json --outputFile=unit-test-output.json
       - run: yarn test:integration -- -- -- --json --outputFile=int-test-output.json


### PR DESCRIPTION
With this PR the node version increases in several of our GitHub actions to version 18.
This should also fix the current error in the downloads action.