### PR TITLE
chore: Fix turbo --force error

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "doc": "ts-node scripts/generate-docs.ts",
     "preversion": "ts-node scripts/before-bump.ts",
     "version": "changeset version",
-    "postversion": "yarn generate --force && yarn doc && ts-node scripts/after-bump.ts",
+    "postversion": "yarn generate && yarn doc && ts-node scripts/after-bump.ts",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix --force",
     "check:circular": "madge --extensions ts --ts-config=./tsconfig.json --circular --exclude 'dist|test-packages|connectivity/src/scp-cf/environment-accessor.ts|http-client/src/csrf-token-header.ts' ./packages",


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Fixes the following issue on running bump script:

```
$ yarn generate --force && yarn doc && ts-node scripts/after-bump.ts
$ turbo run generate --force --force
ERROR the argument '--force' cannot be used multiple times
```

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
