### PR TITLE
feat: Allow registerDestination to infer mTLS certs on CF

### DIFF
--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -37,18 +37,19 @@
     "readme": "ts-node ../../scripts/replace-common-readme.ts"
   },
   "dependencies": {
-    "@sap-cloud-sdk/util": "^3.0.2",
     "@sap-cloud-sdk/resilience": "^3.0.2",
+    "@sap-cloud-sdk/util": "^3.0.2",
     "@sap/xsenv": "^3.4.0",
     "@sap/xssec": "^3.2.17",
+    "async-retry": "^1.3.3",
     "axios": "^1.3.4",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
-    "jsonwebtoken": "^9.0.0",
-    "async-retry": "^1.3.3"
+    "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {
     "base64url": "^3.0.1",
+    "mock-fs": "^5.2.0",
     "nock": "^13.3.0",
     "typescript": "~5.0.3"
   }

--- a/packages/connectivity/src/http-agent/http-agent.spec.ts
+++ b/packages/connectivity/src/http-agent/http-agent.spec.ts
@@ -288,8 +288,8 @@ describe('getAgentConfig', () => {
         };
         const actual = getAgentConfig(destination)['httpsAgent'].options;
 
-        expect(await actual.cert).toEqual('my-cert');
-        expect(await actual.key).toEqual('my-key');
+        expect(actual.cert).toEqual('my-cert');
+        expect(actual.key).toEqual('my-key');
         expect(actual.pfx).not.toBeDefined();
         expect(actual.passphrase).not.toBeDefined();
       });
@@ -303,8 +303,8 @@ describe('getAgentConfig', () => {
 
       const actual = getAgentConfig(destination)['httpsAgent'].options;
 
-      expect(await actual.cert).not.toBeDefined();
-      expect(await actual.key).not.toBeDefined();
+      expect(actual.cert).not.toBeDefined();
+      expect(actual.key).not.toBeDefined();
     });
 
     it('returns an object with key "httpsAgent" and mTLS options missing for destinations without inferMtlsCertificate option', async () => {
@@ -314,8 +314,8 @@ describe('getAgentConfig', () => {
 
       const actual = getAgentConfig(destination)['httpsAgent'].options;
 
-      expect(await actual.cert).not.toBeDefined();
-      expect(await actual.key).not.toBeDefined();
+      expect(actual.cert).not.toBeDefined();
+      expect(actual.key).not.toBeDefined();
     });
   });
 });

--- a/packages/connectivity/src/http-agent/http-agent.ts
+++ b/packages/connectivity/src/http-agent/http-agent.ts
@@ -1,7 +1,7 @@
-import { readFile } from 'fs/promises';
+import { createLogger, last } from '@sap-cloud-sdk/util';
+import { readFileSync } from 'fs';
 import http from 'http';
 import https from 'https';
-import { createLogger, last } from '@sap-cloud-sdk/util';
 import {
   Destination,
   DestinationCertificate,
@@ -125,8 +125,8 @@ function getKeyStoreOption(destination: Destination): Record<string, any> {
 function getMtlsOptions(destination: Destination): Record<string, any> {
   if (mtlsIsEnabled(destination)) {
     return {
-      cert: readFile(process.env.CF_INSTANCE_CERT as string, 'utf8'),
-      key: readFile(process.env.CF_INSTANCE_KEY as string, 'utf8')
+      cert: readFileSync(process.env.CF_INSTANCE_CERT as string, 'utf8'),
+      key: readFileSync(process.env.CF_INSTANCE_KEY as string, 'utf8')
     };
   }
   return {};

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
@@ -22,6 +22,12 @@ const testDestination: DestinationWithName = {
   url: 'https://example.com'
 };
 
+const testDestinationWithMtls: DestinationWithName = {
+  name: 'RegisteredDestination',
+  url: 'https://example.com',
+  inferMtlsCertificate: true
+};
+
 const mailDestination: DestinationWithName = {
   name: 'RegisteredDestination',
   type: 'MAIL'
@@ -49,6 +55,14 @@ describe('register-destination', () => {
       destinationName: testDestination.name
     });
     expect(actual).toEqual(testDestination);
+  });
+
+  it('registers HTTP destination with mTLS and retrieves it', async () => {
+    await registerDestination(testDestinationWithMtls);
+    const actual = await getDestination({
+      destinationName: testDestination.name
+    });
+    expect(actual).toEqual(testDestinationWithMtls);
   });
 
   it('registers mail destination and retrieves it', async () => {

--- a/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
@@ -161,6 +161,14 @@ export interface Destination {
    * This field is used to authenticate the destination using a JWT without JKU.
    */
   jwksUri?: string;
+
+  /**
+   * Automatic handling of mTLS certificate and key on CloudFoundry.
+   *
+   * If this option is set to true, the CloudFoundry [instance identity](https://docs.cloudfoundry.org/devguide/deploy-apps/instance-identity.html)
+   * will be automatically used for TLS secured HTTP requests.
+   */
+  inferMtlsCertificate?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
