### PR TITLE
fix: allow noauthentication destinations with proxytype “OnPremise”

### DIFF
--- a/.changeset/great-ads-live.md
+++ b/.changeset/great-ads-live.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/connectivity': minor
 ---
 
-[Fixed Issue] Allow the use of authentication type "NoAuthentication" with proxy type "OnPremise" without requiring the "SAP-Connectivity-Authentication" header.
+[Fixed Issue] Allow the use of authentication type `NoAuthentication` with proxy type `OnPremise` without requiring the `SAP-Connectivity-Authentication` header.

--- a/.changeset/great-ads-live.md
+++ b/.changeset/great-ads-live.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Fixed Issue] Allow the use of authentication type "NoAuthentication" with proxy type "OnPremise" without requiring the "SAP-Connectivity-Authentication" header.

--- a/.changeset/witty-suns-vanish.md
+++ b/.changeset/witty-suns-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Compatibility Note] Using Principal Propagation through authentication type to "NoAuthentication" is no longer supported. This resulted in erroneous behavior for destinations with authentication type "NoAuthentication". If you need to use Principal Propagation use authentication type "PrincipalPropagation".

--- a/.changeset/witty-suns-vanish.md
+++ b/.changeset/witty-suns-vanish.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/connectivity': minor
 ---
 
-[Compatibility Note] Using Principal Propagation through authentication type to "NoAuthentication" is no longer supported. This resulted in erroneous behavior for destinations with authentication type "NoAuthentication". If you need to use Principal Propagation use authentication type "PrincipalPropagation".
+[Compatibility Note] Using Principal Propagation through authentication type `NoAuthentication` is no longer supported. This resulted in erroneous behavior for destinations with authentication type `NoAuthentication`. If you need to use Principal Propagation use authentication type `PrincipalPropagation`.

--- a/packages/connectivity/src/scp-cf/authorization-header.spec.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.spec.ts
@@ -54,7 +54,7 @@ describe('buildAuthorizationHeaders', () => {
       ).resolves.not.toThrow();
     });
 
-    it('defaults to NoAuthentication and does not create authentication headers when only url is defined', async () => {
+    it('defaults to NoAuthentication and does not create authentication headers when only URL is defined', async () => {
       const spy = jest.spyOn(destinationImport, 'sanitizeDestination');
       const headerPromise = buildAuthorizationHeaders({
         url: 'https://example.com'
@@ -64,31 +64,6 @@ describe('buildAuthorizationHeaders', () => {
         expect.objectContaining({ authentication: 'NoAuthentication' })
       );
       expect((await headerPromise).authorization).toBeUndefined();
-    });
-
-    it("does not add authentication headers for proxy type 'Internet'", async () => {
-      const headers = await buildAuthorizationHeaders({
-        url: defaultDestination.url,
-        proxyType: 'Internet'
-      });
-      expect(headers.authorization).toBeUndefined();
-    });
-
-    it("adds on premise related headers for authentication type 'NoAuthentication' combined with proxy type 'OnPremise'", async () => {
-      const destination = {
-        url: '',
-        authentication: 'NoAuthentication',
-        proxyType: 'OnPremise',
-        proxyConfiguration: {
-          headers: {
-            'SAP-Connectivity-Authentication': 'someValueDestination',
-            'Proxy-Authorization': 'someProxyValue'
-          }
-        }
-      } as Destination;
-
-      const headers = await buildAuthorizationHeaders(destination);
-      checkHeaders(headers);
     });
   });
 

--- a/packages/connectivity/src/scp-cf/authorization-header.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.ts
@@ -179,9 +179,6 @@ async function getAuthenticationRelatedHeaders(
       );
       return;
     case 'NoAuthentication':
-      if (destination.proxyType === 'OnPremise') {
-        return headerForPrincipalPropagation(destination);
-      }
       return;
     case 'ClientCertificateAuthentication':
       return;


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes https://github.com/SAP/cloud-sdk-backlog/issues/1160

Fix NoAuthentication for proxytype "OnPremise". This behavior existed only due to a historic bug, which was worked around like this.
We contacted the colleagues from BTP connectivity and learned that this headers is in fact not needed (and incorrect) when using NoAuthentication.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
