### PR TITLE
fix: csrf token fetching

### DIFF
--- a/.changeset/tasty-ties-give.md
+++ b/.changeset/tasty-ties-give.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/http-client': minor
 ---
 
-[Fixed Issue] CSRF token fetching now supports large requests.
+[Fixed Issue] Improve CSRF token fetching for large requests.

--- a/.changeset/tasty-ties-give.md
+++ b/.changeset/tasty-ties-give.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/http-client': minor
+---
+
+[Fixed Issue] CSRF token fetching now supports large requests.

--- a/packages/http-client/src/csrf-token-middleware.spec.ts
+++ b/packages/http-client/src/csrf-token-middleware.spec.ts
@@ -59,7 +59,6 @@ describe('CSRF middleware', () => {
       { url: host },
       { method: 'POST', url: 'some/path' }
     );
-
     expect(spy).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({

--- a/packages/http-client/src/csrf-token-middleware.spec.ts
+++ b/packages/http-client/src/csrf-token-middleware.spec.ts
@@ -59,6 +59,7 @@ describe('CSRF middleware', () => {
       { url: host },
       { method: 'POST', url: 'some/path' }
     );
+
     expect(spy).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
@@ -116,7 +117,7 @@ describe('CSRF middleware', () => {
     );
   });
 
-  it('fetches headers from "/some/path/" first', async () => {
+  it('fetches headers from "/some/path/" first, without sending data', async () => {
     nock(host).head('/some/path/').reply(200, {}, csrfResponseHeaders);
     nock(host).post('/some/path').reply(200, {});
     const spy = jest.spyOn(axios, 'request');
@@ -129,7 +130,8 @@ describe('CSRF middleware', () => {
       expect.objectContaining({
         method: 'head',
         headers: csrfFetchHeader,
-        url: 'some/path/'
+        url: 'some/path/',
+        data: {}
       })
     );
   });

--- a/packages/http-client/src/csrf-token-middleware.ts
+++ b/packages/http-client/src/csrf-token-middleware.ts
@@ -174,6 +174,7 @@ async function makeCsrfRequests(
     ...requestConfig,
     method: options.method || 'head',
     params: {},
+    data: {},
     url: options.url || requestConfig.url,
     headers: buildCsrfFetchHeaders(requestConfig.headers)
   };


### PR DESCRIPTION
With this PR, we stop sending the request's data when requesting a CSRF token, which caused issues for users who were sending large requests (see [issue](https://github.com/SAP/cloud-sdk-js/issues/3846))
