### PR TITLE
fix: Fix proxy configuration for SAP Cloud Connector

### DIFF
--- a/.changeset/happy-mirrors-explain.md
+++ b/.changeset/happy-mirrors-explain.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Fixed Issue] Use axios native proxy, instead of proxy agent, which causes connection issues for write requests on SAP Cloud Connector.

--- a/.changeset/three-fireants-happen.md
+++ b/.changeset/three-fireants-happen.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Compatibility Note] Proxy configuration is no longer realized through a proxy agent, but with the native axios proxy setting instead.

--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -43,8 +43,6 @@
     "@sap/xssec": "^3.2.17",
     "async-retry": "^1.3.3",
     "axios": "^1.5.1",
-    "http-proxy-agent": "^7.0.0",
-    "https-proxy-agent": "^7.0.2",
     "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {

--- a/packages/connectivity/src/http-agent/http-agent.spec.ts
+++ b/packages/connectivity/src/http-agent/http-agent.spec.ts
@@ -1,12 +1,7 @@
 import { X509Certificate } from 'node:crypto';
 import mock from 'mock-fs';
 import { createLogger } from '@sap-cloud-sdk/util';
-import {
-  proxyAgent,
-  ProxyConfiguration,
-  DestinationCertificate
-} from '../scp-cf';
-import { connectivityProxyConfigMock } from '../../../../test-resources/test/test-util/environment-mocks';
+import { DestinationCertificate } from '../scp-cf';
 import { HttpDestination } from '../scp-cf/destination';
 import { registerDestinationCache } from '../scp-cf/destination/register-destination-cache';
 import { certAsString } from '../../../../test-resources/test/test-util/test-certificate';
