### PR TITLE
Revert "chore(deps-dev): bump typedoc from 0.25.0 to 0.25.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "turbo": "^1.10.15",
-    "typedoc": "0.25.2",
+    "typedoc": "0.25.0",
     "typescript": "~5.1.6"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9532,10 +9532,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typedoc@0.25.2:
-  version "0.25.2"
-  resolved "https://registry.npmjs.org/typedoc/-/typedoc-0.25.2.tgz#39f525c28b6eb61da54dda4ec6b1500df620bed8"
-  integrity sha512-286F7BeATBiWe/qC4PCOCKlSTwfnsLbC/4cZ68oGBbvAqb9vV33quEOXx7q176OXotD+JdEerdQ1OZGJ818lnA==
+typedoc@0.25.0:
+  version "0.25.0"
+  resolved "https://registry.npmjs.org/typedoc/-/typedoc-0.25.0.tgz#287f83d01c1c2186766884f4e04d698820d68115"
+  integrity sha512-FvCYWhO1n5jACE0C32qg6b3dSfQ8f2VzExnnRboowHtqUD6ARzM2r8YJeZFYXhcm2hI4C2oCRDgNPk/yaQUN9g==
   dependencies:
     lunr "^2.3.9"
     marked "^4.3.0"


### PR DESCRIPTION
Reverts SAP/cloud-sdk-js#4196