### PR TITLE
fix: fix types for transpilation on generation

### DIFF
--- a/.changeset/strong-ducks-cheat.md
+++ b/.changeset/strong-ducks-cheat.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/resilience': patch
+---
+
+[Fixed Issue] Fix transpilation on OData generation, where types for 'opossum' could not be found.

--- a/packages/resilience/src/circuit-breaker.ts
+++ b/packages/resilience/src/circuit-breaker.ts
@@ -6,9 +6,13 @@ import { MiddlewareContext, Middleware, MiddlewareOptions } from './middleware';
 /**
  * Map of all existing circuit breakers.
  * Entries are added in a lazy way.
+ * TODO:
+ *  The value type here should be CircuitBreaker, but this would make the Opossum types part of our public API.
+ *  This happens although it is marked as internal, because transpilation includes internal.
+ *  Adding CircuitBreaker will break transpilation on generation.
  * @internal
  */
-export const circuitBreakers: Record<string, CircuitBreaker> = {};
+export const circuitBreakers: Record<string, any> = {};
 
 /**
  * @internal


### PR DESCRIPTION
This should fix the issue identified by the E2E tests + Tom, where the types for 'opossum' cannot be found.