### PR TITLE
fix: Remove transport.verify step before sending email

### DIFF
--- a/.changeset/swift-berries-hide.md
+++ b/.changeset/swift-berries-hide.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/mail-client': patch
+---
+
+[Fixed Issue] Fix `Invalid greeting` error from nodemailer by removing the `transport.verify` function call.

--- a/packages/mail-client/src/mail-client.spec.ts
+++ b/packages/mail-client/src/mail-client.spec.ts
@@ -200,7 +200,6 @@ describe('mail client', () => {
     const spyCreateTransport = jest
       .spyOn(nodemailer, 'createTransport')
       .mockReturnValue(mockTransport as any);
-    const spyVerifyTransport = jest.spyOn(mockTransport, 'verify');
     const spySendMail = jest.spyOn(mockTransport, 'sendMail');
     const spyCloseTransport = jest.spyOn(mockTransport, 'close');
     const destination: any = {
@@ -241,7 +240,6 @@ describe('mail client', () => {
     expect(spyCreateTransport).toBeCalledWith(
       expect.objectContaining(mailClientOptions)
     );
-    expect(spyVerifyTransport).toBeCalledTimes(1);
     expect(spySendMail).toBeCalledTimes(2);
     expect(spySendMail).toBeCalledWith(mailOptions1);
     expect(spySendMail).toBeCalledWith(mailOptions2);
@@ -255,7 +253,6 @@ describe('mail client', () => {
     const spyCreateTransport = jest
       .spyOn(nodemailer, 'createTransport')
       .mockReturnValue(mockTransport as any);
-    const spyVerifyTransport = jest.spyOn(mockTransport, 'verify');
     const spySendMail = jest.spyOn(mockTransport, 'sendMail');
     const spyCloseTransport = jest.spyOn(mockTransport, 'close');
     const spyEndSocket = jest.spyOn(mockSocket.socket, 'end');
@@ -287,7 +284,6 @@ describe('mail client', () => {
     ).resolves.not.toThrow();
     expect(spyCreateSocket).toBeCalledTimes(1);
     expect(spyCreateTransport).toBeCalledTimes(1);
-    expect(spyVerifyTransport).toBeCalledTimes(1);
     expect(spySendMail).toBeCalledTimes(1);
     expect(spySendMail).toBeCalledWith(mailOptions);
     expect(spyCloseTransport).toBeCalledTimes(1);

--- a/packages/mail-client/src/mail-client.ts
+++ b/packages/mail-client/src/mail-client.ts
@@ -238,13 +238,6 @@ async function sendMailWithNodemailer<T extends MailConfig>(
     mailClientOptions,
     socket
   );
-  transport.verify(function (error) {
-    if (error) {
-      logger.debug(`The verification of the transport failed: ${error}`);
-    } else {
-      logger.debug('The transport is successfully verified.');
-    }
-  });
 
   const mailConfigsFromDestination =
     buildMailConfigsFromDestination(mailDestination);


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

The step results in the following error:

`Error from nodemailer \"Error: Invalid greeting. response=250-mail07.wdf.sap.corp\n250-PIPELINING\n250-SIZE 307200000\n250-VRFY\n250-ETRN\n250-STARTTLS\n250-ENHANCEDSTATUSCODES\n250-8BITMIME\n250-DSN\n250-SMTPUTF8\n250 CHUNKING: 250-mail07.wdf.sap.corp\n250-PIPELINING\n250-SIZE 307200000\n250-VRFY\n250-ETRN\n250-STARTTLS\n250-ENHANCEDSTATUSCODES\n250-8BITMIME\n250-DSN\n250-SMTPUTF8\n250 CHUNKING\`

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
