### PR TITLE
chore: Configure generator in e2e tests to overwrite old files

### DIFF
--- a/test-packages/e2e-tests/test/generator.config.json
+++ b/test-packages/e2e-tests/test/generator.config.json
@@ -1,5 +1,6 @@
 {
   "input": "../../../test-resources/odata-service-specs/v2/API_TEST_SRV/",
   "outputDir": "generator-test-output",
-  "skipValidation": true
+  "skipValidation": true,
+  "overwrite": true
 }


### PR DESCRIPTION
Without this option, repeated e2e test runs will fail.