@@ -18,37 +13,19 @@ describe('createAgent', () => {
     authentication: 'NoAuthentication'
   };
 
-  const proxyDestination: HttpDestination = {
-    ...baseDestination,
-    proxyConfiguration: {
-      ...connectivityProxyConfigMock,
-      headers: {
-        'Proxy-Authorization': 'Bearer jwt'
-      }
-    }
-  };
-
   const trustAllDestination: HttpDestination = {
     ...baseDestination,
     isTrustingAllCertificates: true
   };
 
-  it('returns the default agent if neither a proxy configuration is present nor TrustAll is set', async () => {
+  it('returns the default agent if TrustAll is not set', async () => {
     const agentConfig = (await getAgentConfigAsync(baseDestination))[
       'httpsAgent'
     ];
     expect(agentConfig.options.rejectUnauthorized).toBe(true);
   });
 
-  it('returns a proxy agent if there is a proxy setting on the destination', async () => {
-    const agentConfig = (await getAgentConfigAsync(proxyDestination))[
-      'httpsAgent'
-    ];
-    expect(agentConfig.proxy.protocol).toEqual('http:');
-    expect(agentConfig.connectOpts.rejectUnauthorized).toBe(true);
-  });
-
-  it('returns a trustAll agent if TrustAll is configured', async () => {
+  it('disables rejectUnauthorized agent if TrustAll is configured', async () => {
     const agentConfig = (await getAgentConfigAsync(trustAllDestination))[
       'httpsAgent'
     ];
@@ -70,47 +47,6 @@ describe('createAgent', () => {
     };
     expect((await getAgentConfigAsync(destHttp))['httpAgent']).toHaveProperty(
       'protocol',
-      'http:'
-    );
-  });
-
-  it('returns a proxy agent if a proxy setting and TrustAll are BOTH configured', async () => {
-    const agentConfig = (
-      await getAgentConfigAsync({
-        ...proxyDestination,
-        ...trustAllDestination
-      })
-    )['httpsAgent'];
-    expect(agentConfig.proxy.protocol).toEqual('http:');
-    expect(agentConfig.connectOpts.rejectUnauthorized).toEqual(false);
-  });
-
-  it('should return a proxy-agent with the same protocol as the destination (https).', () => {
-    const proxyConfiguration: ProxyConfiguration = {
-      host: 'some.host.com',
-      port: 4711,
-      protocol: 'https'
-    };
-    const destHttpWithProxy: HttpDestination = {
-      url: 'http://example.com',
-      proxyConfiguration
-    };
-    expect(proxyAgent(destHttpWithProxy)['httpAgent'].proxy.protocol).toEqual(
-      'https:'
-    );
-  });
-
-  it('should return a proxy-agent with the same protocol as the destination (http).', () => {
-    const proxyConfiguration: ProxyConfiguration = {
-      host: 'some.host.com',
-      port: 4711,
-      protocol: 'http'
-    };
-    const destHttpsWithProxy: HttpDestination = {
-      url: 'https://example.com',
-      proxyConfiguration
-    };
-    expect(proxyAgent(destHttpsWithProxy)['httpsAgent'].proxy.protocol).toEqual(
       'http:'
     );
   });

--- a/packages/connectivity/src/http-agent/http-agent.ts
+++ b/packages/connectivity/src/http-agent/http-agent.ts
@@ -3,6 +3,7 @@ import http from 'http';
 import https from 'https';
 import { createLogger, last } from '@sap-cloud-sdk/util';
 import {
+  BasicProxyConfiguration,
   Destination,
   DestinationCertificate,
   getProtocolOrDefault
@@ -10,6 +11,7 @@ import {
 /* Careful the proxy imports cause circular dependencies if imported from scp directly */
 import {
   addProxyConfigurationInternet,
+  getProxyConfig,
   HttpDestination,
   proxyStrategy
 } from '../scp-cf/destination';
@@ -262,6 +264,7 @@ function createDefaultAgent(
  */
 export async function urlAndAgent(targetUri: string): Promise<{
   baseURL: string;
+  proxy?: BasicProxyConfiguration | false;
   httpAgent?: http.Agent;
   httpsAgent?: http.Agent;
 }> {
@@ -271,6 +274,7 @@ export async function urlAndAgent(targetUri: string): Promise<{
   }
   return {
     baseURL: destination.url,
-    ...(await getAgentConfigAsync(destination))
+    ...(await getAgentConfigAsync(destination)),
+    proxy: getProxyConfig(destination)
   };
 }

--- a/packages/connectivity/src/http-agent/http-agent.ts
+++ b/packages/connectivity/src/http-agent/http-agent.ts
@@ -39,7 +39,7 @@ export async function getAgentConfigAsync(
     ...getKeyStoreOptions(destination),
     ...(await getMtlsOptions(destination))
   };
-  return createDefaultAgent(destination, certificateOptions);
+  return createAgent(destination, certificateOptions);
 }
 
 /**
@@ -57,7 +57,7 @@ export function getAgentConfig(
     ...getTrustStoreOptions(destination),
     ...getKeyStoreOptions(destination)
   };
-  return createDefaultAgent(destination, certificateOptions);
+  return createAgent(destination, certificateOptions);
 }
 
 /**
@@ -245,14 +245,13 @@ function selectCertificate(destination): DestinationCertificate {
  * @internal
  * See https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener for details on the possible options
  */
-function createDefaultAgent(
+function createAgent(
   destination: HttpDestination,
   options: https.AgentOptions
 ): HttpAgentConfig | HttpsAgentConfig {
-  if (getProtocolOrDefault(destination) === 'https') {
-    return { httpsAgent: new https.Agent(options) };
-  }
-  return { httpAgent: new http.Agent(options) };
+  return getProtocolOrDefault(destination) === 'https'
+    ? { httpsAgent: new https.Agent(options) }
+    : { httpAgent: new http.Agent(options) };
 }
 
 /**

--- a/packages/connectivity/src/index.ts
+++ b/packages/connectivity/src/index.ts
@@ -34,6 +34,7 @@ export {
   DestinationAccessorOptions,
   DestinationSelectionStrategies,
   JwtPayload,
+  BasicProxyConfiguration,
   ProxyConfiguration,
   ProxyConfigurationHeaders,
   Service,

--- a/packages/connectivity/src/scp-cf/connectivity-service-types.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service-types.ts
@@ -11,7 +11,22 @@ import { Protocol } from './protocol';
  * Note: The [no_proxy] environment variables contains a list of URLs for which no proxy will be used even if [http_proxy, https_proxy] are set.
  * Wildcards like *.some.domain.com are not supported while checking the no_proxy env.
  */
-export interface ProxyConfiguration {
+export interface ProxyConfiguration extends BasicProxyConfiguration {
+  /**
+   * HTTP headers to be added to a request if tunneled through the proxy.
+   */
+  headers?: ProxyConfigurationHeaders;
+
+  /**
+   * A JWT for proxy authorization, which is used when HTTP headers are not applicable, e.g., using socket protocols.
+   */
+  'proxy-authorization'?: string;
+}
+
+/**
+ * Standard proxy configuration without additional headers nor authorization info.
+ */
+export interface BasicProxyConfiguration {
   /**
    * The host of the proxy.
    */
@@ -27,16 +42,6 @@ export interface ProxyConfiguration {
    *
    */
   protocol: Protocol;
-
-  /**
-   * HTTP headers to be added to a request if tunneled through the proxy.
-   */
-  headers?: ProxyConfigurationHeaders;
-
-  /**
-   * A JWT for proxy authorization, which is used when http headers are not applicable, e.g., using socket protocols.
-   */
-  'proxy-authorization'?: string;
 }
 
 /**

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import { createLogger } from '@sap-cloud-sdk/util';
+import axios from 'axios';
 import {
   connectivityProxyConfigMock,
   mockServiceBindings
@@ -22,12 +23,9 @@ import {
 } from '../../../../../test-resources/test/test-util/mocked-access-tokens';
 import {
   basicMultipleResponse,
-  destinationName,
-  onPremiseMultipleResponse,
   onPremisePrincipalPropagationMultipleResponse
 } from '../../../../../test-resources/test/test-util/example-destination-service-responses';
 import { getDestination } from './destination-accessor';
-import { parseDestination } from './destination';
 import * as ProxyUtil from './http-proxy-util';
 import { alwaysProvider } from './destination-selection-strategies';
 import { Destination } from './destination-service-types';
@@ -35,106 +33,56 @@ import { destinationCache } from './destination-cache';
 import { destinationServiceCache } from './destination-service-cache';
 
 describe('proxy configuration', () => {
-  afterEach(() => {
-    delete process.env['https_proxy'];
-  });
-
-  it('should take the environment variable.', async () => {
+  beforeEach(() => {
     mockServiceBindings();
     mockVerifyJwt();
     mockServiceToken();
-    mockJwtBearerToken();
+  });
 
-    const httpMocks = [
-      mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken),
-      mockSubaccountDestinationsCall(
-        nock,
-        basicMultipleResponse,
-        200,
-        subscriberServiceToken
-      )
-    ];
+  afterEach(() => {
+    delete process.env['https_proxy'];
+    jest.resetAllMocks();
+  });
+
+  it('should take the environment variable', async () => {
+    jest
+      .spyOn(axios, 'request')
+      .mockImplementation(mockDestinationCalls(basicMultipleResponse[0]));
+
     process.env['https_proxy'] = 'some.proxy.com:1234';
 
-    const actual = await getDestination({
-      destinationName,
-      jwt: subscriberServiceToken,
-      cacheVerificationKeys: false
+    const destination = await getDestination({
+      destinationName: 'FINAL-DESTINATION'
     });
-    expect(actual?.proxyConfiguration).toEqual({
+
+    expect(destination?.proxyConfiguration).toEqual({
       host: 'some.proxy.com',
       protocol: 'http',
       port: 1234
     });
-    httpMocks.forEach(mock => expect(mock.isDone()).toBe(true));
   });
 
-  it('should ignore the proxy if the destination is onPrem type.', async () => {
-    mockServiceBindings();
-    mockVerifyJwt();
-    mockServiceToken();
-    mockJwtBearerToken();
-
-    const httpMocks = [
-      mockInstanceDestinationsCall(
-        nock,
-        onPremisePrincipalPropagationMultipleResponse,
-        200,
-        subscriberServiceToken
-      ),
-      mockSubaccountDestinationsCall(nock, [], 200, subscriberServiceToken)
-    ];
+  it('should ignore the proxy if the destination has proxy type "OnPremise"', async () => {
+    jest
+      .spyOn(axios, 'request')
+      .mockImplementation(
+        mockDestinationCalls(onPremisePrincipalPropagationMultipleResponse[0])
+      );
 
     process.env['https_proxy'] = 'some.proxy.com:1234';
-    const expected = {
+
+    const destination = await getDestination({
+      destinationName: 'OnPremise',
+      jwt: subscriberUserToken
+    });
+
+    expect(destination?.proxyConfiguration).toEqual({
       ...connectivityProxyConfigMock,
       headers: {
         'Proxy-Authorization': `Bearer ${subscriberServiceToken}`,
-        'SAP-Connectivity-Authentication': `Bearer ${subscriberServiceToken}`
+        'SAP-Connectivity-Authentication': `Bearer ${subscriberUserToken}`
       }
-    };
-
-    const actual = await getDestination({
-      destinationName: 'OnPremise',
-      jwt: subscriberServiceToken,
-      cacheVerificationKeys: false
     });
-    expect(actual?.proxyConfiguration).toEqual(expected);
-    httpMocks.forEach(mock => expect(mock.isDone()).toBe(true));
-  });
-
-  it('returns a destination with a connectivity service proxy configuration when ProxyType equals "OnPremise"', async () => {
-    mockServiceBindings();
-    mockVerifyJwt();
-    mockServiceToken();
-
-    const httpMocks = [
-      mockInstanceDestinationsCall(nock, [], 200, providerServiceToken),
-      mockSubaccountDestinationsCall(
-        nock,
-        onPremiseMultipleResponse,
-        200,
-        providerServiceToken
-      )
-    ];
-
-    const expected = {
-      ...parseDestination({
-        Name: 'OnPremise',
-        URL: 'my.on.premise.system:54321',
-        ProxyType: 'OnPremise',
-        Authentication: 'NoAuthentication'
-      }),
-      proxyConfiguration: {
-        ...connectivityProxyConfigMock,
-        headers: {
-          'Proxy-Authorization': `Bearer ${providerServiceToken}`
-        }
-      }
-    };
-    const actual = await getDestination({ destinationName: 'OnPremise' });
-    expect(actual).toEqual(expected);
-    httpMocks.forEach(mock => expect(mock.isDone()).toBe(true));
   });
 });
 
@@ -256,3 +204,32 @@ describe('truststore configuration', () => {
     });
   });
 });
+
+function mockDestinationCalls(
+  destination: Destination
+): (config: any) => Promise<any> {
+  return async config => {
+    if (
+      config.baseURL?.endsWith('instanceDestinations') ||
+      config.baseURL?.endsWith('subaccountDestinations')
+    ) {
+      return { data: [destination] };
+    }
+    return {
+      data: {
+        destinationConfiguration: destination,
+        authTokens: [
+          {
+            type: 'Bearer',
+            value: 'token',
+            expires_in: '3600',
+            http_header: {
+              key: 'Authorization',
+              value: 'Bearer token'
+            }
+          }
+        ]
+      }
+    };
+  };
+}

--- a/packages/connectivity/src/scp-cf/destination/destination-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.ts
@@ -381,7 +381,6 @@ async function callDestinationService(
 
   const requestConfig: RawAxiosRequestConfig = {
     ...(await urlAndAgent(context.uri)),
-    proxy: false,
     method: 'get',
     headers
   };

--- a/packages/connectivity/src/scp-cf/destination/http-proxy-util.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/http-proxy-util.spec.ts
@@ -1,7 +1,9 @@
 import { createLogger } from '@sap-cloud-sdk/util';
 import { basicHeader } from '../authorization-header';
+import { BasicProxyConfiguration } from '../connectivity-service-types';
 import {
   addProxyConfigurationInternet,
+  getProxyConfig,
   parseProxyEnv,
   proxyStrategy
 } from './http-proxy-util';
@@ -184,7 +186,7 @@ describe('proxy-util', () => {
   });
 });
 
-describe('parseProxyEnv', () => {
+describe('parseProxyEnv()', () => {
   it('parses URL with "https:" protocol and hostname', () => {
     const logger = createLogger('proxy-util');
     const logSpy = jest.spyOn(logger, 'debug');
@@ -338,5 +340,33 @@ describe('parseProxyEnv', () => {
       host: '127.0.0.0',
       port: 8080
     });
+  });
+});
+
+describe('getProxyConfig()', () => {
+  it('returns a basic proxy config', () => {
+    const basicProxyConfig: BasicProxyConfiguration = {
+      host: 'some.host.com',
+      port: 4711,
+      protocol: 'https'
+    };
+    const destHttpWithProxy: HttpDestination = {
+      url: 'http://example.com',
+      proxyConfiguration: {
+        ...basicProxyConfig,
+        headers: {
+          'Proxy-Authorization': 'Bearer auth-token',
+          'SAP-Connectivity-Authentication': 'Bearer auth-token'
+        }
+      }
+    };
+    expect(getProxyConfig(destHttpWithProxy)).toEqual(basicProxyConfig);
+  });
+
+  it('returns a false, if destination has no proxy configuration', () => {
+    const destHttpWithProxy: HttpDestination = {
+      url: 'http://example.com'
+    };
+    expect(getProxyConfig(destHttpWithProxy)).toEqual(false);
   });
 });

--- a/packages/http-client/src/http-client-types.ts
+++ b/packages/http-client/src/http-client-types.ts
@@ -4,6 +4,7 @@ import type {
   Middleware,
   MiddlewareOptions
 } from '@sap-cloud-sdk/resilience';
+import { BasicProxyConfiguration } from '@sap-cloud-sdk/connectivity';
 
 /**
  * Context for HttpRequests of the middleware.
@@ -43,25 +44,29 @@ export type HttpMiddleware = Middleware<
  */
 export interface DestinationHttpRequestConfig {
   /**
-   * `baseURL` will be prepended to {@link HttpRequestConfigBase#url} unless `url` is absolute.
+   * Will be prepended to {@link HttpRequestConfigBase#url} unless `url` is absolute.
    */
   baseURL: string;
   /**
-   * `headers` are custom headers to be sent.
+   * Additional headers to be sent.
    */
   headers: Record<string, string>;
   /**
-   * `params` are the URL parameters to be sent with the request.
+   * URL parameters to be sent with the request.
    */
   params?: Record<string, string>;
   /**
-   * `httpAgent` defines a custom agent to be used when performing http requests.
+   * Agent to be used when performing HTTP requests.
    */
   httpAgent?: http.Agent;
   /**
-   * `httpsAgent` defines a custom agent to be used when performing https requests.
+   * Agent to be used when performing HTTPS requests.
    */
   httpsAgent?: http.Agent;
+  /**
+   * Proxy configuration, when going through a proxy like the SAP Cloud Connector.
+   */
+  proxy: BasicProxyConfiguration | false;
 }
 
 /**

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -18,6 +18,7 @@ import {
   HttpDestination
 } from '@sap-cloud-sdk/connectivity';
 import { registerDestinationCache } from '@sap-cloud-sdk/connectivity/internal';
+import { ProxyConfiguration } from '@sap-cloud-sdk/connectivity/src';
 import { responseWithPublicKey } from '../../connectivity/src/scp-cf/jwt.spec';
 import {
   basicMultipleResponse,
@@ -680,13 +681,14 @@ sap-client:001`);
     }, 60000);
 
     it('overwrites the default axios config with destination related request config', async () => {
+      const proxyConfiguration: ProxyConfiguration = {
+        host: 'dummy',
+        port: 1234,
+        protocol: 'http'
+      };
       const destination: HttpDestination = {
         url: 'https://destinationUrl',
-        proxyConfiguration: {
-          host: 'dummy',
-          port: 1234,
-          protocol: 'http'
-        }
+        proxyConfiguration
       };
 
       const requestSpy = jest.spyOn(axios, 'request').mockResolvedValue(true);
@@ -695,10 +697,7 @@ sap-client:001`);
       ).resolves.not.toThrow();
       expect(requestSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          proxy: false,
-          httpsAgent: expect.objectContaining({
-            proxy: expect.objectContaining({ hostname: 'dummy', port: '1234' })
-          })
+          proxy: proxyConfiguration
         })
       );
     });

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -95,7 +95,7 @@ describe('generic http client', () => {
   };
 
   describe('buildHttpRequest', () => {
-    it('provides a baseURL, headers, and either an httpAgent or an httpsAgent', async () => {
+    it('creates an https request', async () => {
       const expectedHttps: DestinationHttpRequestConfig = {
         baseURL: 'https://example.com',
         headers: {
@@ -109,7 +109,9 @@ describe('generic http client', () => {
 
       expect(actualHttps).toMatchObject(expectedHttps);
       expect(actualHttps.httpsAgent).toBeDefined();
+    });
 
+    it('creates an http request with a proxy configuration', async () => {
       const expectedProxy: DestinationHttpRequestConfig = {
         baseURL: 'http://example.com',
         headers: {
@@ -117,7 +119,11 @@ describe('generic http client', () => {
           'sap-client': '001',
           'Proxy-Authorization': proxyAuthorization
         },
-        proxy: false
+        proxy: {
+          host: 'proxy.host',
+          port: 1234,
+          protocol: 'http'
+        }
       };
 
       const actualProxy = await buildHttpRequest(proxyDestination);

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -100,7 +100,8 @@ describe('generic http client', () => {
         headers: {
           authorization: 'Basic VVNFUk5BTUU6UEFTU1dPUkQ=',
           'sap-client': '001'
-        }
+        },
+        proxy: false
       };
 
       const actualHttps = await buildHttpRequest(httpsDestination);
@@ -114,7 +115,8 @@ describe('generic http client', () => {
           authorization: 'Basic VVNFUk5BTUU6UEFTU1dPUkQ=',
           'sap-client': '001',
           'Proxy-Authorization': proxyAuthorization
-        }
+        },
+        proxy: false
       };
 
       const actualProxy = await buildHttpRequest(proxyDestination);

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -11,6 +11,7 @@ import {
   DestinationConfiguration,
   getAdditionalHeaders,
   getAdditionalQueryParameters,
+  getProxyConfig,
   getTenantIdWithFallback,
   HttpDestination,
   resolveDestination
@@ -83,6 +84,7 @@ export function execute(executeFn: ExecuteHttpRequestFn<HttpResponse>) {
 
     const destinationRequestConfig =
       await buildHttpRequest(resolvedDestination);
+
     logCustomHeadersWarning(requestConfig.headers);
     const request = await buildRequestWithMergedHeadersAndQueryParameters(
       requestConfig,
@@ -399,6 +401,7 @@ async function buildDestinationHttpRequestConfig(
     baseURL: destination.url,
     headers,
     params: destination.queryParameters,
+    proxy: getProxyConfig(destination),
     ...(await getAgentConfigAsync(destination))
   };
 }
@@ -455,7 +458,6 @@ export function getAxiosConfigWithDefaultsWithoutMethod(): Omit<
   'method'
 > {
   return {
-    proxy: false,
     httpAgent: new http.Agent(),
     httpsAgent: new https.Agent(),
     timeout: 0, // zero means no timeout https://github.com/axios/axios/blob/main/README.md#request-config


### PR DESCRIPTION
Remove http(s) proxy agents and replace them with the native axios config. Apparently, the agents stopped working on cloud connector as they try to setup multiple connections when there is a `data` property in the request 🙀

The decision to use the http(s) proxy agents was made, because we wanted to be able to combine proxies + certificate options. 

- [x] Only merge once the combination of proxy + cert was tested thoroughly, potentially through BAS or a suitable E2E test.
=> This was not possible before and might only work with node 20.

Closes #4152 

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
