### PR TITLE
feat: Fix expires in property

### DIFF
--- a/.changeset/selfish-needles-grow.md
+++ b/.changeset/selfish-needles-grow.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Compatibility Note] The `expiresIn` property of `authTokens` on a `Destination` can be undefined.

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
@@ -161,7 +161,7 @@ function destinationAuthToken(
     return [
       {
         value: token,
-        expiresIn: decoded.exp!.toString(),
+        expiresIn: decoded.exp?.toString(),
         error: null,
         http_header: { key: 'Authorization', value: `Bearer ${token}` },
         type: 'Bearer'

--- a/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-types.ts
@@ -186,7 +186,7 @@ export interface DestinationAuthToken {
   /**
    * The number of seconds until the access token expires.
    */
-  expiresIn: string;
+  expiresIn?: string;
   /**
    * Potential error of token retrieval in the destination service.
    */

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
@@ -120,7 +120,7 @@ function buildClientCredentialsDestination(
   name
 ): Destination {
   const expiresIn = Math.floor(
-    (decodeJwt(token).exp! * 1000 - Date.now()) / 1000
+    (decodeJwt(token).exp || 0 * 1000 - Date.now()) / 1000
   ).toString(10);
   return {
     url,

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
@@ -119,9 +119,10 @@ function buildClientCredentialsDestination(
   url: string,
   name
 ): Destination {
-  const expiresIn = Math.floor(
-    (decodeJwt(token).exp || 0 * 1000 - Date.now()) / 1000
-  ).toString(10);
+  const expirationTime = decodeJwt(token).exp;
+  const expiresIn = expirationTime
+    ? Math.floor((expirationTime * 1000 - Date.now()) / 1000).toString(10)
+    : undefined;
   return {
     url,
     name,


### PR DESCRIPTION
The `expiresIn` property of a Destination’s auth tokens can be undefined. This PR fixes this.