### PR TITLE
fix: exclude test-directories from blackduck scan

### DIFF
--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -25,7 +25,7 @@ jobs:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
-            --excludedDirectories=test-packages, --min-scan-interval=0 \
+            --excludedDirectories=test-packages,--min-scan-interval=0 \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -19,7 +19,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: sudo apt-get install jq
       - run: echo "project_version=$(cat package.json | jq '.version' | tr -d '"')" >> $GITHUB_ENV
-      - run: alias --detect.timeout=6000='--detect.timeout=6000 --min-scan-interval=0'
+      - run: alias '--detect.timeout=6000'='--detect.timeout=6000 --min-scan-interval=0'
       - name: Blackduck Scan
         uses: SAP/project-piper-action@27cadf261545552a68660531476c0915a97ee3d8
         with:

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -24,13 +24,13 @@ jobs:
         with:
           command: detectExecuteScan
           flags: \
-            --npmDependencyTypesExcluded=DEV \
             --version=$PROJECT_VERSION \
-            --excludedDirectories=test-packages \
-            --scanProperties=" \
-            --blackduck.signature.scanner.memory=4096 \
-            --detect.timeout=6000 \
-            --blackduck.trust.cert=true"
+            --npmDependencyTypesExcluded=DEV \
+            --excludedDirectories=test-packages
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}
+          BLACKDUCK_SIGNATURE_SCANNER_MEMORY: 4096
+          DETECT_TIMEOUT: 6000
+
+          # BLACKDUCK_TRUST_CERT: true

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -26,7 +26,6 @@ jobs:
           flags: \
             --version=$PROJECT_VERSION \
             --customEnvironmentVariables=MIN_SCAN_INTERVAL \
-            --minScanInterval=0 \
             --excludedDirectories=test-packages \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -29,7 +29,7 @@ jobs:
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
             --blackduck.trust.cert=true \
-            --detect.yarn.excluded.workspaces=test-packages/self-tests"
+            --detect.yarn.excluded.workspaces=/test-packages/self-tests"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -19,13 +19,13 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: sudo apt-get install jq
       - run: echo "project_version=$(cat package.json | jq '.version' | tr -d '"')" >> $GITHUB_ENV
+      - run: alias ./detect.sh='./detect.sh --min-scan-interval=0'
       - name: Blackduck Scan
         uses: SAP/project-piper-action@27cadf261545552a68660531476c0915a97ee3d8
         with:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
-            --customEnvironmentVariables=MIN_SCAN_INTERVAL \
             --excludedDirectories=test-packages \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
@@ -34,4 +34,3 @@ jobs:
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}
-          MIN_SCAN_INTERVAL: 0

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -26,11 +26,11 @@ jobs:
           flags: \
             --version=$PROJECT_VERSION \
             --scanProperties="\
-            --detect.yarn.prod.only=true \
+            --detect.yarn.dependency.types.excluded=NONE,NON_PRODUCTION \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
-            --blackduck.trust.cert=true \
-            --detect.excluded.directories=test-packages"
+            --blackduck.trust.cert=true" \
+            # --detect.excluded.directories=test-packages"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -30,7 +30,7 @@ jobs:
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
             --blackduck.trust.cert=true \
