### PR TITLE
chore: Remove xsuaa dependency when caching service tokens

### DIFF
--- a/.changeset/cuddly-adults-taste.md
+++ b/.changeset/cuddly-adults-taste.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Improvement] Do not rely on XSUAA service when caching service tokens. Cache keys are now based on service credentials URL.

--- a/packages/connectivity/src/scp-cf/token-accessor.spec.ts
+++ b/packages/connectivity/src/scp-cf/token-accessor.spec.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../../test-resources/test/test-util/xsuaa-service-mocks';
 import { clientCredentialsTokenCache } from './client-credentials-token-cache';
 import { jwtBearerToken, serviceToken } from './token-accessor';
+import { ClientCredentialsResponse } from './xsuaa-service-types';
 
 describe('token accessor', () => {
   describe('serviceToken()', () => {
@@ -283,16 +284,47 @@ describe('token accessor', () => {
       );
     });
 
-    it('throws an error if no XSUAA service is bound', async () => {
+    it('uses given service to retrieve token from cache', async () => {
       process.env.VCAP_SERVICES = JSON.stringify({
         destination: [destinationBindingClientSecretMock]
       });
+      const token = signedJwt({ dummy: 'content' });
 
-      await expect(
-        serviceToken('destination')
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        '"Could not find binding to service \'xsuaa\', that includes credentials."'
+      clientCredentialsTokenCache.clear();
+      clientCredentialsTokenCache.cacheToken(
+        destinationBindingClientSecretMock.credentials.url,
+        destinationBindingClientSecretMock.credentials.clientid,
+        { access_token: token } as ClientCredentialsResponse
       );
+
+      await expect(serviceToken('destination')).resolves.toEqual(token);
+    });
+
+    it('uses given service to cache token', async () => {
+      process.env.VCAP_SERVICES = JSON.stringify({
+        destination: [destinationBindingClientSecretMock]
+      });
+      const token = { access_token: signedJwt({ dummy: 'content' }) };
+
+      mockClientCredentialsGrantCall(
+        destinationBindingClientSecretMock.credentials.url,
+        token,
+        200,
+        destinationBindingClientSecretMock.credentials
+      );
+
+      clientCredentialsTokenCache.clear();
+
+      await expect(serviceToken('destination')).resolves.toEqual(
+        token.access_token
+      );
+
+      expect(
+        clientCredentialsTokenCache.getToken(
+          destinationBindingClientSecretMock.credentials.url,
+          destinationBindingClientSecretMock.credentials.clientid
+        )
+      ).toEqual(token);
     });
 
     it('throws an error if no target service is bound', async () => {

--- a/test-resources/bootstrap-test.js
+++ b/test-resources/bootstrap-test.js
@@ -1,3 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const util = require('@sap-cloud-sdk/util');
 util.muteLoggers();
+
+if (typeof $jsDebugIsRegistered !== 'undefined') {
+  jest.setTimeout(5 * 60 * 1000);
+}


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Related to SAP/cloud-sdk-backlog#865.

This is the second of three PRs to remove the SDK's dependency on an XSUAA service binding.
Instead of relying on the XSUAA service to be there, the URL from the credentials of the service that the token is retrieved or is used for caching.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
