### PR TITLE
fix: revert v2 serializer behavior for Edm.decimal

### DIFF
--- a/.changeset/brave-tables-fetch.md
+++ b/.changeset/brave-tables-fetch.md
@@ -4,4 +4,4 @@
 '@sap-cloud-sdk/odata-v4': patch
 ---
 
-[Fixed Issue]: Revert v2 serializer behavior for Edm.decimal so that for v2, all the Edm.decimal will be serialized as string.
+[Fixed Issue]: Fix OData v2 serialization for `Edm.Decimal` to serialize to `string`.

--- a/.changeset/brave-tables-fetch.md
+++ b/.changeset/brave-tables-fetch.md
@@ -1,0 +1,7 @@
+---
+'@sap-cloud-sdk/odata-common': patch
+'@sap-cloud-sdk/odata-v2': patch
+'@sap-cloud-sdk/odata-v4': patch
+---
+
+[Fixed Issue]: Revert v2 serializer behavior for Edm.decimal so that for v2, all the Edm.decimal will be serialized as string.

--- a/packages/odata-common/src/de-serializers/default-de-serializers.ts
+++ b/packages/odata-common/src/de-serializers/default-de-serializers.ts
@@ -108,17 +108,7 @@ export const defaultDeSerializersRaw: DefaultDeSerializers = {
   /* DeSerializers with v2 and v4 specific URI serializer defaults. */
   'Edm.Decimal': {
     deserialize: deserializeToBigNumber,
-    serialize: value => {
-      const primitiveNumber =
-        typeof value === 'number' ? value : value.toNumber();
-      if (
-        primitiveNumber <= Number.MAX_SAFE_INTEGER &&
-        primitiveNumber >= Number.MIN_SAFE_INTEGER
-      ) {
-        return primitiveNumber;
-      }
-      return serializeFromBigNumber(value);
-    }
+    serialize: serializeFromBigNumber
   },
   'Edm.Guid': {
     deserialize: validateGuid,

--- a/packages/odata-v2/src/de-serializers/payload-value-converter.spec.ts
+++ b/packages/odata-v2/src/de-serializers/payload-value-converter.spec.ts
@@ -176,7 +176,7 @@ describe('tsToEdm()', () => {
   });
 
   it('should parse BigNumber to Edm.Decimal', () => {
-    const expected = 1.23;
+    const expected = '1.23';
     const actual = tsToEdm(
       new BigNumber('1.23'),
       'Edm.Decimal',

--- a/packages/odata-v2/src/de-serializers/payload-value-converter.spec.ts
+++ b/packages/odata-v2/src/de-serializers/payload-value-converter.spec.ts
@@ -317,7 +317,7 @@ describe('EDM to ts to EDM does not lead to information loss', () => {
   });
 
   it('Edm.Decimal', () => {
-    const expected = 123456.789;
+    const expected = '123456.789';
     expect(
       tsToEdm(
         edmToTs(expected, 'Edm.Decimal', defaultDeSerializers),

--- a/packages/odata-v4/src/de-serializers/default-de-serializers.ts
+++ b/packages/odata-v4/src/de-serializers/default-de-serializers.ts
@@ -76,7 +76,18 @@ const defaultDeSerializersRaw: DefaultDeSerializers = {
   },
   /* DeSerializers with v4 specific URI serializer defaults. */
   'Edm.Decimal': {
-    ...defaultDeSerializersCommon['Edm.Decimal'],
+    deserialize: defaultDeSerializersCommon['Edm.Decimal'].deserialize,
+    serialize: value => {
+      const primitiveNumber =
+        typeof value === 'number' ? value : value.toNumber();
+      if (
+        primitiveNumber <= Number.MAX_SAFE_INTEGER &&
+        primitiveNumber >= Number.MIN_SAFE_INTEGER
+      ) {
+        return primitiveNumber;
+      }
+      return defaultDeSerializersCommon['Edm.Decimal'].serialize(value);
+    },
     serializeToUri: (value, serialize) => String(serialize(value))
   },
   'Edm.Guid': {


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->
For odata-v2, Edm.decimal should always serialize as a string. This PR reverts the change for odata-v2 done in https://github.com/SAP/cloud-sdk-js/pull/4020.

Closes SAP/cloud-sdk-backlog#1087.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
