### PR TITLE
chore: add `x-sap-security-session: create` for SAMLAssertion

### DIFF
--- a/packages/connectivity/src/scp-cf/authorization-header.spec.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.spec.ts
@@ -159,7 +159,8 @@ describe('buildAuthorizationHeaders', () => {
       );
 
       expect(actual).toEqual({
-        authorization: destination.authTokens![0].http_header.value
+        authorization: destination.authTokens![0].http_header.value,
+        'x-sap-security-session': 'create'
       });
     });
   });

--- a/packages/connectivity/src/scp-cf/authorization-header.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.ts
@@ -150,7 +150,12 @@ function getProxyRelatedAuthHeaders(
 
 async function getAuthenticationRelatedHeaders(
   destination: Destination
-): Promise<AuthenticationHeaderCloud | AuthenticationHeaderOnPrem | AuthenticationHeaderSAMLAssertion | undefined> {
+): Promise<
+  | AuthenticationHeaderCloud
+  | AuthenticationHeaderOnPrem
+  | AuthenticationHeaderSAMLAssertion
+  | undefined
+> {
   const destinationAuthHeaders = getAuthHeader(
     destination.authentication,
     destination.headers

--- a/packages/connectivity/src/scp-cf/authorization-header.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.ts
@@ -185,11 +185,11 @@ async function getAuthenticationRelatedHeaders(
     case 'OAuth2JWTBearer':
     case 'OAuth2ClientCredentials':
     case 'OAuth2Password':
-    case 'OAuth2RefreshToken':
+    case 'OAuth2RefreshToken': {
       const header = headerFromTokens(
         destination.authentication,
         destination.authTokens
-      )
+      );
       if (destination.authentication === 'SAMLAssertion') {
         logger.warn(
           "Destination authentication flow is 'SamlAssertion' and the auth header contains the SAML assertion. In most cases you want to translate the assertion to a Bearer token using the 'OAuth2SAMLBearerAssertion' flow."
@@ -197,9 +197,10 @@ async function getAuthenticationRelatedHeaders(
         return {
           ...header,
           'x-sap-security-session': 'create'
-        }
+        };
       }
       return header;
+    }
     case 'BasicAuthentication':
       return headerFromBasicAuthDestination(destination);
     case 'PrincipalPropagation':

--- a/packages/connectivity/src/scp-cf/authorization-header.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.ts
@@ -134,7 +134,7 @@ interface AuthenticationHeaders {
   'SAP-Connectivity-Authentication'?: string;
 }
 interface AuthenticationHeaderSAMLAssertion {
-  'x-sap-security-session': string;
+  'x-sap-security-session': 'create';
 }
 
 function getProxyRelatedAuthHeaders(

--- a/packages/connectivity/src/scp-cf/authorization-header.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.ts
@@ -133,6 +133,7 @@ interface AuthenticationHeaders {
   'Proxy-Authorization'?: string;
   'SAP-Connectivity-Authentication'?: string;
 }
+
 interface AuthenticationHeaderSAMLAssertion {
   'x-sap-security-session': 'create';
 }

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-authentication-type.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-authentication-type.spec.ts
@@ -758,7 +758,7 @@ describe('authentication types', () => {
     expectAllMocksUsed(httpMocks);
   });
 
-  describe('autehntication type SamlAssertion', () => {
+  describe('authentication type SamlAssertion', () => {
     it('receives the saml assertion in the destination', async () => {
       const httpMocks = [
         mockInstanceDestinationsCall(nock, [], 200, providerServiceToken),


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#1112.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