-            --detect.excludedDirectories=test-packages"
+            --detect.excludedDirectories=test-packages/**"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -19,7 +19,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: sudo apt-get install jq
       - run: echo "project_version=$(cat package.json | jq '.version' | tr -d '"')" >> $GITHUB_ENV
-      - run: alias '--detect.timeout=6000'='--detect.timeout=6000 --min-scan-interval=0'
+      - run: alias detect.timeout=6000='detect.timeout=6000 --min-scan-interval=0'
       - name: Blackduck Scan
         uses: SAP/project-piper-action@27cadf261545552a68660531476c0915a97ee3d8
         with:

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -25,7 +25,7 @@ jobs:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
-            --excludedDirectories=test-packages,"--min-scan-interval=0 \
+            --excludedDirectories=test-packages, --min-scan-interval=0 \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -25,13 +25,14 @@ jobs:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
+            --customEnvironmentVariables=MIN_SCAN_INTERVAL \
             --minScanInterval=0 \
             --excludedDirectories=test-packages \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
-            --blackduck.trust.cert=true \
-            --detect.blackduck.scan.mode=RAPID"
+            --blackduck.trust.cert=true"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}
+          MIN_SCAN_INTERVAL: 0

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -26,7 +26,6 @@ jobs:
           flags: \
             --version=$PROJECT_VERSION \
             --scanProperties="\
-            --detect.yarn.dependency.types.excluded=NONE \
             --detect.yarn.dependency.types.excluded=NON_PRODUCTION \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -25,7 +25,7 @@ jobs:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
-            --excludedDirectories=test-packages \
+            --excludedDirectories=test-packages/** \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -31,7 +31,7 @@ jobs:
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
             --blackduck.trust.cert=true \
-            --detect.blackduck.scan.mode"
+            --detect.blackduck.scan.mode=RAPID"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -25,7 +25,7 @@ jobs:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
-            --excludedDirectories="test-packages, --min-scan-interval=0" \
+            --excludedDirectories="test-packages --min-scan-interval=0" \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -30,7 +30,7 @@ jobs:
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
             --blackduck.trust.cert=true \
-            --detect.excludedDirectories=test-packages/**"
+            --detect.excluded.directories=test-packages"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -30,7 +30,5 @@ jobs:
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}
-          BLACKDUCK_SIGNATURE_SCANNER_MEMORY: 4096
           DETECT_TIMEOUT: 6000
-
-          # BLACKDUCK_TRUST_CERT: true
+          DETECT_YARN_EXCLUDED_WORKSPACES: test-packages/**

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -26,11 +26,12 @@ jobs:
           flags: \
             --version=$PROJECT_VERSION \
             --scanProperties="\
-            --detect.yarn.dependency.types.excluded=NONE,NON_PRODUCTION \
+            --detect.yarn.dependency.types.excluded=NONE \
+            --detect.yarn.dependency.types.excluded=NON_PRODUCTION \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
             --blackduck.trust.cert=true" \
-            # --detect.excluded.directories=test-packages"
+            # --detect.excluded.directories=test-packages/**"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -25,7 +25,8 @@ jobs:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
-            --excludedDirectories=/test-packages/** \
+            --minScanInterval=0 \
+            --excludedDirectories=test-packages \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -25,10 +25,10 @@ jobs:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
-            --npmDependencyTypesExcluded=DEV \
             --excludedDirectories=test-packages
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}
           DETECT_TIMEOUT: 6000
           DETECT_YARN_EXCLUDED_WORKSPACES: test-packages/**
+          DETECT_YARN_DEPENDENCY_TYPES_EXCLUDED: NON_PRODUCTION

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -19,14 +19,13 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: sudo apt-get install jq
       - run: echo "project_version=$(cat package.json | jq '.version' | tr -d '"')" >> $GITHUB_ENV
-      - run: alias detect.timeout=6000='detect.timeout=6000 --min-scan-interval=0'
       - name: Blackduck Scan
         uses: SAP/project-piper-action@27cadf261545552a68660531476c0915a97ee3d8
         with:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
-            --excludedDirectories=test-packages \
+            --excludedDirectories=test-packages,"--min-scan-interval=0 \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -25,11 +25,11 @@ jobs:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
-            --excludedDirectories=test-packages/** \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
-            --blackduck.trust.cert=true"
+            --blackduck.trust.cert=true \
+            --detect.yarn.excluded.workspaces=test-packages/**"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -29,7 +29,8 @@ jobs:
             --detect.yarn.prod.only=true \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
-            --blackduck.trust.cert=true"
+            --blackduck.trust.cert=true \
+            --detect.excludedDirectories=test-packages"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -25,11 +25,11 @@ jobs:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
-            --scanProperties="\
+            --excludedDirectories=test-packages \
+            --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
-            --blackduck.trust.cert=true" \
-            --detect.excluded.directories=**/test-packages/**"
+            --blackduck.trust.cert=true"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -29,7 +29,7 @@ jobs:
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
             --blackduck.trust.cert=true \
-            --detect.yarn.excluded.workspaces=/test-packages/self-tests"
+            --detect.yarn.excluded.workspaces=test-packages/integration-tests,test-packages/e2e-tests,test-packages/test-services-odata-common,test-packages/test-services-odata-v2,test-packages/test-services-odata-v4,test-packages/test-services-openapi,test-packages/test-services-e2e,test-packages/type-tests,test-packages/self-tests"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -26,11 +26,10 @@ jobs:
           flags: \
             --version=$PROJECT_VERSION \
             --scanProperties="\
-            --detect.yarn.dependency.types.excluded=NON_PRODUCTION \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
             --blackduck.trust.cert=true" \
-            # --detect.excluded.directories=test-packages/**"
+            --detect.excluded.directories=**/test-packages/**"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -24,8 +24,9 @@ jobs:
         with:
           command: detectExecuteScan
           flags: \
+            --npmDependencyTypesExcluded=DEV \
             --version=$PROJECT_VERSION \
-            --excludedDirectories="test-packages --min-scan-interval=0" \
+            --excludedDirectories=test-packages \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -30,7 +30,8 @@ jobs:
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
-            --blackduck.trust.cert=true"
+            --blackduck.trust.cert=true \
+            --detect.blackduck.scan.mode"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -19,7 +19,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: sudo apt-get install jq
       - run: echo "project_version=$(cat package.json | jq '.version' | tr -d '"')" >> $GITHUB_ENV
-      - run: alias ./detect.sh='./detect.sh --min-scan-interval=0'
+      - run: alias --detect.timeout=6000='--detect.timeout=6000 --min-scan-interval=0'
       - name: Blackduck Scan
         uses: SAP/project-piper-action@27cadf261545552a68660531476c0915a97ee3d8
         with:

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -25,7 +25,7 @@ jobs:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
-            --excludedDirectories=test-packages,--min-scan-interval=0 \
+            --excludedDirectories="test-packages, --min-scan-interval=0" \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -29,7 +29,7 @@ jobs:
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
             --blackduck.trust.cert=true \
-            --detect.yarn.excluded.workspaces=test-packages/**"
+            --detect.yarn.excluded.workspaces=test-packages/self-tests"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -25,11 +25,11 @@ jobs:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
+            --excludedDirectories=/test-packages/** \
             --scanProperties=" \
             --blackduck.signature.scanner.memory=4096 \
             --detect.timeout=6000 \
-            --blackduck.trust.cert=true \
-            --detect.yarn.excluded.workspaces=test-packages/integration-tests,test-packages/e2e-tests,test-packages/test-services-odata-common,test-packages/test-services-odata-v2,test-packages/test-services-odata-v4,test-packages/test-services-openapi,test-packages/test-services-e2e,test-packages/type-tests,test-packages/self-tests"
+            --blackduck.trust.cert=true"
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           PROJECT_VERSION: ${{ env.project_version }}

--- a/packages/connectivity/src/scp-cf/authorization-header.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.ts
@@ -46,11 +46,6 @@ export function getAuthHeader(
   }
 }
 
-/**
- * Remove me pls.
- */
-export const someChangeForBlackDuck = 'hey';
-
 function toAuthorizationHeader(
   authorization: string
 ): AuthenticationHeaderCloud {

--- a/packages/connectivity/src/scp-cf/authorization-header.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.ts
@@ -46,6 +46,11 @@ export function getAuthHeader(
   }
 }
 
+/**
+ * Remove me pls.
+ */
+export const someChangeForBlackDuck = 'hey';
+
 function toAuthorizationHeader(
   authorization: string
 ): AuthenticationHeaderCloud {


### PR DESCRIPTION
With this PR, Blackduck will no longer fail if vulnerabilities are found in our test packages.