### PR TITLE
fix: Support ClientCertificateAuthentication without password

### DIFF
--- a/.changeset/quiet-zebras-call.md
+++ b/.changeset/quiet-zebras-call.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+---
+
+[Fixed Issue] Support destinations of type `ClientCertificateAuthentication` without password.

--- a/packages/connectivity/src/http-agent/http-agent.spec.ts
+++ b/packages/connectivity/src/http-agent/http-agent.spec.ts
@@ -163,6 +163,30 @@ describe('createAgent', () => {
     ).toMatchObject(expectedOptions);
   });
 
+  it('returns an agent with certificate and no passphrase for authentication type ClientCertificateAuthentication', async () => {
+    const destination: HttpDestination = {
+      url: 'https://destination.example.com',
+      authentication: 'ClientCertificateAuthentication',
+      keyStoreName: 'cert.p12',
+      certificates: [
+        {
+          name: 'cert.p12',
+          content: 'base64string',
+          type: 'CERTIFICATE'
+        }
+      ]
+    };
+
+    const expectedOptions = {
+      rejectUnauthorized: true,
+      pfx: Buffer.from('base64string', 'base64')
+    };
+
+    expect(
+      (await getAgentConfigAsync(destination))['httpsAgent']['options']
+    ).toMatchObject(expectedOptions);
+  });
+
   it("does not return an agent for destinations with authentication types that have a certificate but don't use MTLS", async () => {
     const destination: HttpDestination = {
       url: 'https://destination.example.com',

--- a/packages/connectivity/src/http-agent/http-agent.ts
+++ b/packages/connectivity/src/http-agent/http-agent.ts
@@ -123,18 +123,22 @@ function getTrustStoreOptions(
  */
 function getKeyStoreOptions(destination: Destination): Record<string, any> {
   if (
-    destination.keyStoreName &&
-    destination.keyStorePassword &&
     // Only add certificates, when using MTLS (https://github.com/SAP/cloud-sdk-js/issues/3544)
     destination.authentication === 'ClientCertificateAuthentication' &&
     // pfx is an alternative to providing key and cert individually
     // For mTLS we provide key and cert, in non-mTLS cases we provide pfx
-    !mtlsIsEnabled(destination)
+    !mtlsIsEnabled(destination) &&
+    destination.keyStoreName
   ) {
     const certificate = selectCertificate(destination);
 
     logger.debug(`Certificate with name "${certificate.name}" selected.`);
 
+    if (!destination.keyStorePassword) {
+      logger.debug(
+        `Destination '${destination.name}' does not have a keystore password.`
+      );
+    }
     return {
       pfx: Buffer.from(certificate.content, 'base64'),
       passphrase: destination.keyStorePassword


### PR DESCRIPTION
Allow MTLS destinations to not have password. Closes https://github.com/SAP/cloud-sdk-backlog/issues/1125.