### PR TITLE
feat: Support `forwardAuthToken` for all types of destinations

### DIFF
--- a/.changeset/chilly-poets-walk.md
+++ b/.changeset/chilly-poets-walk.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Compatibility Note] Deprecate `destinationForServiceBinding()` and `PartialDestinationFetchOptions`. Use `getDestinationFromServiceBinding()` and `ServiceBindingTransformOptions` instead.

--- a/.changeset/lazy-cougars-dream.md
+++ b/.changeset/lazy-cougars-dream.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[New Feature] Support forwarding of auth tokens for destinations from the destination service, service bindings and environment variables.

--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -48,7 +48,6 @@
     "jsonwebtoken": "^9.0.1"
   },
   "devDependencies": {
-    "base64url": "^3.0.1",
     "mock-fs": "^5.2.0",
     "nock": "^13.3.2",
     "typescript": "~5.0.4"

--- a/packages/connectivity/src/index.ts
+++ b/packages/connectivity/src/index.ts
@@ -52,7 +52,9 @@ export {
   DestinationsByType,
   DestinationForServiceBindingOptions,
   destinationForServiceBinding,
+  getDestinationFromServiceBinding,
   PartialDestinationFetchOptions,
+  ServiceBindingTransformOptions,
   getAllDestinationsFromDestinationService
 } from './scp-cf';
 

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
@@ -58,6 +58,7 @@ const providerDestination: DestinationConfiguration = {
 const parsedProviderDestination: DestinationWithoutToken = {
   authentication: 'NoAuthentication',
   certificates: [],
+  forwardAuthToken: false,
   isTrustingAllCertificates: false,
   name: 'DESTINATION',
   originalProperties: {
@@ -78,6 +79,7 @@ const subscriberDestination: DestinationConfiguration = {
 const parsedSubscriberDestination: DestinationWithoutToken = {
   authentication: 'NoAuthentication',
   certificates: [],
+  forwardAuthToken: false,
   isTrustingAllCertificates: false,
   name: 'DESTINATION',
   originalProperties: {

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
@@ -171,6 +171,7 @@ describe('get destination with PrivateLink proxy type', () => {
     authTokens: [],
     authentication: 'NoAuthentication',
     certificates: [],
+    forwardAuthToken: false,
     isTrustingAllCertificates: false,
     name: 'PrivateLinkDest',
     originalProperties: {

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-types.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-types.ts
@@ -70,9 +70,10 @@ export interface DestinationAccessorOptions {
   /**
    * This property is only considered in case no `jwt` is provided.
    * It is meant for situations where you do not have a token e.g. background processes.
-   * The value for iss is the issuer field of a JWT e.g. https://<your-subdomain>.localhost:8080/uaa/oauth/token'.
+   * The value for `iss` is the issuer field of a JWT e.g. https://<your-subdomain>.localhost:8080/uaa/oauth/token'.
    *
-   * ATTENTION: If this property is used, no validation of the provided subdomain value is done. This is differs from how the `jwt` is handled.
+   * ATTENTION: If this property is used, no validation of the provided subdomain value is done.
+   * This is differs from how the `jwt` is handled.
    * So be careful that the used value is not manipulated and breaks the tenant isolation of your application.
    */
   iss?: string;

--- a/packages/connectivity/src/scp-cf/destination/destination-from-env.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-env.spec.ts
@@ -4,10 +4,12 @@ import {
   mockDestinationsEnv,
   unmockDestinationsEnv
 } from '../../../../../test-resources/test/test-util/request-mocker';
+import { signedJwt } from '../../../../../test-resources/test/test-util';
 import { Destination } from './destination-service-types';
 import {
   getDestinationFromEnvByName,
-  getDestinationsFromEnv
+  getDestinationsFromEnv,
+  searchEnvVariablesForDestination
 } from './destination-from-env';
 import { getDestination, useOrFetchDestination } from './destination-accessor';
 import { sanitizeDestination } from './destination';
@@ -61,6 +63,21 @@ describe('env-destination-accessor', () => {
   afterEach(() => {
     unmockDestinationsEnv();
     jest.resetAllMocks();
+  });
+
+  describe('searchEnvVariablesForDestination', () => {
+    it('sets forwarded auth token if needed', async () => {
+      const destinationName = 'FORWARD';
+      const jwt = signedJwt({});
+      mockDestinationsEnv({ name: destinationName, forwardAuthToken: true });
+
+      const destination = searchEnvVariablesForDestination({
+        destinationName,
+        jwt
+      });
+
+      expect(destination?.authTokens?.[0]).toMatchObject({ value: jwt });
+    });
   });
 
   describe('getDestinationsFromEnv()', () => {

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.spec.ts
@@ -1,0 +1,72 @@
+import nock from 'nock';
+import {
+  mockInstanceDestinationsCall,
+  mockServiceBindings,
+  mockServiceToken,
+  mockSubaccountDestinationsCall,
+  mockVerifyJwt,
+  providerServiceToken
+} from '../../../../../test-resources/test/test-util';
+import { getDestinationFromDestinationService } from './destination-from-service';
+
+describe('getDestinationFromDestinationService', () => {
+  let serviceTokenSpy;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockServiceBindings();
+    mockVerifyJwt();
+    serviceTokenSpy = mockServiceToken();
+    mockInstanceDestinationsCall(nock, [], 200, providerServiceToken);
+  });
+
+  it('adds JWT to destination, when `forwardAuthToken` is set (NoAuthentication)', async () => {
+    const destination = {
+      URL: 'https://example.com',
+      Name: 'FORWARD',
+      ProxyType: 'Internet',
+      Authentication: 'NoAuthentication',
+      forwardAuthToken: 'true'
+    };
+    mockSubaccountDestinationsCall(
+      nock,
+      [destination],
+      200,
+      providerServiceToken
+    );
+
+    const retrievedDestination = await getDestinationFromDestinationService({
+      destinationName: 'FORWARD',
+      jwt: providerServiceToken
+    });
+    expect(retrievedDestination?.forwardAuthToken).toBe(true);
+    expect(retrievedDestination?.authTokens?.[0].value).toEqual(
+      providerServiceToken
+    );
+  });
+
+  it('does not execute additional auth flows, if `forwardAuthToken` is set (e.g. OAuth2ClientCredentials)', async () => {
+    // Without `forwardAuthToken` this test would require an additional single subaccount destination call
+    const destination = {
+      URL: 'https://example.com',
+      Name: 'FORWARD',
+      ProxyType: 'Internet',
+      Authentication: 'OAuth2ClientCredentials',
+      forwardAuthToken: 'true'
+    };
+    mockSubaccountDestinationsCall(
+      nock,
+      [destination],
+      200,
+      providerServiceToken
+    );
+
+    const retrievedDestination = await getDestinationFromDestinationService({
+      destinationName: 'FORWARD',
+      jwt: providerServiceToken
+    });
+    expect(retrievedDestination?.forwardAuthToken).toBe(true);
+    expect(retrievedDestination?.authTokens?.[0].value).toEqual(
+      providerServiceToken
+    );
+  });
+});

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
@@ -1,16 +1,19 @@
 import {
   mockServiceToken,
-  providerUserPayload
+  providerUserPayload,
+  providerUserToken,
+  signedJwt
 } from '../../../../../test-resources/test/test-util';
 import * as tokenAccessor from '../token-accessor';
 import { Service } from '../environment-accessor/environment-accessor-types';
+import { decodeJwt } from '../jwt';
 import { getDestination } from './destination-accessor';
-import { destinationForServiceBinding } from './destination-from-vcap';
+import { getDestinationFromServiceBinding } from './destination-from-vcap';
 import { destinationCache } from './destination-cache';
 import SpyInstance = jest.SpyInstance;
 
 describe('vcap-service-destination', () => {
-  const spy = jest.spyOn(tokenAccessor, 'serviceToken');
+  const serviceTokenSpy = jest.spyOn(tokenAccessor, 'serviceToken');
 
   beforeAll(() => {
     mockServiceToken();
@@ -20,9 +23,10 @@ describe('vcap-service-destination', () => {
     mockServiceBindings();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     delete process.env.VCAP_SERVICES;
     jest.clearAllMocks();
+    await destinationCache.clear();
   });
 
   function getActualClientId(spyInstance: SpyInstance): string {
@@ -31,8 +35,9 @@ describe('vcap-service-destination', () => {
 
   it('creates a destination for the business logging service', async () => {
     await expect(
-      destinationForServiceBinding('my-business-logging', {
-        jwt: providerUserPayload
+      getDestinationFromServiceBinding({
+        destinationName: 'my-business-logging',
+        jwt: providerUserToken
       })
     ).resolves.toEqual({
       url: 'https://business-logging.my.example.com',
@@ -41,13 +46,14 @@ describe('vcap-service-destination', () => {
       authTokens: [expect.objectContaining({ value: expect.any(String) })]
     });
 
-    expect(getActualClientId(spy)).toBe('clientIdBusinessLogging');
+    expect(getActualClientId(serviceTokenSpy)).toBe('clientIdBusinessLogging');
   });
 
   it('creates ad destination for the xsuaa service', async () => {
     await expect(
-      destinationForServiceBinding('my-xsuaa', {
-        jwt: providerUserPayload
+      getDestinationFromServiceBinding({
+        destinationName: 'my-xsuaa',
+        jwt: providerUserToken
       })
     ).resolves.toEqual({
       url: 'https://api.authentication.sap.hana.ondemand.com',
@@ -56,13 +62,14 @@ describe('vcap-service-destination', () => {
       authTokens: [expect.objectContaining({ value: expect.any(String) })]
     });
 
-    expect(getActualClientId(spy)).toBe('clientIdXsUaa');
+    expect(getActualClientId(serviceTokenSpy)).toBe('clientIdXsUaa');
   });
 
   it('creates a destination for the service manager service', async () => {
     await expect(
-      destinationForServiceBinding('my-service-manager', {
-        jwt: providerUserPayload
+      getDestinationFromServiceBinding({
+        destinationName: 'my-service-manager',
+        jwt: providerUserToken
       })
     ).resolves.toEqual({
       url: 'https://service-manager.cfapps.sap.hana.ondemand.com',
@@ -71,13 +78,14 @@ describe('vcap-service-destination', () => {
       authTokens: [expect.objectContaining({ value: expect.any(String) })]
     });
 
-    expect(getActualClientId(spy)).toBe('clientIdServiceManager');
+    expect(getActualClientId(serviceTokenSpy)).toBe('clientIdServiceManager');
   });
 
   it('creates a destination for the destination service', async () => {
     await expect(
-      destinationForServiceBinding('my-destination-service', {
-        jwt: providerUserPayload
+      getDestinationFromServiceBinding({
+        destinationName: 'my-destination-service',
+        jwt: providerUserToken
       })
     ).resolves.toEqual({
       url: 'https://destination-configuration.cfapps.sap.hana.ondemand.com',
@@ -85,13 +93,14 @@ describe('vcap-service-destination', () => {
       name: 'my-destination-service',
       authTokens: [expect.objectContaining({ value: expect.any(String) })]
     });
-    expect(getActualClientId(spy)).toBe('clientIdDestination');
+    expect(getActualClientId(serviceTokenSpy)).toBe('clientIdDestination');
   });
 
   it('creates a destination for the saas registry', async () => {
     await expect(
-      destinationForServiceBinding('my-saas-registry', {
-        jwt: providerUserPayload
+      getDestinationFromServiceBinding({
+        destinationName: 'my-saas-registry',
+        jwt: providerUserToken
       })
     ).resolves.toEqual({
       url: 'https://saas-manager.mesh.cf.sap.hana.ondemand.com',
@@ -99,13 +108,14 @@ describe('vcap-service-destination', () => {
       name: 'my-saas-registry',
       authTokens: [expect.objectContaining({ value: expect.any(String) })]
     });
-    expect(getActualClientId(spy)).toBe('clientIdSaasRegistry');
+    expect(getActualClientId(serviceTokenSpy)).toBe('clientIdSaasRegistry');
   });
 
   it('creates a destination for the workflow', async () => {
     await expect(
-      destinationForServiceBinding('my-workflow', {
-        jwt: providerUserPayload
+      getDestinationFromServiceBinding({
+        destinationName: 'my-workflow',
+        jwt: providerUserToken
       })
     ).resolves.toEqual({
       url: 'https://api.workflow-sap.cfapps.sap.hana.ondemand.com/workflow-service/odata',
@@ -113,12 +123,12 @@ describe('vcap-service-destination', () => {
       name: 'my-workflow',
       authTokens: [expect.objectContaining({ value: expect.any(String) })]
     });
-    expect(getActualClientId(spy)).toBe('clientIdWorkFlow');
+    expect(getActualClientId(serviceTokenSpy)).toBe('clientIdWorkFlow');
   });
 
   it('creates a destination for the XF s4 hana cloud service', async () => {
     await expect(
-      destinationForServiceBinding('my-s4-hana-cloud')
+      getDestinationFromServiceBinding({ destinationName: 'my-s4-hana-cloud' })
     ).resolves.toEqual({
       url: 'https://my.example.com',
       authentication: 'BasicAuthentication',
@@ -128,18 +138,18 @@ describe('vcap-service-destination', () => {
   });
 
   it('uses the cache if enabled', async () => {
-    await destinationCache.clear();
-
-    await destinationForServiceBinding('my-destination-service', {
+    await getDestinationFromServiceBinding({
+      destinationName: 'my-destination-service',
       useCache: true,
-      jwt: providerUserPayload
+      jwt: providerUserToken
     });
-    await destinationForServiceBinding('my-destination-service', {
+    await getDestinationFromServiceBinding({
+      destinationName: 'my-destination-service',
       useCache: true,
-      jwt: providerUserPayload
+      jwt: providerUserToken
     });
 
-    expect(spy).toBeCalledTimes(1);
+    expect(serviceTokenSpy).toBeCalledTimes(1);
     expect(
       destinationCache
         .getCacheInstance()
@@ -153,7 +163,8 @@ describe('vcap-service-destination', () => {
     }));
 
     await expect(
-      destinationForServiceBinding('my-custom-service', {
+      getDestinationFromServiceBinding({
+        destinationName: 'my-custom-service',
         serviceBindingTransformFn
       })
     ).resolves.toEqual({
@@ -163,16 +174,19 @@ describe('vcap-service-destination', () => {
   });
 
   it('throws an error if the service type is not supported', async () => {
-    await expect(() => destinationForServiceBinding('my-custom-service'))
-      .rejects.toThrowErrorMatchingInlineSnapshot(`
-      "The service "my-custom-service" is of type "undefined" which is not supported! Consider providing your own transformation function when calling destinationForServiceBinding, like this:
+    await expect(() =>
+      getDestinationFromServiceBinding({ destinationName: 'my-custom-service' })
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      "The service "my-custom-service" is of type "undefined" which is not supported! Consider providing your own transformation function when calling \`getDestinationFromServiceBinding()\`, like this:
         destinationServiceForBinding(yourServiceName, { serviceBindingToDestination: yourTransformationFunction });"
     `);
   });
 
   it('throws an error if no service binding can be found for the given name', async () => {
     await expect(() =>
-      destinationForServiceBinding('non-existent-service')
+      getDestinationFromServiceBinding({
+        destinationName: 'non-existent-service'
+      })
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       '"Could not find service with name: \'non-existent-service\'."'
     );
@@ -192,6 +206,66 @@ describe('vcap-service-destination', () => {
       url: 'https://custom-service.my.example.com'
     });
     expect(serviceBindingTransformFn).toBeCalledTimes(1);
+  });
+
+  it('sets forwarded auth token if needed (uncached)', async () => {
+    const jwt = signedJwt({});
+
+    const destination = await getDestinationFromServiceBinding({
+      destinationName: 'my-custom-service',
+      jwt,
+      serviceBindingTransformFn: async ({ name }) => ({
+        forwardAuthToken: true,
+        name
+      })
+    });
+
+    expect(destination?.authTokens?.[0]).toMatchObject({ value: jwt });
+  });
+
+  it('sets forwarded auth token if needed (cached)', async () => {
+    const jwt = signedJwt({ zid: 'tenant' });
+
+    destinationCache.cacheRetrievedDestination(
+      decodeJwt(jwt),
+      {
+        name: 'my-custom-service',
+        forwardAuthToken: true
+      },
+      'tenant'
+    );
+
+    const destination = await getDestinationFromServiceBinding({
+      destinationName: 'my-custom-service',
+      useCache: true,
+      jwt
+    });
+
+    expect(destination?.authTokens?.[0]).toMatchObject({ value: jwt });
+  });
+
+  // TODO: fix in #1123
+  it.skip('does not cache the forwarded token', async () => {
+    const jwt = signedJwt({ zid: 'tenant' });
+
+    await getDestinationFromServiceBinding({
+      destinationName: 'my-custom-service',
+      useCache: true,
+      jwt,
+      serviceBindingTransformFn: async ({ name }) => ({
+        forwardAuthToken: true,
+        name
+      })
+    });
+
+    const destination = await destinationCache.retrieveDestinationFromCache(
+      decodeJwt(jwt),
+      'my-custom-service',
+      'tenant'
+    );
+
+    expect(destination).toBeDefined();
+    expect(destination?.authTokens).toBeUndefined();
   });
 });
 

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
@@ -114,7 +114,7 @@ async function retrieveDestinationWithoutCache({
  * @param serviceInstanceName - The name of the service.
  * @param options - Options to customize the behavior of this function.
  * @returns A destination.
- * @deprecated Since v3.4.0. Use {@link `getDestinationFromServiceBinding()`} instead.
+ * @deprecated Since v3.4.0. Use {@link getDestinationFromServiceBinding} instead.
  */
 export async function destinationForServiceBinding(
   serviceInstanceName: string,

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
@@ -3,6 +3,7 @@ import { JwtPayload } from '../jsonwebtoken-type';
 import { decodeJwt, decodeOrMakeJwt } from '../jwt';
 import { Service } from '../environment-accessor/environment-accessor-types';
 import { getServiceBindingByInstanceName } from '../environment-accessor';
+import { CachingOptions } from '../cache';
 import {
   addProxyConfigurationInternet,
   proxyStrategy
@@ -11,6 +12,7 @@ import { Destination, isHttpDestination } from './destination-service-types';
 import type { DestinationFetchOptions } from './destination-accessor-types';
 import { destinationCache } from './destination-cache';
 import { serviceToDestinationTransformers } from './service-binding-to-destination';
+import { setForwardedAuthTokenIfNeeded } from './forward-auth-token';
 
 const logger = createLogger({
   package: 'connectivity',
@@ -18,17 +20,91 @@ const logger = createLogger({
 });
 
 /**
+ * @deprecated Since v3.4.0. Use either `ServiceBindingTransformOptions` or `getDestinationFromServiceBinding`.
  * Represents partial options to fetch destinations.
  */
-export interface PartialDestinationFetchOptions {
+export type PartialDestinationFetchOptions = {
   /**
-   * The fetched destination will be cached if set to true.
-   */
-  useCache?: boolean;
-  /**
-   * The jwt payload used to fetch destinations.
+   * The JWT used to fetch destinations.
+   * The use of `JwtPayload` is deprecated since v3.4.0 and will be removed in the next major version update.
+   * Use `string` instead.
    */
   jwt?: JwtPayload;
+} & CachingOptions;
+
+/**
+ * Tries to build a destination from a service binding with the given name.
+ * Throws an error if no services are bound at all, no service with the given name can be found, or the service type is not supported.
+ * The last error can be circumvent by using the second parameter to provide a custom function that transforms a service binding to a destination.
+ * @param options - Options to customize the behavior of this function.
+ * @returns A destination.
+ */
+export async function getDestinationFromServiceBinding(
+  options: Pick<
+    DestinationFetchOptions,
+    'jwt' | 'iss' | 'useCache' | 'destinationName'
+  > &
+    DestinationForServiceBindingOptions
+): Promise<Destination> {
+  const decodedJwt = options.iss
+    ? { iss: options.iss }
+    : options.jwt
+    ? decodeJwt(options.jwt)
+    : undefined;
+
+  const retrievalOptions = { ...options, jwt: decodedJwt };
+  const destination =
+    (await retrieveDestinationFromCache(retrievalOptions)) ||
+    (await retrieveDestinationWithoutCache(retrievalOptions));
+
+  const destWithProxy =
+    destination &&
+    isHttpDestination(destination) &&
+    ['internet', 'private-link'].includes(proxyStrategy(destination))
+      ? addProxyConfigurationInternet(destination)
+      : destination;
+
+  if (options.useCache) {
+    // As the grant type is clientCredential, isolation strategy is 'tenant'.
+    await destinationCache.cacheRetrievedDestination(
+      decodeOrMakeJwt(options.jwt),
+      destWithProxy,
+      'tenant'
+    );
+  }
+
+  setForwardedAuthTokenIfNeeded(destWithProxy, options.jwt);
+
+  return destWithProxy;
+}
+
+async function retrieveDestinationFromCache(
+  options: Pick<DestinationFetchOptions, 'useCache' | 'destinationName'> & {
+    jwt?: JwtPayload;
+  }
+) {
+  if (options.useCache) {
+    return destinationCache.retrieveDestinationFromCache(
+      decodeOrMakeJwt(options.jwt),
+      options.destinationName,
+      'tenant'
+    );
+  }
+}
+
+async function retrieveDestinationWithoutCache({
+  useCache,
+  jwt,
+  destinationName,
+  serviceBindingTransformFn
+}: Pick<DestinationFetchOptions, 'useCache' | 'destinationName'> & {
+  jwt?: JwtPayload;
+} & DestinationForServiceBindingOptions) {
+  const selected = getServiceBindingByInstanceName(destinationName);
+  return (serviceBindingTransformFn || transform)(selected, {
+    useCache,
+    jwt
+  });
 }
 
 /**
@@ -38,6 +114,7 @@ export interface PartialDestinationFetchOptions {
  * @param serviceInstanceName - The name of the service.
  * @param options - Options to customize the behavior of this function.
  * @returns A destination.
+ * @deprecated Since v3.4.0. Use {@link `getDestinationForServiceBinding`} instead.
  */
 export async function destinationForServiceBinding(
   serviceInstanceName: string,
@@ -45,20 +122,25 @@ export async function destinationForServiceBinding(
     PartialDestinationFetchOptions = {}
 ): Promise<Destination> {
   if (options.useCache) {
-    const fromCache = await destinationCache.retrieveDestinationFromCache(
-      decodeOrMakeJwt(options.jwt),
-      serviceInstanceName,
-      'tenant'
-    );
-    if (fromCache) {
-      return fromCache;
+    const destinationFromCache =
+      await destinationCache.retrieveDestinationFromCache(
+        decodeOrMakeJwt(options.jwt),
+        serviceInstanceName,
+        'tenant'
+      );
+
+    if (destinationFromCache) {
+      return destinationFromCache;
     }
   }
 
-  const selected = getServiceBindingByInstanceName(serviceInstanceName)!;
-  const destination = options.serviceBindingTransformFn
-    ? await options.serviceBindingTransformFn(selected, options)
-    : await transform(selected, options);
+  const optionsForTransformation = {
+    useCache: options.useCache,
+    jwt: options.jwt
+  };
+  const selected = getServiceBindingByInstanceName(serviceInstanceName);
+  const transformFn = options.serviceBindingTransformFn || transform;
+  const destination = await transformFn(selected, optionsForTransformation);
 
   const destWithProxy =
     destination &&
@@ -80,7 +162,7 @@ export async function destinationForServiceBinding(
 }
 
 /**
- * Options to customize the behavior of {@link destinationForServiceBinding}.
+ * Options to customize the behavior of {@link getDestinationFromServiceBinding}.
  */
 export interface DestinationForServiceBindingOptions {
   /**
@@ -90,16 +172,26 @@ export interface DestinationForServiceBindingOptions {
 }
 
 /**
+ * Represents options passed to the service binding transform function.
+ */
+export type ServiceBindingTransformOptions = {
+  /**
+   * The JWT payload used to fetch destinations.
+   */
+  jwt?: JwtPayload;
+} & CachingOptions;
+
+/**
  * Type of the function to transform the service binding.
  */
 export type ServiceBindingTransformFunction = (
   service: Service,
-  options?: PartialDestinationFetchOptions
+  options?: ServiceBindingTransformOptions
 ) => Promise<Destination>;
 
 async function transform(
   service: Service,
-  options?: PartialDestinationFetchOptions
+  options?: ServiceBindingTransformOptions
 ): Promise<Destination> {
   if (!serviceToDestinationTransformers[service.label]) {
     throw serviceTypeNotSupportedError(service);
@@ -109,31 +201,23 @@ async function transform(
 }
 
 function serviceTypeNotSupportedError(service: Service): Error {
-  return Error(`The service "${service.name}" is of type "${service.label}" which is not supported! Consider providing your own transformation function when calling destinationForServiceBinding, like this:
+  return Error(`The service "${service.name}" is of type "${service.label}" which is not supported! Consider providing your own transformation function when calling \`getDestinationFromServiceBinding()\`, like this:
   destinationServiceForBinding(yourServiceName, { serviceBindingToDestination: yourTransformationFunction });`);
 }
 
 /**
  * @internal
  */
-export async function searchServiceBindingForDestination({
-  iss,
-  jwt,
-  serviceBindingTransformFn,
-  destinationName,
-  useCache
-}: DestinationFetchOptions &
-  DestinationForServiceBindingOptions): Promise<Destination | null> {
+export async function searchServiceBindingForDestination(
+  options: DestinationFetchOptions & DestinationForServiceBindingOptions
+): Promise<Destination | null> {
   logger.debug('Attempting to retrieve destination from service binding.');
   try {
-    const jwtFromOptions = iss ? { iss } : jwt ? decodeJwt(jwt) : undefined;
-    const useCacheIgnoringUndefined =
-      typeof useCache !== 'undefined' ? { useCache } : {};
-    const destination = await destinationForServiceBinding(destinationName, {
-      serviceBindingTransformFn,
-      jwt: jwtFromOptions,
-      ...useCacheIgnoringUndefined
-    });
+    // TODO: Why did we do this?
+    // const useCacheIgnoringUndefined =
+    //   typeof useCache !== 'undefined' ? { useCache } : {};
+    const destination = await getDestinationFromServiceBinding(options);
+
     logger.info('Successfully retrieved destination from service binding.');
     return destination;
   } catch (error) {

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
@@ -114,7 +114,7 @@ async function retrieveDestinationWithoutCache({
  * @param serviceInstanceName - The name of the service.
  * @param options - Options to customize the behavior of this function.
  * @returns A destination.
- * @deprecated Since v3.4.0. Use {@link `getDestinationForServiceBinding`} instead.
+ * @deprecated Since v3.4.0. Use {@link `getDestinationFromServiceBinding()`} instead.
  */
 export async function destinationForServiceBinding(
   serviceInstanceName: string,

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
@@ -213,9 +213,6 @@ export async function searchServiceBindingForDestination(
 ): Promise<Destination | null> {
   logger.debug('Attempting to retrieve destination from service binding.');
   try {
-    // TODO: Why did we do this?
-    // const useCacheIgnoringUndefined =
-    //   typeof useCache !== 'undefined' ? { useCache } : {};
     const destination = await getDestinationFromServiceBinding(options);
 
     logger.info('Successfully retrieved destination from service binding.');

--- a/packages/connectivity/src/scp-cf/destination/destination.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination.spec.ts
@@ -44,6 +44,31 @@ describe('parseDestination', () => {
     expect(actual.isTrustingAllCertificates).toBe(false);
   });
 
+  it('parses `forwardAuthToken` as boolean', () => {
+    const destination = parseDestination({
+      URL: 'https://example.com',
+      forwardAuthToken: 'true'
+    });
+    expect(destination.forwardAuthToken).toBe(true);
+  });
+
+  it('parses `HTML5.ForwardAuthToken` as boolean', () => {
+    const destination = parseDestination({
+      URL: 'https://example.com',
+      'HTML5.ForwardAuthToken': 'true'
+    });
+    expect(destination.forwardAuthToken).toBe(true);
+  });
+
+  it('`forwardAuthToken` overwrites `HTML5.ForwardAuthToken` as boolean', () => {
+    const destination = parseDestination({
+      URL: 'https://example.com',
+      forwardAuthToken: 'false',
+      'HTML5.ForwardAuthToken': 'true'
+    });
+    expect(destination.forwardAuthToken).toBe(false);
+  });
+
   it("'jwks' is correctly parsed", () => {
     const actual = parseDestination({
       ...basicMultipleResponse[0],

--- a/packages/connectivity/src/scp-cf/destination/destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination.ts
@@ -290,11 +290,12 @@ function setForwardAuthToken(
 ): Destination {
   const forwardAuthToken =
     destination.originalProperties?.forwardAuthToken ??
-    destination.originalProperties?.['HTML5.ForwardAuthToken'];
+    destination.originalProperties?.['HTML5.ForwardAuthToken'] ??
+    destination.forwardAuthToken;
 
   return {
     ...destination,
-    forwardAuthToken: forwardAuthToken === 'true'
+    forwardAuthToken: forwardAuthToken === 'true' || forwardAuthToken === true
   };
 }
 

--- a/packages/connectivity/src/scp-cf/destination/destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination.ts
@@ -20,11 +20,12 @@ import {
 export function sanitizeDestination(
   destination: Record<string, any>
 ): Destination {
-  const destAuthToken = parseAuthTokens(destination);
-  let parsedDestination = parseCertificates(destAuthToken) as Destination;
+  let parsedDestination = parseAuthTokens(destination);
+  parsedDestination = parseCertificates(parsedDestination) as Destination;
 
   parsedDestination = setDefaultAuthenticationFallback(parsedDestination);
   parsedDestination = setTrustAll(parsedDestination);
+  parsedDestination = setForwardAuthToken(parsedDestination);
   parsedDestination = setOriginalProperties(parsedDestination);
 
   return parsedDestination;
@@ -33,7 +34,7 @@ export function sanitizeDestination(
 /**
  * Takes a JSON object returned by any of the calls to the destination service and returns an SDK compatible destination object.
  * This function only accepts destination configurations of type 'HTTP' and will error if no 'URL' is given.
- * TODO: Remove from public api in version 3. (Check if related types can also be removed from public api).
+ * TODO: deprecated: Remove from public api in version 4. (Check if related types can also be removed from public api).
  * @param destinationJson - A JSON object returned by the destination service.
  * @returns An SDK compatible destination object.
  */
@@ -284,6 +285,19 @@ function getAuthenticationType(destination: Destination): AuthenticationType {
     : 'NoAuthentication';
 }
 
+function setForwardAuthToken(
+  destination: Destination & { forwardAuthToken?: string }
+): Destination {
+  const forwardAuthToken =
+    destination.originalProperties?.forwardAuthToken ??
+    destination.originalProperties?.['HTML5.ForwardAuthToken'];
+
+  return {
+    ...destination,
+    forwardAuthToken: forwardAuthToken === 'true'
+  };
+}
+
 /**
  * Destination configuration alongside auth tokens and certificates.
  */
@@ -422,7 +436,12 @@ const configMapping: Record<string, keyof Destination> = {
   /**
    * URI of the JSON web key set, containing the signing keys which are used to validate the JWT provided in the X-User-Token header.
    */
-  'x_user_token.jwks_uri': 'jwksUri'
+  'x_user_token.jwks_uri': 'jwksUri',
+  'HTML5.ForwardAuthToken': 'forwardAuthToken',
+  /**
+   * This overwrites `HTML5.ForwardAuthToken`, if both exist (during sanitize).
+   */
+  forwardAuthToken: 'forwardAuthToken'
 };
 
 /**

--- a/packages/connectivity/src/scp-cf/destination/forward-auth-token.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/forward-auth-token.spec.ts
@@ -1,0 +1,36 @@
+import { createLogger } from '@sap-cloud-sdk/util';
+import { signedJwt } from '../../../../../test-resources/test/test-util';
+import { setForwardedAuthTokenIfNeeded } from './forward-auth-token';
+
+describe('forward auth token', () => {
+  describe('setForwardedAuthTokenIfNeeded', () => {
+    it('sets an auth token, when `forwardAuthToken` is set', () => {
+      const jwt = signedJwt({});
+      const destination = setForwardedAuthTokenIfNeeded(
+        { forwardAuthToken: true },
+        jwt
+      );
+      expect(destination.authTokens?.[0]).toMatchObject(
+        expect.objectContaining({ value: jwt })
+      );
+    });
+
+    it('does not set an auth token, when `forwardAuthToken` is not set', () => {
+      const jwt = signedJwt({});
+      const destination = setForwardedAuthTokenIfNeeded({}, jwt);
+      expect(destination.authTokens).toBeUndefined();
+    });
+
+    it('shows a warning if `forwardAuthToken` is enabled, but no jwt is passed', () => {
+      const logger = createLogger({
+        messageContext: 'forward-auth-token'
+      });
+
+      const warnSpy = jest.spyOn(logger, 'warn');
+      setForwardedAuthTokenIfNeeded({ forwardAuthToken: true });
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Option 'forwardAuthToken' was set on destination but no token was provided to forward. This is most likely unintended and will lead to an authorization error on request execution."
+      );
+    });
+  });
+});

--- a/packages/connectivity/src/scp-cf/destination/forward-auth-token.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/forward-auth-token.spec.ts
@@ -3,32 +3,42 @@ import { signedJwt } from '../../../../../test-resources/test/test-util';
 import { setForwardedAuthTokenIfNeeded } from './forward-auth-token';
 
 describe('forward auth token', () => {
-  describe('setForwardedAuthTokenIfNeeded', () => {
-    it('sets an auth token, when `forwardAuthToken` is set', () => {
-      const jwt = signedJwt({});
-      const destination = setForwardedAuthTokenIfNeeded(
-        { forwardAuthToken: true },
-        jwt
-      );
-      expect(destination.authTokens?.[0]).toMatchObject({ value: jwt });
+  it('sets an auth token, when `forwardAuthToken` is set', () => {
+    const jwt = signedJwt({});
+    const destination = setForwardedAuthTokenIfNeeded(
+      { forwardAuthToken: true },
+      jwt
+    );
+    expect(destination.authTokens?.[0]).toMatchObject({ value: jwt });
+  });
+
+  it('does not set an auth token, when `forwardAuthToken` is not set', () => {
+    const jwt = signedJwt({});
+    const destination = setForwardedAuthTokenIfNeeded({}, jwt);
+    expect(destination.authTokens).toBeUndefined();
+  });
+
+  it('shows a warning if `forwardAuthToken` is enabled, but no JWT is passed', () => {
+    const logger = createLogger({
+      messageContext: 'forward-auth-token'
     });
 
-    it('does not set an auth token, when `forwardAuthToken` is not set', () => {
-      const jwt = signedJwt({});
-      const destination = setForwardedAuthTokenIfNeeded({}, jwt);
-      expect(destination.authTokens).toBeUndefined();
+    const warnSpy = jest.spyOn(logger, 'warn');
+    setForwardedAuthTokenIfNeeded({ forwardAuthToken: true });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Option 'forwardAuthToken' was set on destination but no token was provided to forward. This is most likely unintended and will lead to an authorization error on request execution."
+    );
+  });
+
+  it('shows a warning if `forwardAuthToken` is enabled, but passed JWT is encoded', () => {
+    const logger = createLogger({
+      messageContext: 'forward-auth-token'
     });
 
-    it('shows a warning if `forwardAuthToken` is enabled, but no jwt is passed', () => {
-      const logger = createLogger({
-        messageContext: 'forward-auth-token'
-      });
-
-      const warnSpy = jest.spyOn(logger, 'warn');
-      setForwardedAuthTokenIfNeeded({ forwardAuthToken: true });
-      expect(warnSpy).toHaveBeenCalledWith(
-        "Option 'forwardAuthToken' was set on destination but no token was provided to forward. This is most likely unintended and will lead to an authorization error on request execution."
-      );
-    });
+    const warnSpy = jest.spyOn(logger, 'warn');
+    setForwardedAuthTokenIfNeeded({ forwardAuthToken: true }, {});
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Option 'forwardAuthToken' was set on destination but the provided token is decoded. To use 'forwardAuthToken', provide an encoded token. This is most likely unintended and will lead to an authorization error on request execution."
+    );
   });
 });

--- a/packages/connectivity/src/scp-cf/destination/forward-auth-token.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/forward-auth-token.spec.ts
@@ -10,9 +10,7 @@ describe('forward auth token', () => {
         { forwardAuthToken: true },
         jwt
       );
-      expect(destination.authTokens?.[0]).toMatchObject(
-        expect.objectContaining({ value: jwt })
-      );
+      expect(destination.authTokens?.[0]).toMatchObject({ value: jwt });
     });
 
     it('does not set an auth token, when `forwardAuthToken` is not set', () => {

--- a/packages/connectivity/src/scp-cf/destination/forward-auth-token.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/forward-auth-token.spec.ts
@@ -29,16 +29,4 @@ describe('forward auth token', () => {
       "Option 'forwardAuthToken' was set on destination but no token was provided to forward. This is most likely unintended and will lead to an authorization error on request execution."
     );
   });
-
-  it('shows a warning if `forwardAuthToken` is enabled, but passed JWT is encoded', () => {
-    const logger = createLogger({
-      messageContext: 'forward-auth-token'
-    });
-
-    const warnSpy = jest.spyOn(logger, 'warn');
-    setForwardedAuthTokenIfNeeded({ forwardAuthToken: true }, {});
-    expect(warnSpy).toHaveBeenCalledWith(
-      "Option 'forwardAuthToken' was set on destination but the provided token is decoded. To use 'forwardAuthToken', provide an encoded token. This is most likely unintended and will lead to an authorization error on request execution."
-    );
-  });
 });

--- a/packages/connectivity/src/scp-cf/destination/forward-auth-token.ts
+++ b/packages/connectivity/src/scp-cf/destination/forward-auth-token.ts
@@ -1,6 +1,5 @@
 import { createLogger } from '@sap-cloud-sdk/util';
 import { decodeJwt } from '../jwt';
-import { JwtPayload } from '../jsonwebtoken-type';
 import { Destination, DestinationAuthToken } from './destination-service-types';
 
 const logger = createLogger({
@@ -29,20 +28,13 @@ function buildDestinationAuthToken(
   ];
 }
 
-// TODO: deprecated: The use of JWTPayload should be removed in the next major version
-function validateToken(
-  token: string | JwtPayload | undefined
-): token is string {
+function validateToken(token: string | undefined): token is string {
   if (!token) {
     logger.warn(
       "Option 'forwardAuthToken' was set on destination but no token was provided to forward. This is most likely unintended and will lead to an authorization error on request execution."
     );
-  } else if (typeof token !== 'string') {
-    logger.warn(
-      "Option 'forwardAuthToken' was set on destination but the provided token is decoded. To use 'forwardAuthToken', provide an encoded token. This is most likely unintended and will lead to an authorization error on request execution."
-    );
   }
-  return typeof token === 'string';
+  return !!token;
 }
 
 /**
@@ -53,7 +45,7 @@ function validateToken(
  */
 export function setForwardedAuthTokenIfNeeded(
   destination: Destination,
-  token?: string | JwtPayload
+  token?: string
 ): Destination {
   if (destination.forwardAuthToken) {
     if (validateToken(token)) {

--- a/packages/connectivity/src/scp-cf/destination/forward-auth-token.ts
+++ b/packages/connectivity/src/scp-cf/destination/forward-auth-token.ts
@@ -1,0 +1,52 @@
+import { createLogger } from '@sap-cloud-sdk/util';
+import { decodeJwt } from '../jwt';
+import { Destination, DestinationAuthToken } from './destination-service-types';
+
+const logger = createLogger({
+  package: 'connectivity',
+  messageContext: 'forward-auth-token'
+});
+
+/**
+ * Transform a token to the format given by the destination service.
+ * @param token - Token to transform.
+ * @returns The transformed token.
+ */
+function buildDestinationAuthToken(
+  token?: string
+): [DestinationAuthToken] | undefined {
+  if (token) {
+    const decoded = decodeJwt(token);
+    logger.debug(
+      "Option 'forwardAuthToken' enabled on destination. Using the given token for the destination."
+    );
+    return [
+      {
+        value: token,
+        expiresIn: decoded.exp?.toString(),
+        error: null,
+        http_header: { key: 'Authorization', value: `Bearer ${token}` },
+        type: 'Bearer'
+      }
+    ];
+  }
+  logger.warn(
+    "Option 'forwardAuthToken' was set on destination but no token was provided to forward. This is most likely unintended and will lead to an authorization error on request execution."
+  );
+}
+
+/**
+ * @internal
+ * Set forwarded auth token, if needed.
+ * @param destination - Destination to set the token on, if needed.
+ * @param token - Token to forward, if needed.
+ */
+export function setForwardedAuthTokenIfNeeded(
+  destination: Destination,
+  token?: string
+): Destination {
+  if (destination.forwardAuthToken) {
+    destination.authTokens = buildDestinationAuthToken(token);
+  }
+  return destination;
+}

--- a/packages/connectivity/src/scp-cf/destination/index.ts
+++ b/packages/connectivity/src/scp-cf/destination/index.ts
@@ -10,6 +10,7 @@ export * from './destination-service-cache';
 export * from './destination-service-types';
 export * from './destination-service';
 export * from './destination';
+export * from './forward-auth-token';
 export * from './get-subscriber-token';
 export * from './get-provider-token';
 export * from './http-proxy-util';

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
@@ -2,8 +2,8 @@ import { Service } from '../environment-accessor/environment-accessor-types';
 import { serviceToken } from '../token-accessor';
 import { decodeJwt } from '../jwt';
 import type {
-  PartialDestinationFetchOptions,
-  ServiceBindingTransformFunction
+  ServiceBindingTransformFunction,
+  ServiceBindingTransformOptions
 } from './destination-from-vcap';
 import { Destination } from './destination-service-types';
 
@@ -25,7 +25,7 @@ export const serviceToDestinationTransformers: Record<
 
 async function xsuaaToDestination(
   service: Service,
-  options?: PartialDestinationFetchOptions
+  options?: ServiceBindingTransformOptions
 ): Promise<Destination> {
   const token = await serviceToken(service, options);
   return buildClientCredentialsDestination(
@@ -37,7 +37,7 @@ async function xsuaaToDestination(
 
 async function serviceManagerBindingToDestination(
   service: Service,
-  options?: PartialDestinationFetchOptions
+  options?: ServiceBindingTransformOptions
 ): Promise<Destination> {
   const token = await serviceToken(service, options);
   return buildClientCredentialsDestination(
@@ -49,7 +49,7 @@ async function serviceManagerBindingToDestination(
 
 async function destinationBindingToDestination(
   service: Service,
-  options?: PartialDestinationFetchOptions
+  options?: ServiceBindingTransformOptions
 ): Promise<Destination> {
   const token = await serviceToken(service, options);
   return buildClientCredentialsDestination(
@@ -61,7 +61,7 @@ async function destinationBindingToDestination(
 
 async function saasRegistryBindingToDestination(
   service: Service,
-  options?: PartialDestinationFetchOptions
+  options?: ServiceBindingTransformOptions
 ): Promise<Destination> {
   const token = await serviceToken(service, options);
   return buildClientCredentialsDestination(
@@ -73,7 +73,7 @@ async function saasRegistryBindingToDestination(
 
 async function businessLoggingBindingToDestination(
   service: Service,
-  options?: PartialDestinationFetchOptions
+  options?: ServiceBindingTransformOptions
 ): Promise<Destination> {
   const transformedService = {
     ...service,
@@ -89,7 +89,7 @@ async function businessLoggingBindingToDestination(
 
 async function workflowBindingToDestination(
   service: Service,
-  options?: PartialDestinationFetchOptions
+  options?: ServiceBindingTransformOptions
 ): Promise<Destination> {
   const transformedService = {
     ...service,

--- a/packages/connectivity/src/scp-cf/environment-accessor/service-bindings.ts
+++ b/packages/connectivity/src/scp-cf/environment-accessor/service-bindings.ts
@@ -69,7 +69,7 @@ export function resolveServiceBinding(service: string | Service): Service {
  */
 export function getServiceBindingByInstanceName(
   serviceInstanceName: string
-): Service | undefined {
+): Service {
   const service = xsenv.filterServices(serviceInstanceName);
 
   if (!service.length) {

--- a/packages/connectivity/src/scp-cf/token-accessor.ts
+++ b/packages/connectivity/src/scp-cf/token-accessor.ts
@@ -27,7 +27,7 @@ export async function serviceToken(
   service: string | Service,
   options?: CachingOptions & {
     jwt?: string | JwtPayload;
-    // TODO: 4.0 Remove
+    // TODO: deprecated: 4.0 Remove
     xsuaaCredentials?: XsuaaServiceCredentials;
   }
 ): Promise<string> {

--- a/packages/generator-common/src/file-writer/create-file.spec.ts
+++ b/packages/generator-common/src/file-writer/create-file.spec.ts
@@ -126,7 +126,7 @@ describe('createFile', () => {
 
   it('uses default config if custom prettier config is not found', async () => {
     const logger = createLogger('create-file');
-    const spy = jest.spyOn(prettier, 'format');
+    jest.spyOn(prettier, 'format');
     const loggerSpy = jest.spyOn(logger, 'warn');
     const defaultConfig = await readPrettierConfig('not-existing/.prettierrc');
 

--- a/packages/odata-common/src/request/odata-request.ts
+++ b/packages/odata-common/src/request/odata-request.ts
@@ -228,12 +228,11 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
    * @returns Promise resolving to the requested data.
    */
   async execute(): Promise<HttpResponse> {
-    const destination = this.destination;
-    if (!destination) {
+    if (!this.destination) {
       throw Error('The destination cannot be undefined.');
     }
 
-    return executeHttpRequest(destination, await this.requestConfig(), {
+    return executeHttpRequest(this.destination, await this.requestConfig(), {
       fetchCsrfToken: this.config.fetchCsrfToken
     }).catch(error => {
       throw constructError(error, this.config.method, this.serviceUrl());

--- a/yarn.lock
+++ b/yarn.lock
@@ -2404,11 +2404,6 @@ base64-js@^1.3.1:
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-base64url@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
-  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
-
 basic-ftp@^5.0.2:
   version "5.0.3"
   resolved "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz#b14c0fe8111ce001ec913686434fe0c2fb461228"


### PR DESCRIPTION
This allows to set `forwardAuthToken` on all types of destinations. Previously this was only possible for registered destinations.

Closes https://github.com/SAP/cloud-sdk-backlog/issues/1121.