### PR TITLE
chore: Fix canary build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
+          registry-url: 'https://registry.npmjs.org'
       - run: yarn install --ignore-engines --frozen-lockfile
       - run: yarn test:unit
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,6 @@ jobs:
       - run: yarn install --frozen-lockfile
       - name: Canary Release
         run: |
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
           date=`date +%Y%m%d%H%M%S`
           rm -f .changeset/*.md
           cp canary-release-changeset.md .changeset
@@ -150,7 +149,7 @@ jobs:
           yarn changeset pre exit
           yarn changeset publish --tag canary
         env:
-          NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
   draft-github-release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR should fix the failing canary builds, according to [this](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages).

<!-- Please provide a description of what your change does and why it is needed. -->


<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
