### PR TITLE
chore: Replace short snapshots with inline snapshots

### DIFF
--- a/packages/connectivity/src/scp-cf/destination/__snapshots__/destination-from-vcap.spec.ts.snap
+++ b/packages/connectivity/src/scp-cf/destination/__snapshots__/destination-from-vcap.spec.ts.snap
@@ -1,6 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`vcap-service-destination throws an error if the service type is not supported 1`] = `
-"The service "my-custom-service" is of type "undefined" which is not supported! Consider providing your own transformation function when calling destinationForServiceBinding, like this:
-  destinationServiceForBinding(yourServiceName, { serviceBindingToDestination: yourTransformationFunction });"
-`;

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
@@ -163,9 +163,11 @@ describe('vcap-service-destination', () => {
   });
 
   it('throws an error if the service type is not supported', async () => {
-    await expect(() =>
-      destinationForServiceBinding('my-custom-service')
-    ).rejects.toThrowErrorMatchingSnapshot();
+    await expect(() => destinationForServiceBinding('my-custom-service'))
+      .rejects.toThrowErrorMatchingInlineSnapshot(`
+      "The service "my-custom-service" is of type "undefined" which is not supported! Consider providing your own transformation function when calling destinationForServiceBinding, like this:
+        destinationServiceForBinding(yourServiceName, { serviceBindingToDestination: yourTransformationFunction });"
+    `);
   });
 
   it('throws an error if no service binding can be found for the given name', async () => {

--- a/packages/http-client/src/__snapshots__/http-client.spec.ts.snap
+++ b/packages/http-client/src/__snapshots__/http-client.spec.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`generic http client executeHttpRequest throws an error if the destination URL uses neither "http" nor "https" as protocol (e.g. RFC) 1`] = `"Protocol of the provided destination (rfc://example.com) is not supported! Currently only HTTP and HTTPS are supported."`;

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -752,7 +752,9 @@ sap-client:001`);
 
       await expect(
         executeHttpRequest(destination, { method: 'get' })
-      ).rejects.toThrowErrorMatchingSnapshot();
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        '"Protocol of the provided destination (rfc://example.com) is not supported! Currently only HTTP and HTTPS are supported."'
+      );
     });
 
     it('includes the default axios config in request', async () => {

--- a/packages/odata-v2/src/request-builder/__snapshots__/create-request-builder.spec.ts.snap
+++ b/packages/odata-v2/src/request-builder/__snapshots__/create-request-builder.spec.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`CreateRequestBuilder throws an error when request execution fails 1`] = `"Create request failed!"`;

--- a/packages/odata-v2/src/request-builder/__snapshots__/delete-request-builder.spec.ts.snap
+++ b/packages/odata-v2/src/request-builder/__snapshots__/delete-request-builder.spec.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`DeleteRequestBuilder throws an error when request execution fails 1`] = `"OData delete request failed!"`;

--- a/packages/odata-v2/src/request-builder/__snapshots__/function-import-request-builder.spec.ts.snap
+++ b/packages/odata-v2/src/request-builder/__snapshots__/function-import-request-builder.spec.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`FunctionImportRequestBuilder throws an error when shared entity type is used as return type 1`] = `"get request to http://example.com/sap/opu/odata/sap/API_TEST_SRV failed! "`;

--- a/packages/odata-v2/src/request-builder/__snapshots__/get-all-request-builder.spec.ts.snap
+++ b/packages/odata-v2/src/request-builder/__snapshots__/get-all-request-builder.spec.ts.snap
@@ -1,5 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`GetAllRequestBuilder execute throws an error when request execution fails 1`] = `"get request to http://example.com/sap/opu/odata/sap/API_TEST_SRV failed! "`;
-
-exports[`GetAllRequestBuilder execute throws an error when the destination cannot be found 1`] = `"Could not find a destination with name "NonExistentDestination"! Unable to execute request."`;

--- a/packages/odata-v2/src/request-builder/__snapshots__/get-by-key-request-builder.spec.ts.snap
+++ b/packages/odata-v2/src/request-builder/__snapshots__/get-by-key-request-builder.spec.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`GetByKeyRequestBuilder throws a useful error when request execution fails 1`] = `"OData get by key request failed!"`;

--- a/packages/odata-v2/src/request-builder/__snapshots__/update-request-builder.spec.ts.snap
+++ b/packages/odata-v2/src/request-builder/__snapshots__/update-request-builder.spec.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`UpdateRequestBuilder throws an error when request execution fails 1`] = `"OData update request failed!"`;

--- a/packages/odata-v2/src/request-builder/create-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/create-request-builder.spec.ts
@@ -273,7 +273,9 @@ describe('CreateRequestBuilder', () => {
       someEntity
     ).execute(defaultDestination);
 
-    await expect(createRequest).rejects.toThrowErrorMatchingSnapshot();
+    await expect(createRequest).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"Create request failed!"'
+    );
   });
 
   it('create an entity with csrf token request when the option is set to false', async () => {

--- a/packages/odata-v2/src/request-builder/delete-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/delete-request-builder.spec.ts
@@ -133,7 +133,9 @@ describe('DeleteRequestBuilder', () => {
       KeyPropertyGuid: keyPropGuid
     }).execute(defaultDestination);
 
-    await expect(deleteRequest).rejects.toThrowErrorMatchingSnapshot();
+    await expect(deleteRequest).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"OData delete request failed!"'
+    );
   });
 
   describe('executeRaw', () => {

--- a/packages/odata-v2/src/request-builder/function-import-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/function-import-request-builder.spec.ts
@@ -220,7 +220,9 @@ describe('FunctionImportRequestBuilder', () => {
 
     await expect(
       requestBuilder.execute(defaultDestination)
-    ).rejects.toThrowErrorMatchingSnapshot();
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"get request to http://example.com/sap/opu/odata/sap/API_TEST_SRV failed! "'
+    );
   });
 });
 

--- a/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
@@ -205,7 +205,9 @@ describe('GetAllRequestBuilder', () => {
         destinationName: 'NonExistentDestination'
       });
 
-      await expect(getAllRequest).rejects.toThrowErrorMatchingSnapshot();
+      await expect(getAllRequest).rejects.toThrowErrorMatchingInlineSnapshot(
+        '"Could not find a destination with name "NonExistentDestination"! Unable to execute request."'
+      );
     });
 
     it('throws an error when request execution fails', async () => {
@@ -219,7 +221,9 @@ describe('GetAllRequestBuilder', () => {
 
       const getAllRequest = requestBuilder.execute(defaultDestination);
 
-      await expect(getAllRequest).rejects.toThrowErrorMatchingSnapshot();
+      await expect(getAllRequest).rejects.toThrowErrorMatchingInlineSnapshot(
+        '"get request to http://example.com/sap/opu/odata/sap/API_TEST_SRV failed! "'
+      );
     });
 
     it('considers custom timeout on the request', async () => {

--- a/packages/odata-v2/src/request-builder/get-by-key-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-by-key-request-builder.spec.ts
@@ -199,6 +199,8 @@ describe('GetByKeyRequestBuilder', () => {
       KeyPropertyGuid: uuid(),
       KeyPropertyString: 'test'
     }).execute(defaultDestination);
-    await expect(getByKeyRequest).rejects.toThrowErrorMatchingSnapshot();
+    await expect(getByKeyRequest).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"OData get by key request failed!"'
+    );
   });
 });

--- a/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/update-request-builder.spec.ts
@@ -394,7 +394,9 @@ describe('UpdateRequestBuilder', () => {
       entity
     ).execute(defaultDestination);
 
-    await expect(updateRequest).rejects.toThrowErrorMatchingSnapshot();
+    await expect(updateRequest).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"OData update request failed!"'
+    );
   });
 
   it('should set the remote state and ETag', async () => {

--- a/packages/odata-v2/src/uri-conversion/__snapshots__/get-resource-path.spec.ts.snap
+++ b/packages/odata-v2/src/uri-conversion/__snapshots__/get-resource-path.spec.ts.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`get resource path throws error if keys are nullish 1`] = `"Cannot get resource path for entity A_TestEntity. The following keys have nullish values, but are not nullable: KeyPropertyGuid, KeyPropertyString"`;
-
-exports[`get resource path throws error if no keys set 1`] = `"Cannot get resource path for entity A_TestEntity. The following keys are missing: KeyPropertyGuid, KeyPropertyString"`;
-
-exports[`get resource path throws error if not all keys are set 1`] = `"Cannot get resource path for entity A_TestEntity. The following keys are missing: KeyPropertyString"`;

--- a/packages/odata-v2/src/uri-conversion/get-resource-path.spec.ts
+++ b/packages/odata-v2/src/uri-conversion/get-resource-path.spec.ts
@@ -27,7 +27,9 @@ describe('get resource path', () => {
   it('throws error if no keys set', () => {
     expect(() =>
       getResourcePathForKeys({}, testEntityApi)
-    ).toThrowErrorMatchingSnapshot();
+    ).toThrowErrorMatchingInlineSnapshot(
+      '"Cannot get resource path for entity A_TestEntity. The following keys are missing: KeyPropertyGuid, KeyPropertyString"'
+    );
   });
 
   it('throws error if not all keys are set', () => {
@@ -35,7 +37,9 @@ describe('get resource path', () => {
 
     expect(() =>
       getResourcePathForKeys(keys, testEntityApi)
-    ).toThrowErrorMatchingSnapshot();
+    ).toThrowErrorMatchingInlineSnapshot(
+      '"Cannot get resource path for entity A_TestEntity. The following keys are missing: KeyPropertyString"'
+    );
   });
 
   it('throws error if keys are nullish', () => {
@@ -43,7 +47,9 @@ describe('get resource path', () => {
 
     expect(() =>
       getResourcePathForKeys(keys, testEntityApi)
-    ).toThrowErrorMatchingSnapshot();
+    ).toThrowErrorMatchingInlineSnapshot(
+      '"Cannot get resource path for entity A_TestEntity. The following keys have nullish values, but are not nullable: KeyPropertyGuid, KeyPropertyString"'
+    );
   });
 
   it('allows values to be empty string', () => {

--- a/packages/util/src/__snapshots__/url.spec.ts.snap
+++ b/packages/util/src/__snapshots__/url.spec.ts.snap
@@ -1,5 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`url does not throw for existing link 1`] = `200`;
-
-exports[`url throws for non existing link 1`] = `"Request failed with status code 404"`;

--- a/packages/util/src/url.spec.ts
+++ b/packages/util/src/url.spec.ts
@@ -7,13 +7,15 @@ describe('url', () => {
 
     await expect(
       checkUrlExists('https://non.existing.com')
-    ).rejects.toThrowErrorMatchingSnapshot();
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"Request failed with status code 404"'
+    );
   });
 
   it('does not throw for existing link', async () => {
     nock('https://existing.com').head(/.*/).reply(200);
     await expect(
       checkUrlExists('https://existing.com')
-    ).resolves.toMatchSnapshot();
+    ).resolves.toMatchInlineSnapshot('200');
   });
 });

--- a/test-packages/integration-tests/test/v2/__snapshots__/request-builder.spec.ts.snap
+++ b/test-packages/integration-tests/test/v2/__snapshots__/request-builder.spec.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Request Builder should fail for update request without keys 1`] = `"OData update request failed!"`;

--- a/test-packages/integration-tests/test/v2/request-builder.spec.ts
+++ b/test-packages/integration-tests/test/v2/request-builder.spec.ts
@@ -376,7 +376,9 @@ describe('Request Builder', () => {
       )
       .execute(destination);
 
-    await expect(request).rejects.toThrowErrorMatchingSnapshot();
+    await expect(request).rejects.toThrowErrorMatchingInlineSnapshot(
+      '"OData update request failed!"'
+    );
   });
 
   it('should resolve for delete with keys', async () => {


### PR DESCRIPTION
I noticed that we have a lot of snapshots files where they are not needed. Inline snapshots are more convenient here, because you see the data right away + no IO is necessary.