### PR TITLE
chore: Add ignores for depcheck in e2e tests

### DIFF
--- a/test-packages/e2e-tests/package.json
+++ b/test-packages/e2e-tests/package.json
@@ -20,7 +20,7 @@
     "test:e2e": "jest",
     "lint": "eslint --ext .ts . && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -c",
     "lint:fix": "set TIMING=1 && eslint --ext .ts . --fix --quiet && prettier . --config ../../.prettierrc --ignore-path ../../.prettierignore -w --loglevel error",
-    "check:dependencies": "depcheck . --ignores='express,sqlite3,@sap/cds'",
+    "check:dependencies": "depcheck . --ignores='express,sqlite3,@sap/cds,bignumber.js,@sap-cloud-sdk/odata-v2'",
     "generate-edmx": "cds compile srv -s TestService -2 edmx > TestService.edmx"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes the following build issue:

@sap-cloud-sdk/e2e-tests:check:dependencies: Missing dependencies
@sap-cloud-sdk/e2e-tests:check:dependencies: * @sap-cloud-sdk/odata-v2: ./test/generator-test-output/API_TEST_SRV/BatchRequest.ts
@sap-cloud-sdk/e2e-tests:check:dependencies: * bignumber.js: ./test/generator-test-output/API_TEST_SRV/service.ts

<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
