### PR TITLE
chore: read prettier config once

### DIFF
--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -2,10 +2,11 @@ import { resolve } from 'path';
 import { existsSync, promises } from 'fs';
 import mock from 'mock-fs';
 import { readJSON } from '@sap-cloud-sdk/util';
-import prettier from 'prettier';
 import { getInputFilePaths } from '@sap-cloud-sdk/generator-common/internal';
 import { emptyDocument } from '../test/test-util';
 import { generate } from './generator';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const prettier = require('prettier');
 
 jest.mock('../../generator-common/internal', () => {
   const actual = jest.requireActual('../../generator-common/internal');

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -6,8 +6,6 @@ import prettier from 'prettier';
 import { getInputFilePaths } from '@sap-cloud-sdk/generator-common/internal';
 import { emptyDocument } from '../test/test-util';
 import { generate } from './generator';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const prettier = require('prettier');
 
 jest.mock('../../generator-common/internal', () => {
   const actual = jest.requireActual('../../generator-common/internal');

--- a/packages/openapi-generator/src/generator.spec.ts
+++ b/packages/openapi-generator/src/generator.spec.ts
@@ -2,6 +2,7 @@ import { resolve } from 'path';
 import { existsSync, promises } from 'fs';
 import mock from 'mock-fs';
 import { readJSON } from '@sap-cloud-sdk/util';
+import prettier from 'prettier';
 import { getInputFilePaths } from '@sap-cloud-sdk/generator-common/internal';
 import { emptyDocument } from '../test/test-util';
 import { generate } from './generator';

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -192,7 +192,7 @@ async function generateMandatorySources(
   const createFileOptions = await getFileCreationOptions(options);
   if (openApiDocument.schemas.length) {
     const schemaDir = resolve(serviceDir, 'schema');
-    await createSchemaFiles(schemaDir, openApiDocument, options);
+    await createSchemaFiles(schemaDir, openApiDocument, createFileOptions);
     await createFile(
       schemaDir,
       'index.ts',
@@ -230,17 +230,16 @@ async function createApis(
 async function createSchemaFiles(
   dir: string,
   openApiDocument: OpenApiDocument,
-  options: ParsedGeneratorOptions
+  createFileOptions: CreateFileOptions
 ): Promise<void> {
   await mkdir(dir, { recursive: true });
-  const fileCreateOptions = await getFileCreationOptions(options);
   await Promise.all(
     openApiDocument.schemas.map(schema =>
       createFile(
         dir,
         `${schema.fileName}.ts`,
         schemaFile(schema),
-        fileCreateOptions
+        createFileOptions
       )
     )
   );


### PR DESCRIPTION
I noticed, that the prettier config file is read once per schema file. This is not necessary as it is read once before and can be reused.