### PR TITLE
feat(logging): set level via env var

### DIFF
--- a/packages/util/src/logger/cloud-sdk-logger.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.ts
@@ -116,6 +116,7 @@ export function createLogger(
       : { ...messageContext };
   const logger = container.get(customFields.messageContext, {
     level:
+      process.env.SAP_CLOUD_SDK_LOG_LEVEL ||
       customLogLevels[customFields.messageContext] ||
       customFields.level ||
       container.options.level ||


### PR DESCRIPTION
support setting the log level via env var, which allows to switch the level without changing and redeploying the app