### PR TITLE
chore: Move dependencies to dev dependencies

### DIFF
--- a/packages/resilience/package.json
+++ b/packages/resilience/package.json
@@ -38,14 +38,14 @@
     "readme": "ts-node ../../scripts/replace-common-readme.ts"
   },
   "dependencies": {
-    "@types/opossum": "^6.2.3",
-    "opossum": "^7.1.0",
     "@sap-cloud-sdk/util": "^3.0.2",
-    "@types/async-retry": "^1.4.5",
     "async-retry": "^1.3.3",
-    "axios": "^1.3.4"
+    "axios": "^1.3.4",
+    "opossum": "^7.1.0"
   },
   "devDependencies": {
+    "@types/async-retry": "^1.4.5",
+    "@types/opossum": "^6.2.3",
     "nock": "^13.3.0",
     "typescript": "~4.9.5"
   }


### PR DESCRIPTION
I think these dependencies were added to the wrong category by accident. I don't see a reason to make them productive dependencies.