### PR TITLE
fixed selectionStrategy compare function (#4090)

### DIFF
--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -540,12 +540,12 @@ Possible alternatives for such technical user authentication are BasicAuthentica
   private isProviderNeeded(
     resultFromSubscriber: DestinationSearchResult | undefined
   ): boolean {
-    if (this.options.selectionStrategy === alwaysSubscriber) {
+    if (this.options.selectionStrategy.toString() === alwaysSubscriber.toString()) {
       return false;
     }
 
     if (
-      this.options.selectionStrategy === subscriberFirst &&
+      this.options.selectionStrategy.toString() === subscriberFirst.toString() &&
       resultFromSubscriber
     ) {
       return false;
@@ -563,7 +563,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
       return false;
     }
 
-    if (this.options.selectionStrategy === alwaysProvider) {
+    if (this.options.selectionStrategy.toString() === alwaysProvider.toString()) {
       return false;
     }
 


### PR DESCRIPTION

Closes SAP/cloud-sdk-backlog#4090 .

Fixes the issue where selectionStrategy is not correctly compared when imported from different locations.