### PR TITLE
fix: Resilience undefined handling

### DIFF
--- a/.changeset/small-news-roll.md
+++ b/.changeset/small-news-roll.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/resilience': patch
+---
+
+[Fixed Issue] Fix parsing error when the last response in a chain of retries returned undefined.

--- a/packages/resilience/src/resilience.spec.ts
+++ b/packages/resilience/src/resilience.spec.ts
@@ -76,6 +76,7 @@ describe('combined resilience features', () => {
 
     expect(response.status).toBe(HTTP_STATUS.OK);
   }, 10000);
+
   it('uses circuit breaker and timeout by default with resilience()', async () => {
     const delay = 100;
     nock(host, {})

--- a/packages/resilience/src/retry.ts
+++ b/packages/resilience/src/retry.ts
@@ -45,8 +45,7 @@ export function retry<
               logger.debug(
                 'HTTP request failed but error did not contain a response status field as expected. Rethrowing error.'
               );
-            }
-            else if (status.toString().startsWith('4')) {
+            } else if (status.toString().startsWith('4')) {
               bail(new Error(`Request failed with status code ${status}`));
               // We need to return something here but the actual value does not matter
               return undefined as ReturnType;

--- a/packages/resilience/src/retry.ts
+++ b/packages/resilience/src/retry.ts
@@ -46,7 +46,7 @@ export function retry<
                 'HTTP request failed but error did not contain a response status field as expected. Rethrowing error.'
               );
             }
-            if (status.toString().startsWith('4')) {
+            else if (status.toString().startsWith('4')) {
               bail(new Error(`Request failed with status code ${status}`));
               // We need to return something here but the actual value does not matter
               return undefined as ReturnType;


### PR DESCRIPTION
With this PR, a  parsing error when the last response in a chain of retries returned undefined, is fixed.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
