### PR TITLE
chore: Fetch one destination instead of all

### DIFF
--- a/.changeset/funny-weeks-warn.md
+++ b/.changeset/funny-weeks-warn.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Compatibility Note] The SAP Cloud SDK used to get the metadata for a destination (without potentially required authentication flows), through two requests to the destination service `/subaccountDestinations` and `/instanceDestinations`. While this approach has a some advantages when caching, it can cause severe performance issues when not caching. From now on, only one destination is retrieved per requested destination through `/destinations`.

--- a/.changeset/funny-weeks-warn.md
+++ b/.changeset/funny-weeks-warn.md
@@ -2,4 +2,5 @@
 '@sap-cloud-sdk/connectivity': minor
 ---
 
-[Compatibility Note] The SAP Cloud SDK used to get the metadata for a destination (without potentially required authentication flows), through two requests to the destination service `/subaccountDestinations` and `/instanceDestinations`. While this approach has a some advantages when caching, it can cause severe performance issues when not caching. From now on, only one destination is retrieved per requested destination through `/destinations`.
+[Compatibility Note] The SAP Cloud SDK used to get all subaccount and instance destinations, that are available with your JWT (without potentially required token retrieval), through two requests to the destination service (`/subaccountDestinations` and `/instanceDestinations`). While this approach can have advantages when caching, it can cause severe performance issues without caching. Therefore, from now on, only one destination is retrieved per requested destination through `/destinations`.
+You can no longer rely on the SDK to automatically cache all destinations on the first request. If needed, you can call `getAllDestinationsFromDestinationService()` with cache enabled instead.

--- a/.changeset/gorgeous-dogs-beam.md
+++ b/.changeset/gorgeous-dogs-beam.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Improvement] Retrieve only one destination per requested destination instead of all subaccount and instance destinations.

--- a/.changeset/gorgeous-dogs-beam.md
+++ b/.changeset/gorgeous-dogs-beam.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/connectivity': minor
 ---
 
-[Improvement] Retrieve only one destination per requested destination instead of all subaccount and instance destinations.
+[Improvement] Retrieve only one destination per requested destination instead of all subaccount and instance destinations. (See compatibility notes.)

--- a/packages/connectivity/src/scp-cf/circuit-breaker.spec.ts
+++ b/packages/connectivity/src/scp-cf/circuit-breaker.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../../test-resources/test/test-util/environment-mocks';
 import { privateKey } from '../../../../test-resources/test/test-util/keys';
 import { getClientCredentialsToken } from './xsuaa-service';
-import { fetchDestination } from './destination';
+import { fetchDestinationByToken } from './destination';
 
 const jwt = jwt123.sign(
   JSON.stringify({ user_id: 'user', zid: 'tenant' }),
@@ -30,7 +30,7 @@ describe('circuit breaker', () => {
 
   it('opens after 50% failed request attempts (with at least 10 recorded requests) for destination service', async () => {
     const request = () =>
-      fetchDestination(destinationServiceUri, jwt, {
+      fetchDestinationByToken(destinationServiceUri, jwt, {
         destinationName: 'FINAL-DESTINATION'
       });
 

--- a/packages/connectivity/src/scp-cf/circuit-breaker.spec.ts
+++ b/packages/connectivity/src/scp-cf/circuit-breaker.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../../test-resources/test/test-util/environment-mocks';
 import { privateKey } from '../../../../test-resources/test/test-util/keys';
 import { getClientCredentialsToken } from './xsuaa-service';
-import { fetchDestinationByToken } from './destination';
+import { fetchDestinationWithTokenRetrieval } from './destination';
 
 const jwt = jwt123.sign(
   JSON.stringify({ user_id: 'user', zid: 'tenant' }),
@@ -30,7 +30,7 @@ describe('circuit breaker', () => {
 
   it('opens after 50% failed request attempts (with at least 10 recorded requests) for destination service', async () => {
     const request = () =>
-      fetchDestinationByToken(destinationServiceUri, jwt, {
+      fetchDestinationWithTokenRetrieval(destinationServiceUri, jwt, {
         destinationName: 'FINAL-DESTINATION'
       });
 

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-authentication-type.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-authentication-type.spec.ts
@@ -10,8 +10,8 @@ import {
   mockServiceToken
 } from '../../../../../test-resources/test/test-util/token-accessor-mocks';
 import {
-  mockFindDestinationCalls,
-  mockFindDestinationCallsNotFound,
+  mockFetchDestinationCalls,
+  mockFetchDestinationCallsNotFound,
   mockVerifyJwt
 } from '../../../../../test-resources/test/test-util/destination-service-mocks';
 import {
@@ -61,9 +61,9 @@ describe('authentication types', () => {
     it('returns a destination with authTokens if its authenticationType is OAuth2SAMLBearerFlow, subscriber tenant', async () => {
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(oauthSingleResponse, {
+      const httpMocks = mockFetchDestinationCalls(oauthSingleResponse, {
         serviceToken: subscriberServiceToken,
-        mockAuthCall: {
+        mockWithTokenRetrievalCall: {
           headers: { 'x-user-token': subscriberUserToken }
         }
       });
@@ -79,8 +79,8 @@ describe('authentication types', () => {
     it('returns a destination with authTokens if its authenticationType is OAuth2SAMLBearerFlow, provider tenant', async () => {
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(oauthSingleResponse, {
-        mockAuthCall: {
+      const httpMocks = mockFetchDestinationCalls(oauthSingleResponse, {
+        mockWithTokenRetrievalCall: {
           headers: { authorization: `Bearer ${providerUserToken}` }
         }
       });
@@ -105,7 +105,9 @@ describe('authentication types', () => {
         }
       };
 
-      const httpMocks = mockFindDestinationCalls(samlDestinationWithSystemUser);
+      const httpMocks = mockFetchDestinationCalls(
+        samlDestinationWithSystemUser
+      );
 
       const destination = await getDestination({
         destinationName,
@@ -125,7 +127,7 @@ describe('authentication types', () => {
         }
       };
 
-      const httpMocks = mockFindDestinationCalls(
+      const httpMocks = mockFetchDestinationCalls(
         samlDestinationWithSystemUser,
         {
           serviceToken: subscriberServiceToken
@@ -146,7 +148,7 @@ describe('authentication types', () => {
     it('returns a destination with authTokens if its authenticationType is OAuth2ClientCredentials, subscriber tenant', async () => {
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(
+      const httpMocks = mockFetchDestinationCalls(
         oauthClientCredentialsSingleResponse,
         { serviceToken: subscriberServiceToken }
       );
@@ -164,7 +166,7 @@ describe('authentication types', () => {
     it('returns a destination with authTokens if its authenticationType is OAuth2ClientCredentials, provider tenant', async () => {
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(
+      const httpMocks = mockFetchDestinationCalls(
         oauthClientCredentialsSingleResponse
       );
 
@@ -187,10 +189,12 @@ describe('authentication types', () => {
       };
 
       const httpMocks = [
-        ...mockFindDestinationCalls(destinationWithTokenServiceType, {
-          mockAuthCall: { headers: { 'x-tenant': testTenants.subscriber } }
+        ...mockFetchDestinationCalls(destinationWithTokenServiceType, {
+          mockWithTokenRetrievalCall: {
+            headers: { 'x-tenant': testTenants.subscriber }
+          }
         }),
-        ...mockFindDestinationCallsNotFound(destinationName, {
+        ...mockFetchDestinationCallsNotFound(destinationName, {
           serviceToken: subscriberServiceToken
         })
       ];
@@ -211,10 +215,12 @@ describe('authentication types', () => {
       mockJwtBearerToken();
 
       const httpMocks = [
-        ...mockFindDestinationCalls(oauthJwtBearerSingleResponse, {
-          mockAuthCall: { headers: { 'x-user-token': subscriberUserToken } }
+        ...mockFetchDestinationCalls(oauthJwtBearerSingleResponse, {
+          mockWithTokenRetrievalCall: {
+            headers: { 'x-user-token': subscriberUserToken }
+          }
         }),
-        ...mockFindDestinationCallsNotFound(destinationName, {
+        ...mockFetchDestinationCallsNotFound(destinationName, {
           serviceToken: subscriberServiceToken
         })
       ];
@@ -232,11 +238,11 @@ describe('authentication types', () => {
 
   describe('authentication type OAuth2RefreshToken', () => {
     it('returns a destination with auth token if authentication type is OAuth2RefreshToken', async () => {
-      const httpMocks = mockFindDestinationCalls(
+      const httpMocks = mockFetchDestinationCalls(
         oauthRefreshTokenSingleResponse,
         {
           serviceToken: subscriberServiceToken,
-          mockAuthCall: {
+          mockWithTokenRetrievalCall: {
             headers: { 'x-refresh-token': 'dummy-refresh-token' }
           }
         }
@@ -254,11 +260,11 @@ describe('authentication types', () => {
     });
 
     it('fails if refresh token is not provided', async () => {
-      const httpMocks = mockFindDestinationCalls(
+      const httpMocks = mockFetchDestinationCalls(
         oauthRefreshTokenMultipleResponse[0],
         {
           serviceToken: subscriberServiceToken,
-          mockAuthCall: false
+          mockWithTokenRetrievalCall: false
         }
       );
 
@@ -276,10 +282,10 @@ describe('authentication types', () => {
     it('should use the user provider token as auth header and no exchange header for provider destination and provider jwt', async () => {
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(
+      const httpMocks = mockFetchDestinationCalls(
         oauthUserTokenExchangeSingleResponse,
         {
-          mockAuthCall: {
+          mockWithTokenRetrievalCall: {
             headers: { authorization: `Bearer ${providerUserToken}` }
           }
         }
@@ -298,10 +304,10 @@ describe('authentication types', () => {
     it('should use the provider access token as auth header and subscriber jwt as exchange header for provider destination and provider jwt', async () => {
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(
+      const httpMocks = mockFetchDestinationCalls(
         oauthUserTokenExchangeSingleResponse,
         {
-          mockAuthCall: {
+          mockWithTokenRetrievalCall: {
             headers: { 'x-user-token': subscriberUserToken }
           }
         }
@@ -321,11 +327,11 @@ describe('authentication types', () => {
     it('should use the subscriber access token as auth header and subscriber jwt as exchange header for provider destination and provider jwt', async () => {
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(
+      const httpMocks = mockFetchDestinationCalls(
         oauthUserTokenExchangeSingleResponse,
         {
           serviceToken: subscriberServiceToken,
-          mockAuthCall: {
+          mockWithTokenRetrievalCall: {
             headers: { 'x-user-token': subscriberUserToken }
           }
         }
@@ -347,7 +353,7 @@ describe('authentication types', () => {
     it('returns a destination with certificates if the authentication type is ClientCertificateAuthentication, subscriber tenant', async () => {
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(certificateSingleResponse, {
+      const httpMocks = mockFetchDestinationCalls(certificateSingleResponse, {
         serviceToken: subscriberServiceToken
       });
 
@@ -365,7 +371,7 @@ describe('authentication types', () => {
     it('returns a destination with certificates if the authentication type is ClientCertificateAuthentication, provider tenant', async () => {
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(certificateSingleResponse);
+      const httpMocks = mockFetchDestinationCalls(certificateSingleResponse);
 
       const destination = await getDestination({
         destinationName: 'ERNIE-UND-CERT',
@@ -380,10 +386,13 @@ describe('authentication types', () => {
 
   describe('authentication type BasicAuthentication', () => {
     it('returns a destination with OnPrem connectivity and basic auth', async () => {
-      const httpMocks = mockFindDestinationCalls(onPremiseBasicSingleResponse, {
-        serviceToken: subscriberServiceToken,
-        mockAuthCall: false
-      });
+      const httpMocks = mockFetchDestinationCalls(
+        onPremiseBasicSingleResponse,
+        {
+          serviceToken: subscriberServiceToken,
+          mockWithTokenRetrievalCall: false
+        }
+      );
 
       const destination = await getDestination({
         destinationName: 'OnPremise',
@@ -406,9 +415,9 @@ describe('authentication types', () => {
       mockVerifyJwt();
       const serviceTokenSpy = mockServiceToken();
 
-      const httpMocks = mockFindDestinationCalls(basicMultipleResponse[0], {
+      const httpMocks = mockFetchDestinationCalls(basicMultipleResponse[0], {
         serviceToken: subscriberServiceToken,
-        mockAuthCall: false
+        mockWithTokenRetrievalCall: false
       });
 
       const destination = await getDestination({
@@ -426,11 +435,11 @@ describe('authentication types', () => {
 
   describe('authentication type Principal Propagation', () => {
     it('returns a destination with onPrem connectivity and principal propagation', async () => {
-      const httpMocks = mockFindDestinationCalls(
+      const httpMocks = mockFetchDestinationCalls(
         onPremisePrincipalPropagationMultipleResponse[0],
         {
           serviceToken: subscriberServiceToken,
-          mockAuthCall: false
+          mockWithTokenRetrievalCall: false
         }
       );
 
@@ -453,10 +462,10 @@ describe('authentication types', () => {
     });
 
     it('fails for Principal Propagation and no user JWT', async () => {
-      const httpMocks = mockFindDestinationCalls(
+      const httpMocks = mockFetchDestinationCalls(
         onPremisePrincipalPropagationMultipleResponse[0],
         {
-          mockAuthCall: false
+          mockWithTokenRetrievalCall: false
         }
       );
 
@@ -469,11 +478,11 @@ describe('authentication types', () => {
     });
 
     it('fails for Principal Propagation and issuer JWT', async () => {
-      const httpMocks = mockFindDestinationCalls(
+      const httpMocks = mockFetchDestinationCalls(
         onPremisePrincipalPropagationMultipleResponse[0],
         {
           serviceToken: onlyIssuerServiceToken,
-          mockAuthCall: false
+          mockWithTokenRetrievalCall: false
         }
       );
 
@@ -494,11 +503,11 @@ describe('authentication types', () => {
     mockVerifyJwt();
     mockServiceToken();
 
-    const httpMocks = mockFindDestinationCalls(
+    const httpMocks = mockFetchDestinationCalls(
       onPremiseBasicMultipleResponse[0],
       {
         serviceToken: onlyIssuerServiceToken,
-        mockAuthCall: false
+        mockWithTokenRetrievalCall: false
       }
     );
 
@@ -519,9 +528,9 @@ describe('authentication types', () => {
     it('receives the SAML assertion in the destination', async () => {
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(samlAssertionSingleResponse, {
+      const httpMocks = mockFetchDestinationCalls(samlAssertionSingleResponse, {
         serviceToken: subscriberServiceToken,
-        mockAuthCall: {
+        mockWithTokenRetrievalCall: {
           headers: {
             'x-user-token': subscriberUserToken
           }
@@ -543,7 +552,7 @@ describe('authentication types', () => {
     it('returns a destination with auth token if authentication type is OAuth2Password', async () => {
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(oauthPasswordSingleResponse);
+      const httpMocks = mockFetchDestinationCalls(oauthPasswordSingleResponse);
 
       const destination = await getDestination({ destinationName });
       expect(destination).toMatchObject(

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-authentication-type.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-authentication-type.spec.ts
@@ -191,8 +191,7 @@ describe('authentication types', () => {
           mockAuthCall: { headers: { 'x-tenant': testTenants.subscriber } }
         }),
         ...mockFindDestinationCallsNotFound(destinationName, {
-          serviceToken: subscriberServiceToken,
-          mockAuthCall: false
+          serviceToken: subscriberServiceToken
         })
       ];
 
@@ -216,8 +215,7 @@ describe('authentication types', () => {
           mockAuthCall: { headers: { 'x-user-token': subscriberUserToken } }
         }),
         ...mockFindDestinationCallsNotFound(destinationName, {
-          serviceToken: subscriberServiceToken,
-          mockAuthCall: false
+          serviceToken: subscriberServiceToken
         })
       ];
 

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-authentication-type.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-authentication-type.spec.ts
@@ -1,5 +1,4 @@
-import nock from 'nock';
-import { decodeJwt, wrapJwtInHeader } from '../jwt';
+import { decodeJwt } from '../jwt';
 import {
   mockServiceBindings,
   onlyIssuerXsuaaUrl,
@@ -11,38 +10,31 @@ import {
   mockServiceToken
 } from '../../../../../test-resources/test/test-util/token-accessor-mocks';
 import {
-  mockInstanceDestinationsCall,
-  mockSingleDestinationCall,
-  mockSubaccountDestinationsCall,
+  mockFindDestinationCalls,
+  mockFindDestinationCallsNotFound,
   mockVerifyJwt
 } from '../../../../../test-resources/test/test-util/destination-service-mocks';
 import {
   onlyIssuerServiceToken,
-  providerServiceToken,
   providerUserToken,
   subscriberServiceToken,
   subscriberUserToken
 } from '../../../../../test-resources/test/test-util/mocked-access-tokens';
 import {
   basicMultipleResponse,
-  certificateMultipleResponse,
   certificateSingleResponse,
   destinationName,
-  oauthClientCredentialsMultipleResponse,
   oauthClientCredentialsSingleResponse,
-  oauthJwtBearerResponse,
   oauthJwtBearerSingleResponse,
-  oauthMultipleResponse,
-  oauthPasswordMultipleResponse,
   oauthPasswordSingleResponse,
   oauthRefreshTokenMultipleResponse,
   oauthRefreshTokenSingleResponse,
   oauthSingleResponse,
-  oauthUserTokenExchangeMultipleResponse,
   oauthUserTokenExchangeSingleResponse,
   onPremiseBasicMultipleResponse,
   onPremiseBasicSingleResponse,
-  onPremisePrincipalPropagationMultipleResponse
+  onPremisePrincipalPropagationMultipleResponse,
+  samlAssertionSingleResponse
 } from '../../../../../test-resources/test/test-util/example-destination-service-responses';
 import { clientCredentialsTokenCache } from '../client-credentials-token-cache';
 import { parseDestination } from './destination';
@@ -54,6 +46,12 @@ import {
 } from './destination-selection-strategies';
 
 describe('authentication types', () => {
+  beforeEach(() => {
+    mockServiceBindings();
+    mockVerifyJwt();
+    mockServiceToken();
+  });
+
   afterEach(() => {
     clientCredentialsTokenCache.clear();
     destinationCache.clear();
@@ -61,564 +59,348 @@ describe('authentication types', () => {
 
   describe('authentication type OAuth2SAMLBearerFlow', () => {
     it('returns a destination with authTokens if its authenticationType is OAuth2SAMLBearerFlow, subscriber tenant', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
       mockJwtBearerToken();
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          oauthMultipleResponse,
-          200,
-          subscriberServiceToken
-        ),
-        mockSingleDestinationCall(
-          nock,
-          oauthSingleResponse,
-          200,
-          destinationName,
-          {
-            ...wrapJwtInHeader(subscriberServiceToken).headers,
-            'X-user-token': subscriberUserToken
-          },
-          { badheaders: [] }
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(oauthSingleResponse, {
+        serviceToken: subscriberServiceToken,
+        mockAuthCall: {
+          headers: { 'x-user-token': subscriberUserToken }
+        }
+      });
 
-      const expected = parseDestination(oauthSingleResponse);
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName,
         jwt: subscriberUserToken
       });
-      expect(actual).toMatchObject(expected);
+      expect(destination).toMatchObject(parseDestination(oauthSingleResponse));
       expectAllMocksUsed(httpMocks);
     });
 
     it('returns a destination with authTokens if its authenticationType is OAuth2SAMLBearerFlow, provider tenant', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
       mockJwtBearerToken();
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(
-          nock,
-          oauthMultipleResponse,
-          200,
-          providerServiceToken
-        ),
-        mockSubaccountDestinationsCall(nock, [], 200, providerServiceToken),
-        mockSingleDestinationCall(
-          nock,
-          oauthSingleResponse,
-          200,
-          destinationName,
-          wrapJwtInHeader(providerUserToken).headers
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(oauthSingleResponse, {
+        mockAuthCall: {
+          headers: { authorization: `Bearer ${providerUserToken}` }
+        }
+      });
 
-      const expected = parseDestination(oauthSingleResponse);
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName,
         jwt: providerUserToken,
         cacheVerificationKeys: false
       });
 
-      expect(actual).toMatchObject(expected);
+      expect(destination).toMatchObject(parseDestination(oauthSingleResponse));
       expectAllMocksUsed(httpMocks);
     });
 
     it('should use provider client credentials token for SystemUser exists in provider destination', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
-
-      const samlDestinationsWithSystemUser = { ...oauthMultipleResponse[0] };
       // Insert SystemUser in the retrieved OAuth2SAMLBearer destination to trigger principle propagation workflow
-      samlDestinationsWithSystemUser['SystemUser'] = 'defined';
+      const samlDestinationWithSystemUser = {
+        ...oauthSingleResponse,
+        destinationConfiguration: {
+          ...oauthSingleResponse.destinationConfiguration,
+          SystemUser: 'defined'
+        }
+      };
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(
-          nock,
-          [samlDestinationsWithSystemUser],
-          200,
-          providerServiceToken
-        ),
-        mockSubaccountDestinationsCall(nock, [], 200, providerServiceToken),
-        // This single destination call is the one triggered by the OAuth2SAMLBearerAssertion flow
-        mockSingleDestinationCall(
-          nock,
-          oauthSingleResponse,
-          200,
-          destinationName,
-          wrapJwtInHeader(providerServiceToken).headers
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(samlDestinationWithSystemUser);
 
-      const expected = parseDestination(oauthSingleResponse);
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName,
         cacheVerificationKeys: false
       });
-      expect(actual).toMatchObject(expected);
+      expect(destination).toMatchObject(parseDestination(oauthSingleResponse));
       expectAllMocksUsed(httpMocks);
     });
 
     it('should use subscriber client credentials token for SystemUser exists in subscriber destination', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
-
-      const samlDestinationsWithSystemUser = { ...oauthMultipleResponse[0] };
       // Insert SystemUser in the retrieved OAuth2SAMLBearer destination to trigger principle propagation workflow
-      samlDestinationsWithSystemUser['SystemUser'] = 'defined';
+      const samlDestinationWithSystemUser = {
+        ...oauthSingleResponse,
+        destinationConfiguration: {
+          ...oauthSingleResponse.destinationConfiguration,
+          SystemUser: 'defined'
+        }
+      };
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(
-          nock,
-          [samlDestinationsWithSystemUser],
-          200,
-          subscriberServiceToken
-        ),
-        mockSubaccountDestinationsCall(nock, [], 200, subscriberServiceToken),
-        // This single destination call is the one triggered by the OAuth2SAMLBearerAssertion flow
-        mockSingleDestinationCall(
-          nock,
-          oauthSingleResponse,
-          200,
-          destinationName,
-          wrapJwtInHeader(subscriberServiceToken).headers
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(
+        samlDestinationWithSystemUser,
+        {
+          serviceToken: subscriberServiceToken
+        }
+      );
 
-      const expected = parseDestination(oauthSingleResponse);
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName,
         cacheVerificationKeys: false,
         jwt: subscriberUserToken
       });
-      expect(actual).toMatchObject(expected);
+      expect(destination).toMatchObject(parseDestination(oauthSingleResponse));
       expectAllMocksUsed(httpMocks);
     });
   });
 
   describe('authentication type OAuth2ClientCredentials', () => {
     it('returns a destination with authTokens if its authenticationType is OAuth2ClientCredentials, subscriber tenant', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
       mockJwtBearerToken();
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          oauthClientCredentialsMultipleResponse,
-          200,
-          subscriberServiceToken
-        ),
-        mockSingleDestinationCall(
-          nock,
-          oauthClientCredentialsSingleResponse,
-          200,
-          destinationName,
-          wrapJwtInHeader(subscriberServiceToken).headers
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(
+        oauthClientCredentialsSingleResponse,
+        { serviceToken: subscriberServiceToken }
+      );
 
-      const expected = parseDestination(oauthClientCredentialsSingleResponse);
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName,
         jwt: subscriberUserToken
       });
-      expect(actual).toMatchObject(expected);
+      expect(destination).toMatchObject(
+        parseDestination(oauthClientCredentialsSingleResponse)
+      );
       expectAllMocksUsed(httpMocks);
     });
 
     it('returns a destination with authTokens if its authenticationType is OAuth2ClientCredentials, provider tenant', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
       mockJwtBearerToken();
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, providerServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          oauthClientCredentialsMultipleResponse,
-          200,
-          providerServiceToken
-        ),
-        mockSingleDestinationCall(
-          nock,
-          oauthClientCredentialsSingleResponse,
-          200,
-          destinationName,
-          wrapJwtInHeader(providerServiceToken).headers
-        )
-      ];
-      const expected = parseDestination(oauthClientCredentialsSingleResponse);
-      const actual = await getDestination({ destinationName });
-      expect(actual).toMatchObject(expected);
+      const httpMocks = mockFindDestinationCalls(
+        oauthClientCredentialsSingleResponse
+      );
+
+      const destination = await getDestination({ destinationName });
+      expect(destination).toMatchObject(
+        parseDestination(oauthClientCredentialsSingleResponse)
+      );
       expectAllMocksUsed(httpMocks);
     });
 
-    it('returns a destination with authTokens if its authenticationType is OAuth2ClientCredentials, tokenServiceUrlType common and sets X-token header.', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
+    it('returns a destination with authTokens if its authenticationType is OAuth2ClientCredentials, tokenServiceUrlType common and sets x-tenant header.', async () => {
       mockJwtBearerToken();
 
-      const withTokenServiceType = {
+      const destinationWithTokenServiceType = {
         ...oauthClientCredentialsSingleResponse,
-        tokenServiceURLType: 'Common'
+        destinationConfiguration: {
+          ...oauthClientCredentialsSingleResponse.destinationConfiguration,
+          tokenServiceURLType: 'Common'
+        }
       };
 
       const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, providerServiceToken),
-        mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          [withTokenServiceType],
-          200,
-          providerServiceToken
-        ),
-        mockSubaccountDestinationsCall(nock, [], 200, subscriberServiceToken),
-        mockSingleDestinationCall(
-          nock,
-          withTokenServiceType,
-          200,
-          destinationName,
-          {
-            ...wrapJwtInHeader(providerServiceToken).headers,
-            'X-tenant': testTenants.subscriber
-          },
-          { badheaders: [] }
-        )
+        ...mockFindDestinationCalls(destinationWithTokenServiceType, {
+          mockAuthCall: { headers: { 'x-tenant': testTenants.subscriber } }
+        }),
+        ...mockFindDestinationCallsNotFound(destinationName, {
+          serviceToken: subscriberServiceToken,
+          mockAuthCall: false
+        })
       ];
 
-      const expected = parseDestination(oauthClientCredentialsSingleResponse);
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName,
         jwt: subscriberUserToken
       });
-      expect(actual).toMatchObject(expected);
+      expect(destination).toMatchObject(
+        parseDestination(oauthClientCredentialsSingleResponse)
+      );
       expectAllMocksUsed(httpMocks);
     });
   });
 
   describe('authentication type OAuth2JWTBearer', () => {
     it('should use provider service token subscriber x-user-token for provider destination and subscriber jwt', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
       mockJwtBearerToken();
 
       const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, providerServiceToken),
-        mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken),
-        mockSubaccountDestinationsCall(nock, [], 200, subscriberServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          oauthJwtBearerResponse,
-          200,
-          providerServiceToken
-        ),
-        mockSingleDestinationCall(
-          nock,
-          oauthJwtBearerSingleResponse,
-          200,
-          destinationName,
-          {
-            ...wrapJwtInHeader(providerServiceToken).headers,
-            'x-user-token': subscriberUserToken
-          },
-          { badheaders: [] }
-        )
+        ...mockFindDestinationCalls(oauthJwtBearerSingleResponse, {
+          mockAuthCall: { headers: { 'x-user-token': subscriberUserToken } }
+        }),
+        ...mockFindDestinationCallsNotFound(destinationName, {
+          serviceToken: subscriberServiceToken,
+          mockAuthCall: false
+        })
       ];
 
-      const expected = parseDestination(oauthJwtBearerSingleResponse);
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName,
         jwt: subscriberUserToken
       });
-      expect(actual).toMatchObject(expected);
+      expect(destination).toMatchObject(
+        parseDestination(oauthJwtBearerSingleResponse)
+      );
       expectAllMocksUsed(httpMocks);
     });
   });
 
   describe('authentication type OAuth2RefreshToken', () => {
     it('returns a destination with auth token if authentication type is OAuth2RefreshToken', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
+      const httpMocks = mockFindDestinationCalls(
+        oauthRefreshTokenSingleResponse,
+        {
+          serviceToken: subscriberServiceToken,
+          mockAuthCall: {
+            headers: { 'x-refresh-token': 'dummy-refresh-token' }
+          }
+        }
+      );
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          oauthRefreshTokenMultipleResponse,
-          200,
-          subscriberServiceToken
-        ),
-        mockSingleDestinationCall(
-          nock,
-          oauthRefreshTokenSingleResponse,
-          200,
-          destinationName,
-          {
-            ...wrapJwtInHeader(subscriberServiceToken).headers,
-            'X-refresh-token': 'dummy-refresh-token'
-          },
-          { badheaders: [] }
-        )
-      ];
-
-      const expected = parseDestination(oauthRefreshTokenSingleResponse);
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName,
         jwt: subscriberUserToken,
         refreshToken: 'dummy-refresh-token'
       });
-      expect(actual).toMatchObject(expected);
+      expect(destination).toMatchObject(
+        parseDestination(oauthRefreshTokenSingleResponse)
+      );
       expectAllMocksUsed(httpMocks);
     });
 
     it('fails if refresh token is not provided', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
+      const httpMocks = mockFindDestinationCalls(
+        oauthRefreshTokenMultipleResponse[0],
+        {
+          serviceToken: subscriberServiceToken,
+          mockAuthCall: false
+        }
+      );
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          oauthRefreshTokenMultipleResponse,
-          200,
-          subscriberServiceToken
-        )
-      ];
       await expect(
         getDestination({
           destinationName,
           jwt: subscriberUserToken
         })
-      ).rejects.toThrowError(/No refresh token has been provided./);
+      ).rejects.toThrow(/No refresh token has been provided./);
       expectAllMocksUsed(httpMocks);
     });
   });
+
   describe('authentication type OAuth2UserTokenExchange', () => {
     it('should use the user provider token as auth header and no exchange header for provider destination and provider jwt', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
       mockJwtBearerToken();
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, providerServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          oauthUserTokenExchangeMultipleResponse,
-          200,
-          providerServiceToken
-        ),
-        mockSingleDestinationCall(
-          nock,
-          oauthUserTokenExchangeSingleResponse,
-          200,
-          destinationName,
-          wrapJwtInHeader(providerUserToken).headers
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(
+        oauthUserTokenExchangeSingleResponse,
+        {
+          mockAuthCall: {
+            headers: { authorization: `Bearer ${providerUserToken}` }
+          }
+        }
+      );
 
-      const expected = parseDestination(oauthUserTokenExchangeSingleResponse);
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName,
         jwt: providerUserToken
       });
-      expect(actual).toMatchObject(expected);
+      expect(destination).toMatchObject(
+        parseDestination(oauthUserTokenExchangeSingleResponse)
+      );
       expectAllMocksUsed(httpMocks);
     });
 
     it('should use the provider access token as auth header and subscriber jwt as exchange header for provider destination and provider jwt', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
       mockJwtBearerToken();
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, providerServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          oauthUserTokenExchangeMultipleResponse,
-          200,
-          providerServiceToken
-        ),
-        mockSingleDestinationCall(
-          nock,
-          oauthUserTokenExchangeSingleResponse,
-          200,
-          destinationName,
-          {
-            ...wrapJwtInHeader(providerServiceToken).headers,
-            'X-user-token': subscriberUserToken
-          },
-          { badheaders: [] }
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(
+        oauthUserTokenExchangeSingleResponse,
+        {
+          mockAuthCall: {
+            headers: { 'x-user-token': subscriberUserToken }
+          }
+        }
+      );
 
-      const expected = parseDestination(oauthUserTokenExchangeSingleResponse);
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName,
         selectionStrategy: alwaysProvider,
         jwt: subscriberUserToken
       });
-      expect(actual).toMatchObject(expected);
+      expect(destination).toMatchObject(
+        parseDestination(oauthUserTokenExchangeSingleResponse)
+      );
       expectAllMocksUsed(httpMocks);
     });
 
     it('should use the subscriber access token as auth header and subscriber jwt as exchange header for provider destination and provider jwt', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
       mockJwtBearerToken();
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          oauthUserTokenExchangeMultipleResponse,
-          200,
-          subscriberServiceToken
-        ),
-        mockSingleDestinationCall(
-          nock,
-          oauthUserTokenExchangeSingleResponse,
-          200,
-          destinationName,
-          {
-            ...wrapJwtInHeader(subscriberServiceToken).headers,
-            'X-user-token': subscriberUserToken
-          },
-          { badheaders: [] }
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(
+        oauthUserTokenExchangeSingleResponse,
+        {
+          serviceToken: subscriberServiceToken,
+          mockAuthCall: {
+            headers: { 'x-user-token': subscriberUserToken }
+          }
+        }
+      );
 
-      const expected = parseDestination(oauthUserTokenExchangeSingleResponse);
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName,
         selectionStrategy: alwaysSubscriber,
         jwt: subscriberUserToken
       });
-      expect(actual).toMatchObject(expected);
+      expect(destination).toMatchObject(
+        parseDestination(oauthUserTokenExchangeSingleResponse)
+      );
       expectAllMocksUsed(httpMocks);
     });
   });
 
   describe('authentication type ClientCertificateAuthentication', () => {
     it('returns a destination with certificates if the authentication type is ClientCertificateAuthentication, subscriber tenant', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
       mockJwtBearerToken();
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          certificateMultipleResponse,
-          200,
-          subscriberServiceToken
-        ),
-        mockSingleDestinationCall(
-          nock,
-          certificateSingleResponse,
-          200,
-          'ERNIE-UND-CERT',
-          wrapJwtInHeader(subscriberServiceToken).headers
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(certificateSingleResponse, {
+        serviceToken: subscriberServiceToken
+      });
 
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName: 'ERNIE-UND-CERT',
         jwt: subscriberUserToken,
         cacheVerificationKeys: false
       });
-      expect(actual!.certificates!.length).toBe(1);
-      expect(actual!.keyStoreName).toBe('key.p12');
-      expect(actual!.keyStorePassword).toBe('password');
+      expect(destination?.certificates?.length).toBe(1);
+      expect(destination?.keyStoreName).toBe('key.p12');
+      expect(destination?.keyStorePassword).toBe('password');
       expectAllMocksUsed(httpMocks);
     });
 
     it('returns a destination with certificates if the authentication type is ClientCertificateAuthentication, provider tenant', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
       mockJwtBearerToken();
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, providerServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          certificateMultipleResponse,
-          200,
-          providerServiceToken
-        ),
-        mockSingleDestinationCall(
-          nock,
-          certificateSingleResponse,
-          200,
-          'ERNIE-UND-CERT',
-          wrapJwtInHeader(providerServiceToken).headers
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(certificateSingleResponse);
 
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName: 'ERNIE-UND-CERT',
         cacheVerificationKeys: false
       });
-      expect(actual!.certificates!.length).toBe(1);
-      expect(actual!.keyStoreName).toBe('key.p12');
-      expect(actual!.keyStorePassword).toBe('password');
+      expect(destination?.certificates!.length).toBe(1);
+      expect(destination?.keyStoreName).toBe('key.p12');
+      expect(destination?.keyStorePassword).toBe('password');
       expectAllMocksUsed(httpMocks);
     });
   });
 
   describe('authentication type BasicAuthentication', () => {
     it('returns a destination with OnPrem connectivity and basic auth', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
+      const httpMocks = mockFindDestinationCalls(onPremiseBasicSingleResponse, {
+        serviceToken: subscriberServiceToken,
+        mockAuthCall: false
+      });
 
-      mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken);
-      mockSubaccountDestinationsCall(
-        nock,
-        onPremiseBasicMultipleResponse,
-        200,
-        subscriberServiceToken
-      );
-      mockSingleDestinationCall(
-        nock,
-        onPremiseBasicSingleResponse,
-        200,
-        destinationName,
-        wrapJwtInHeader(subscriberServiceToken).headers
-      );
-
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName: 'OnPremise',
         jwt: subscriberUserToken,
         cacheVerificationKeys: false,
         selectionStrategy: alwaysSubscriber
       });
-      expect(actual?.proxyConfiguration).toMatchObject({
+
+      expect(destination?.proxyConfiguration).toMatchObject({
         host: 'proxy.example.com',
         port: 12345,
         protocol: 'http',
         headers: { 'Proxy-Authorization': expect.stringMatching(/Bearer.*/) }
       });
+      expectAllMocksUsed(httpMocks);
     });
 
     it('returns a destination without authTokens if its authenticationType is Basic', async () => {
@@ -626,23 +408,19 @@ describe('authentication types', () => {
       mockVerifyJwt();
       const serviceTokenSpy = mockServiceToken();
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          basicMultipleResponse,
-          200,
-          subscriberServiceToken
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(basicMultipleResponse[0], {
+        serviceToken: subscriberServiceToken,
+        mockAuthCall: false
+      });
 
-      const expected = parseDestination(basicMultipleResponse[0]);
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName,
         jwt: subscriberUserToken,
         cacheVerificationKeys: false
       });
-      expect(actual).toMatchObject(expected);
+      expect(destination).toMatchObject(
+        parseDestination(basicMultipleResponse[0])
+      );
       expect(serviceTokenSpy).toHaveBeenCalled();
       expectAllMocksUsed(httpMocks);
     });
@@ -650,27 +428,21 @@ describe('authentication types', () => {
 
   describe('authentication type Principal Propagation', () => {
     it('returns a destination with onPrem connectivity and principal propagation', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
+      const httpMocks = mockFindDestinationCalls(
+        onPremisePrincipalPropagationMultipleResponse[0],
+        {
+          serviceToken: subscriberServiceToken,
+          mockAuthCall: false
+        }
+      );
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          onPremisePrincipalPropagationMultipleResponse,
-          200,
-          subscriberServiceToken
-        )
-      ];
-
-      const actual = await getDestination({
+      const destination = await getDestination({
         destinationName: 'OnPremise',
         jwt: subscriberUserToken,
         cacheVerificationKeys: false,
         selectionStrategy: alwaysSubscriber
       });
-      expect(actual?.proxyConfiguration).toMatchObject({
+      expect(destination?.proxyConfiguration).toMatchObject({
         host: 'proxy.example.com',
         port: 12345,
         protocol: 'http',
@@ -683,49 +455,36 @@ describe('authentication types', () => {
     });
 
     it('fails for Principal Propagation and no user JWT', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
-
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, providerServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          onPremisePrincipalPropagationMultipleResponse,
-          200,
-          providerServiceToken
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(
+        onPremisePrincipalPropagationMultipleResponse[0],
+        {
+          mockAuthCall: false
+        }
+      );
 
       await expect(
         getDestination({ destinationName: 'OnPremise' })
-      ).rejects.toThrowError(
+      ).rejects.toThrow(
         "No user token (JWT) has been provided. This is strictly necessary for 'PrincipalPropagation'."
       );
       expectAllMocksUsed(httpMocks);
     });
 
     it('fails for Principal Propagation and issuer JWT', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
-
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, onlyIssuerServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          onPremisePrincipalPropagationMultipleResponse,
-          200,
-          onlyIssuerServiceToken
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(
+        onPremisePrincipalPropagationMultipleResponse[0],
+        {
+          serviceToken: onlyIssuerServiceToken,
+          mockAuthCall: false
+        }
+      );
 
       await expect(
         getDestination({
           destinationName: 'OnPremise',
           iss: onlyIssuerXsuaaUrl
         })
-      ).rejects.toThrowError(
+      ).rejects.toThrow(
         "No user token (JWT) has been provided. This is strictly necessary for 'PrincipalPropagation'."
       );
       expectAllMocksUsed(httpMocks);
@@ -737,80 +496,61 @@ describe('authentication types', () => {
     mockVerifyJwt();
     mockServiceToken();
 
-    const httpMocks = [
-      mockInstanceDestinationsCall(nock, [], 200, onlyIssuerServiceToken),
-      mockSubaccountDestinationsCall(
-        nock,
-        onPremiseBasicMultipleResponse,
-        200,
-        onlyIssuerServiceToken
-      )
-    ];
+    const httpMocks = mockFindDestinationCalls(
+      onPremiseBasicMultipleResponse[0],
+      {
+        serviceToken: onlyIssuerServiceToken,
+        mockAuthCall: false
+      }
+    );
 
-    const dest = await getDestination({
+    const destination = await getDestination({
       destinationName: 'OnPremise',
       iss: onlyIssuerXsuaaUrl
     });
 
     const proxyToken =
-      dest?.proxyConfiguration!.headers!['Proxy-Authorization'].split(' ')[1];
+      destination?.proxyConfiguration!.headers!['Proxy-Authorization'].split(
+        ' '
+      )[1];
     expect(decodeJwt(proxyToken!).zid).toEqual(testTenants.subscriberOnlyIss);
     expectAllMocksUsed(httpMocks);
   });
 
   describe('authentication type SamlAssertion', () => {
-    it('receives the saml assertion in the destination', async () => {
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, providerServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          oauthPasswordMultipleResponse,
-          200,
-          providerServiceToken
-        ),
-        mockSingleDestinationCall(
-          nock,
-          oauthPasswordSingleResponse,
-          200,
-          destinationName,
-          wrapJwtInHeader(providerServiceToken).headers
-        )
-      ];
+    it('receives the SAML assertion in the destination', async () => {
+      mockJwtBearerToken();
 
-      const expected = parseDestination(oauthPasswordSingleResponse);
-      const actual = await getDestination({ destinationName });
-      expect(actual).toMatchObject(expected);
+      const httpMocks = mockFindDestinationCalls(samlAssertionSingleResponse, {
+        serviceToken: subscriberServiceToken,
+        mockAuthCall: {
+          headers: {
+            'x-user-token': subscriberUserToken
+          }
+        }
+      });
+
+      const destination = await getDestination({
+        destinationName,
+        jwt: subscriberUserToken
+      });
+      expect(destination).toMatchObject(
+        parseDestination(samlAssertionSingleResponse)
+      );
       expectAllMocksUsed(httpMocks);
     });
   });
 
   describe('authentication type OAuth2Password', () => {
     it('returns a destination with auth token if authentication type is OAuth2Password', async () => {
-      mockServiceBindings();
-      mockVerifyJwt();
-      mockServiceToken();
       mockJwtBearerToken();
 
-      const httpMocks = [
-        mockInstanceDestinationsCall(nock, [], 200, providerServiceToken),
-        mockSubaccountDestinationsCall(
-          nock,
-          oauthPasswordMultipleResponse,
-          200,
-          providerServiceToken
-        ),
-        mockSingleDestinationCall(
-          nock,
-          oauthPasswordSingleResponse,
-          200,
-          destinationName,
-          wrapJwtInHeader(providerServiceToken).headers
-        )
-      ];
+      const httpMocks = mockFindDestinationCalls(oauthPasswordSingleResponse);
 
-      const expected = parseDestination(oauthPasswordSingleResponse);
-      const actual = await getDestination({ destinationName });
-      expect(actual).toMatchObject(expected);
+      const destination = await getDestination({ destinationName });
+      expect(destination).toMatchObject(
+        parseDestination(oauthPasswordSingleResponse)
+      );
       expectAllMocksUsed(httpMocks);
     });
   });

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-failure-cases.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-failure-cases.spec.ts
@@ -140,12 +140,9 @@ describe('Failure cases', () => {
     mockServiceToken();
 
     const httpMocks = [
+      ...mockFindDestinationCallsNotFound(destinationName),
       ...mockFindDestinationCallsNotFound(destinationName, {
-        mockAuthCall: false
-      }),
-      ...mockFindDestinationCallsNotFound(destinationName, {
-        serviceToken: subscriberServiceToken,
-        mockAuthCall: false
+        serviceToken: subscriberServiceToken
       })
     ];
 

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-failure-cases.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-failure-cases.spec.ts
@@ -1,4 +1,3 @@
-import nock from 'nock';
 import {
   mockServiceBindings,
   xsuaaBindingMock
@@ -72,7 +71,6 @@ describe('Failure cases', () => {
 
     const httpMocks = [
       mockInstanceDestinationsCall(
-        nock,
         {
           ErrorMessage: 'Unable to parse the JWT in Authorization Header.'
         },
@@ -80,7 +78,6 @@ describe('Failure cases', () => {
         subscriberServiceToken
       ),
       mockSubaccountDestinationsCall(
-        nock,
         basicMultipleResponse,
         200,
         subscriberServiceToken

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-failure-cases.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-failure-cases.spec.ts
@@ -11,8 +11,8 @@ import {
   mockServiceToken
 } from '../../../../../test-resources/test/test-util/token-accessor-mocks';
 import {
-  mockFindDestinationCalls,
-  mockFindDestinationCallsNotFound,
+  mockFetchDestinationCalls,
+  mockFetchDestinationCallsNotFound,
   mockInstanceDestinationsCall,
   mockSubaccountDestinationsCall,
   mockVerifyJwt
@@ -103,9 +103,9 @@ describe('Failure cases', () => {
     mockServiceToken();
     mockJwtBearerToken();
 
-    const httpMocks = mockFindDestinationCalls(oauthMultipleResponse[0], {
+    const httpMocks = mockFetchDestinationCalls(oauthMultipleResponse[0], {
       serviceToken: subscriberServiceToken,
-      mockAuthCall: {
+      mockWithTokenRetrievalCall: {
         responseCode: 401,
         response: {
           ErrorMessage: 'Unable to parse the JWT in Authorization Header.'
@@ -137,8 +137,8 @@ describe('Failure cases', () => {
     mockServiceToken();
 
     const httpMocks = [
-      ...mockFindDestinationCallsNotFound(destinationName),
-      ...mockFindDestinationCallsNotFound(destinationName, {
+      ...mockFetchDestinationCallsNotFound(destinationName),
+      ...mockFetchDestinationCallsNotFound(destinationName, {
         serviceToken: subscriberServiceToken
       })
     ];
@@ -158,8 +158,8 @@ describe('Failure cases', () => {
     mockVerifyJwt();
     mockServiceToken();
 
-    const [httpMock] = mockFindDestinationCalls(oauthMultipleResponse[0], {
-      mockAuthCall: false
+    const [httpMock] = mockFetchDestinationCalls(oauthMultipleResponse[0], {
+      mockWithTokenRetrievalCall: false
     });
 
     await expect(

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-jwks.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-jwks.spec.ts
@@ -1,13 +1,9 @@
 import nock from 'nock';
 import {
   customSubscriberUserToken,
-  destinationName,
-  destinationSingleResponse,
-  mockInstanceDestinationsCall,
+  mockFindDestinationCalls,
   mockServiceBindings,
   mockServiceToken,
-  mockSingleDestinationCall,
-  mockSubaccountDestinationsCall,
   oauthMultipleResponse,
   providerServiceToken
 } from '../../../../../test-resources/test/test-util';
@@ -37,18 +33,11 @@ describe('custom JWTs', () => {
     serviceToken: string,
     userJwt: string
   ) {
-    mockInstanceDestinationsCall(nock, [], 200, serviceToken);
-
-    mockSubaccountDestinationsCall(nock, [destination], 200, serviceToken);
-
-    mockSingleDestinationCall(
-      nock,
-      destinationSingleResponse([destination]),
-      200,
-      destinationName,
-      { authorization: `Bearer ${serviceToken}`, 'x-user-token': userJwt },
-      { badheaders: [] }
-    );
+    mockFindDestinationCalls(destination, {
+      serviceToken,
+      badheaders: [],
+      mockAuthCall: { headers: { 'x-user-token': userJwt } }
+    });
   }
 
   it('throws an error if jwks properties are not given in the destination', async () => {

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-jwks.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-jwks.spec.ts
@@ -35,7 +35,6 @@ describe('custom JWTs', () => {
   ) {
     mockFindDestinationCalls(destination, {
       serviceToken,
-      badheaders: [],
       mockAuthCall: { headers: { 'x-user-token': userJwt } }
     });
   }

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-jwks.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-jwks.spec.ts
@@ -1,7 +1,7 @@
 import nock from 'nock';
 import {
   customSubscriberUserToken,
-  mockFindDestinationCalls,
+  mockFetchDestinationCalls,
   mockServiceBindings,
   mockServiceToken,
   oauthMultipleResponse,
@@ -33,9 +33,11 @@ describe('custom JWTs', () => {
     serviceToken: string,
     userJwt: string
   ) {
-    mockFindDestinationCalls(destination, {
+    mockFetchDestinationCalls(destination, {
       serviceToken,
-      mockAuthCall: { headers: { 'x-user-token': userJwt } }
+      mockWithTokenRetrievalCall: {
+        headers: { 'x-user-token': userJwt }
+      }
     });
   }
 

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
@@ -216,7 +216,7 @@ describe('jwtType x selection strategy combinations. Possible values are {subscr
 
       const requestSpy = jest.spyOn(
         destinationService,
-        'fetchSubaccountDestinations'
+        'fetchDestinations'
       );
       const actual = await fetchDestination(
         subscriberUserToken,
@@ -237,7 +237,7 @@ describe('jwtType x selection strategy combinations. Possible values are {subscr
 
       const requestSpy = jest.spyOn(
         destinationService,
-        'fetchSubaccountDestinations'
+        'fetchDestinations'
       );
       const actual = await fetchDestination(
         subscriberUserToken,

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
@@ -2,8 +2,8 @@ import { createLogger, ErrorWithCause } from '@sap-cloud-sdk/util';
 import { AxiosError } from 'axios';
 import nock from 'nock';
 import {
-  mockFindDestinationCalls,
-  mockFindDestinationCallsNotFound,
+  mockFetchDestinationCalls,
+  mockFetchDestinationCallsNotFound,
   mockInstanceDestinationsCall,
   mockSubaccountDestinationsCall,
   mockVerifyJwt
@@ -141,12 +141,12 @@ async function fetchDestination(
 
 function mockDestinationMetadataCalls() {
   return {
-    providerMock: mockFindDestinationCalls(providerDestination, {
-      mockAuthCall: false
+    providerMock: mockFetchDestinationCalls(providerDestination, {
+      mockWithTokenRetrievalCall: false
     })[0],
-    subscriberMock: mockFindDestinationCalls(subscriberDestination, {
+    subscriberMock: mockFetchDestinationCalls(subscriberDestination, {
       serviceToken: subscriberServiceToken,
-      mockAuthCall: false
+      mockWithTokenRetrievalCall: false
     })[0]
   };
 }
@@ -208,9 +208,9 @@ describe('jwtType x selection strategy combinations. Possible values are {subscr
     });
 
     it('subscriberUserToken && subscriberFirst: should try subscriber first (found nothing), provider called and return provider destination', async () => {
-      const [subscriberMock] = mockFindDestinationCalls(providerDestination);
+      const [subscriberMock] = mockFetchDestinationCalls(providerDestination);
 
-      const [providerMock] = mockFindDestinationCallsNotFound(
+      const [providerMock] = mockFetchDestinationCallsNotFound(
         subscriberDestination.Name!,
         { serviceToken: subscriberServiceToken }
       );
@@ -231,8 +231,8 @@ describe('jwtType x selection strategy combinations. Possible values are {subscr
       mockServiceBindings();
       mockServiceToken();
 
-      mockFindDestinationCalls(basicMultipleResponse[0], {
-        mockAuthCall: false
+      mockFetchDestinationCalls(basicMultipleResponse[0], {
+        mockWithTokenRetrievalCall: false
       });
 
       expect(
@@ -251,9 +251,9 @@ describe('jwtType x selection strategy combinations. Possible values are {subscr
         .spyOn(identityService, 'exchangeToken')
         .mockImplementationOnce(() => Promise.resolve(subscriberUserToken));
 
-      mockFindDestinationCalls(samlAssertionMultipleResponse[0], {
+      mockFetchDestinationCalls(samlAssertionMultipleResponse[0], {
         serviceToken: onlyIssuerServiceToken,
-        mockAuthCall: {
+        mockWithTokenRetrievalCall: {
           headers: { 'x-user-token': subscriberUserToken }
         }
       });
@@ -272,7 +272,7 @@ describe('jwtType x selection strategy combinations. Possible values are {subscr
       mockServiceBindings();
       mockServiceToken();
 
-      mockFindDestinationCalls(certificateSingleResponse, {
+      mockFetchDestinationCalls(certificateSingleResponse, {
         serviceToken: onlyIssuerServiceToken
       });
 

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
@@ -89,11 +89,10 @@ const parsedSubscriberDestination: DestinationWithoutToken = {
   url: 'http://subscriber.com'
 };
 
-function mockProvider(returnEmpty = false): nock.Scope[] {
+function mockGetAllProvider(returnEmpty = false): nock.Scope[] {
   return [
-    mockInstanceDestinationsCall(nock, [], 200, providerServiceToken),
+    mockInstanceDestinationsCall([], 200, providerServiceToken),
     mockSubaccountDestinationsCall(
-      nock,
       returnEmpty ? [] : [providerDestination],
       200,
       providerServiceToken
@@ -101,11 +100,10 @@ function mockProvider(returnEmpty = false): nock.Scope[] {
   ];
 }
 
-function mockSubscriber(returnEmpty = false): nock.Scope[] {
+function mockGetAllSubscriber(returnEmpty = false): nock.Scope[] {
   return [
-    mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken),
+    mockInstanceDestinationsCall([], 200, subscriberServiceToken),
     mockSubaccountDestinationsCall(
-      nock,
       returnEmpty ? [] : [subscriberDestination],
       200,
       subscriberServiceToken
@@ -113,16 +111,14 @@ function mockSubscriber(returnEmpty = false): nock.Scope[] {
   ];
 }
 
-function mockInternalErrorSubscriber(): nock.Scope[] {
+function mockGetAllInternalErrorSubscriber(): nock.Scope[] {
   return [
     mockInstanceDestinationsCall(
-      nock,
       'Internal Server Error',
       500,
       subscriberServiceToken
     ),
     mockSubaccountDestinationsCall(
-      nock,
       'Internal Server Error',
       500,
       subscriberServiceToken
@@ -344,8 +340,8 @@ describe('call getAllDestinations with and without subscriber token', () => {
       messageContext: 'destination-accessor'
     });
 
-    mockSubscriber();
-    mockProvider();
+    mockGetAllSubscriber();
+    mockGetAllProvider();
 
     const debugSpy = jest.spyOn(logger, 'debug');
 
@@ -364,15 +360,15 @@ describe('call getAllDestinations with and without subscriber token', () => {
   });
 
   it('should fetch all provider destinations when called without passing a JWT', async () => {
-    mockSubscriber();
-    mockProvider();
+    mockGetAllSubscriber();
+    mockGetAllProvider();
     const allDestinations = await getAllDestinationsFromDestinationService();
     expect(allDestinations).toEqual([parsedProviderDestination]);
   });
 
   it('should return an empty array if no destination are present', async () => {
-    mockSubscriber(true);
-    mockProvider(true);
+    mockGetAllSubscriber(true);
+    mockGetAllProvider(true);
 
     const logger = createLogger({
       package: 'connectivity',
@@ -388,7 +384,7 @@ describe('call getAllDestinations with and without subscriber token', () => {
   });
 
   it('should throw an error', async () => {
-    mockInternalErrorSubscriber();
+    mockGetAllInternalErrorSubscriber();
 
     await getAllDestinationsFromDestinationService({
       jwt: subscriberUserToken

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
@@ -12,7 +12,7 @@ import {
 import {
   mockCertificateCall,
   mockVerifyJwt,
-  mockFindDestinationCalls
+  mockFetchDestinationCalls
 } from '../../../../../test-resources/test/test-util/destination-service-mocks';
 import {
   providerServiceToken,
@@ -92,9 +92,9 @@ describe('get destination with PrivateLink proxy type', () => {
     mockServiceToken();
     mockJwtBearerToken();
 
-    mockFindDestinationCalls(privateLinkDest, {
+    mockFetchDestinationCalls(privateLinkDest, {
       serviceToken: subscriberServiceToken,
-      mockAuthCall: false
+      mockWithTokenRetrievalCall: false
     });
   });
 
@@ -175,8 +175,8 @@ describe('truststore configuration', () => {
     mockServiceToken();
     mockJwtBearerToken();
 
-    mockFindDestinationCalls(destinationWithTrustStore, {
-      mockAuthCall: false
+    mockFetchDestinationCalls(destinationWithTrustStore, {
+      mockWithTokenRetrievalCall: false
     });
 
     const actual = await getDestination({

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
@@ -169,24 +169,11 @@ describe('truststore configuration', () => {
       URL: 'some.example',
       TrustStoreLocation: 'my-cert.pem'
     };
-    mockCertificateCall(
-      nock,
-      'my-cert.pem',
-      providerServiceToken,
-      'subaccount'
-    );
+    mockCertificateCall('my-cert.pem', providerServiceToken, 'subaccount');
     mockServiceBindings();
     mockVerifyJwt();
     mockServiceToken();
     mockJwtBearerToken();
-
-    // mockInstanceDestinationsCall(nock, [], 200, providerServiceToken);
-    // mockSubaccountDestinationsCall(
-    //   nock,
-    //   [destinationWithTrustStore],
-    //   200,
-    //   providerServiceToken
-    // );
 
     mockFindDestinationCalls(destinationWithTrustStore, {
       mockAuthCall: false

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor.ts
@@ -21,12 +21,9 @@ import {
   DestinationWithoutToken
 } from './destination-accessor-types';
 import { searchRegisteredDestination } from './destination-from-registration';
-import {
-  fetchInstanceDestinations,
-  fetchSubaccountDestinations
-} from './destination-service';
 import { getSubscriberToken } from './get-subscriber-token';
 import { getProviderServiceToken } from './get-provider-token';
+import { fetchDestinations } from './destination-service';
 
 const logger = createLogger({
   package: 'connectivity',
@@ -147,8 +144,18 @@ export async function getAllDestinationsFromDestinationService(
   );
 
   const [instance, subaccount] = await Promise.all([
-    fetchInstanceDestinations(destinationServiceUri, token.encoded, options),
-    fetchSubaccountDestinations(destinationServiceUri, token.encoded, options)
+    fetchDestinations(
+      destinationServiceUri,
+      token.encoded,
+      'instance',
+      options
+    ),
+    fetchDestinations(
+      destinationServiceUri,
+      token.encoded,
+      'subaccount',
+      options
+    )
   ]);
 
   const loggerMessage =

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
@@ -2,8 +2,8 @@ import { createLogger } from '@sap-cloud-sdk/util';
 import nock from 'nock';
 import { decodeJwt } from '../jwt';
 import {
-  mockFindDestinationCalls,
-  mockFindDestinationCallsNotFound,
+  mockFetchDestinationCalls,
+  mockFetchDestinationCallsNotFound,
   mockVerifyJwt
 } from '../../../../../test-resources/test/test-util/destination-service-mocks';
 import {
@@ -96,10 +96,12 @@ function mockDestinationsWithSameName() {
     Authentication: 'NoAuthentication' as const
   };
 
-  mockFindDestinationCalls(destination, { mockAuthCall: false });
-  mockFindDestinationCalls(destination, {
+  mockFetchDestinationCalls(destination, {
+    mockWithTokenRetrievalCall: false
+  });
+  mockFetchDestinationCalls(destination, {
     serviceToken: subscriberServiceToken,
-    mockAuthCall: false
+    mockWithTokenRetrievalCall: false
   });
 }
 
@@ -142,11 +144,11 @@ describe('destination cache', () => {
         Authentication: 'NoAuthentication' as const
       };
 
-      mockFindDestinationCalls(providerDest);
-      mockFindDestinationCalls(subscriberDest, {
+      mockFetchDestinationCalls(providerDest);
+      mockFetchDestinationCalls(subscriberDest, {
         serviceToken: subscriberServiceToken
       });
-      mockFindDestinationCalls(subscriberDest2, {
+      mockFetchDestinationCalls(subscriberDest2, {
         serviceToken: subscriberServiceToken
       });
     });
@@ -244,9 +246,9 @@ describe('destination cache', () => {
 
     it('caches nothing if the destination is not found', async () => {
       mockVerifyJwt();
-      mockFindDestinationCallsNotFound('ANY', {
+      mockFetchDestinationCallsNotFound('ANY', {
         serviceToken: subscriberServiceToken,
-        mockAuthCall: false
+        mockWithTokenRetrievalCall: false
       });
 
       await getDestination({
@@ -415,7 +417,7 @@ describe('destination cache', () => {
       mockServiceToken();
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(certificateSingleResponse);
+      const httpMocks = mockFetchDestinationCalls(certificateSingleResponse);
 
       const retrieveFromCacheSpy = jest.spyOn(
         destinationCache,
@@ -462,8 +464,8 @@ describe('destination cache', () => {
       mockServiceToken();
       mockJwtBearerToken();
 
-      const httpMocks = mockFindDestinationCalls(oauthSingleResponse, {
-        mockAuthCall: {
+      const httpMocks = mockFetchDestinationCalls(oauthSingleResponse, {
+        mockWithTokenRetrievalCall: {
           headers: { authorization: `Bearer ${providerUserToken}` }
         }
       });
@@ -515,10 +517,10 @@ describe('destination cache', () => {
       mockServiceToken();
       mockJwtBearerToken();
 
-      mockFindDestinationCalls(
+      mockFetchDestinationCalls(
         onPremisePrincipalPropagationMultipleResponse[0],
         {
-          mockAuthCall: false
+          mockWithTokenRetrievalCall: false
         }
       );
 
@@ -654,7 +656,7 @@ describe('destination cache', () => {
         'tenant'
       );
 
-      const [httpMock] = mockFindDestinationCallsNotFound('ProviderDest', {
+      const [httpMock] = mockFetchDestinationCallsNotFound('ProviderDest', {
         serviceToken: subscriberServiceToken
       });
 

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
@@ -655,8 +655,7 @@ describe('destination cache', () => {
       );
 
       const [httpMock] = mockFindDestinationCallsNotFound('ProviderDest', {
-        serviceToken: subscriberServiceToken,
-        mockAuthCall: false
+        serviceToken: subscriberServiceToken
       });
 
       const actual = await getDestination({

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.spec.ts
@@ -1,7 +1,7 @@
 import {
   mockServiceBindings,
   mockServiceToken,
-  mockFindDestinationCalls,
+  mockFetchDestinationCalls,
   mockVerifyJwt,
   providerServiceToken
 } from '../../../../../test-resources/test/test-util';
@@ -24,8 +24,8 @@ describe('getDestinationFromDestinationService', () => {
       forwardAuthToken: 'true'
     };
 
-    mockFindDestinationCalls(destination, {
-      mockAuthCall: false
+    mockFetchDestinationCalls(destination, {
+      mockWithTokenRetrievalCall: false
     });
 
     const retrievedDestination = await getDestinationFromDestinationService({
@@ -48,7 +48,7 @@ describe('getDestinationFromDestinationService', () => {
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [_, authFlowCall] = mockFindDestinationCalls(destination);
+    const [_, authFlowCall] = mockFetchDestinationCalls(destination);
 
     await getDestinationFromDestinationService({
       destinationName: 'FORWARD',

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -248,7 +248,7 @@ export class DestinationFromServiceRetriever {
     if (destination.authentication !== 'OAuth2ClientCredentials') {
       return undefined;
     }
-    if (destination.originalProperties!['tokenServiceURLType'] !== 'Common') {
+    if (destination.originalProperties?.['tokenServiceURLType'] !== 'Common') {
       return undefined;
     }
     const subdomainSubscriber = getIssuerSubdomain(

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -26,8 +26,8 @@ import {
 import {
   AuthAndExchangeTokens,
   fetchCertificate,
-  fetchDestination,
-  fetchDestinationByToken
+  fetchDestinationWithTokenRetrieval,
+  fetchDestinationWithoutTokenRetrieval
 } from './destination-service';
 import {
   assertHttpDestination,
@@ -234,16 +234,6 @@ export class DestinationFromServiceRetriever {
     return destinationSearchResult;
   }
 
-  private async fetchDestinationByToken(
-    jwt: string | AuthAndExchangeTokens
-  ): Promise<Destination> {
-    return fetchDestinationByToken(
-      getDestinationServiceCredentials().uri,
-      jwt,
-      this.options
-    );
-  }
-
   private getExchangeTenant(destination: Destination): string | undefined {
     if (destination.authentication !== 'OAuth2ClientCredentials') {
       return undefined;
@@ -264,13 +254,13 @@ export class DestinationFromServiceRetriever {
     destinationResult: DestinationSearchResult
   ): Promise<AuthAndExchangeTokens> {
     const { destination, origin } = destinationResult;
-    // This covers the X-Tenant case https://api.sap.com/api/SAP_CP_CF_Connectivity_Destination/resource
+    // This covers the x-tenant case https://api.sap.com/api/SAP_CP_CF_Connectivity_Destination/resource
     const exchangeTenant = this.getExchangeTenant(destination);
     const clientGrant = await serviceToken('destination', {
       jwt:
         origin === 'provider'
           ? this.providerServiceToken.decoded
-          : this.subscriberToken!.serviceJwt!.decoded
+          : this.subscriberToken?.serviceJwt?.decoded
     });
     return { authHeaderJwt: clientGrant, exchangeTenant };
   }
@@ -374,7 +364,11 @@ Possible alternatives for such technical user authentication are BasicAuthentica
     const token =
       await this.getAuthTokenForOAuth2ClientCredentials(destinationResult);
 
-    return this.fetchDestinationByToken(token);
+    return fetchDestinationWithTokenRetrieval(
+      getDestinationServiceCredentials().uri,
+      token,
+      this.options
+    );
   }
 
   private async fetchDestinationWithUserExchangeFlows(
@@ -384,7 +378,12 @@ Possible alternatives for such technical user authentication are BasicAuthentica
       await this.getAuthTokenForOAuth2UserBasedTokenExchanges(
         destinationResult
       );
-    return this.fetchDestinationByToken(token);
+
+    return fetchDestinationWithTokenRetrieval(
+      getDestinationServiceCredentials().uri,
+      token,
+      this.options
+    );
   }
 
   private async fetchDestinationWithRefreshTokenFlow(
@@ -392,7 +391,12 @@ Possible alternatives for such technical user authentication are BasicAuthentica
   ): Promise<Destination> {
     const token =
       await this.getAuthTokenForOAuth2RefreshToken(destinationResult);
-    return this.fetchDestinationByToken(token);
+
+    return fetchDestinationWithTokenRetrieval(
+      getDestinationServiceCredentials().uri,
+      token,
+      this.options
+    );
   }
 
   private async addProxyConfiguration(
@@ -438,7 +442,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
   private async getProviderDestinationService(): Promise<
     DestinationSearchResult | undefined
   > {
-    const providerDestination = await fetchDestination(
+    const providerDestination = await fetchDestinationWithoutTokenRetrieval(
       this.options.destinationName,
       getDestinationServiceCredentials().uri,
       this.providerServiceToken.encoded
@@ -480,7 +484,7 @@ Possible alternatives for such technical user authentication are BasicAuthentica
       );
     }
 
-    const subscriberDestination = await fetchDestination(
+    const subscriberDestination = await fetchDestinationWithoutTokenRetrieval(
       this.options.destinationName,
       getDestinationServiceCredentials().uri,
       this.subscriberToken.serviceJwt.encoded

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -453,7 +453,6 @@ Possible alternatives for such technical user authentication are BasicAuthentica
     );
 
     if (destination) {
-      // TODO: from cache is wrong here
       return { destination, fromCache: false, origin: 'provider' };
     }
   }
@@ -496,7 +495,6 @@ Possible alternatives for such technical user authentication are BasicAuthentica
     );
 
     if (destination) {
-      // TODO: from cache is wrong here
       return { destination, fromCache: false, origin: 'subscriber' };
     }
   }

--- a/packages/connectivity/src/scp-cf/destination/destination-selection-strategies.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-selection-strategies.ts
@@ -12,7 +12,7 @@ const logger = createLogger({
 
 /**
  * Function to implement the selection strategy of the retrieved destination.
- * Use the built in strategies defined in {@link DestinationSelectionStrategies} or make your own function.
+ * Use the built-in strategies defined in {@link DestinationSelectionStrategies} or make your own function.
  */
 export type DestinationSelectionStrategy = (
   allDestinations: AllDestinations,

--- a/packages/connectivity/src/scp-cf/destination/destination-service-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-cache.spec.ts
@@ -11,9 +11,9 @@ import {
   mockVerifyJwt
 } from '../../../../../test-resources/test/test-util/destination-service-mocks';
 import { decodeJwt } from '../jwt';
-import { fetchSubaccountDestinations } from './destination-service';
 import { Destination } from './destination-service-types';
 import { destinationServiceCache } from './destination-service-cache';
+import { fetchDestinations } from './destination-service';
 
 const destinationServiceUrl = 'https://myDestination.service.url';
 
@@ -94,7 +94,7 @@ function getDestinationsFromCache(token: string): Destination[] | undefined {
 }
 
 async function populateCacheDestinations(token): Promise<Destination[]> {
-  return fetchSubaccountDestinations(destinationServiceUrl, token, {
+  return fetchDestinations(destinationServiceUrl, token, 'subaccount', {
     useCache: true
   });
 }

--- a/packages/connectivity/src/scp-cf/destination/destination-service-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-cache.spec.ts
@@ -43,21 +43,18 @@ describe('DestinationServiceCache', () => {
     mockServiceToken();
 
     mockSubaccountDestinationsCall(
-      nock,
       [subscriberDest, subscriberDest2],
       200,
       subscriberServiceToken,
       destinationServiceUrl
     );
     mockSubaccountDestinationsCall(
-      nock,
       [subscriberDest, subscriberDest2],
       200,
       subscriberUserToken,
       destinationServiceUrl
     );
     mockSubaccountDestinationsCall(
-      nock,
       [providerDest],
       200,
       providerServiceToken,

--- a/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
@@ -11,7 +11,7 @@ import { privateKey } from '../../../../../test-resources/test/test-util/keys';
 import { DestinationConfiguration, parseDestination } from './destination';
 import {
   fetchCertificate,
-  fetchDestinationByToken,
+  fetchDestinationWithTokenRetrieval,
   fetchDestinations
 } from './destination-service';
 import { Destination } from './destination-service-types';
@@ -364,7 +364,7 @@ describe('destination service', () => {
         .get('/destination-configuration/v1/destinations/HTTP-BASIC')
         .reply(200, response);
 
-      await fetchDestinationByToken(destinationServiceUri, jwt, {
+      await fetchDestinationWithTokenRetrieval(destinationServiceUri, jwt, {
         destinationName
       });
       expect(
@@ -443,9 +443,13 @@ describe('destination service', () => {
         .get('/destination-configuration/v1/destinations/HTTP-OAUTH')
         .reply(200, response);
 
-      const actual = await fetchDestinationByToken(destinationServiceUri, jwt, {
-        destinationName
-      });
+      const actual = await fetchDestinationWithTokenRetrieval(
+        destinationServiceUri,
+        jwt,
+        {
+          destinationName
+        }
+      );
       expect(actual).toMatchObject(expected);
     });
 
@@ -474,7 +478,7 @@ describe('destination service', () => {
       const requestSpy = jest
         .spyOn(axios, 'request')
         .mockResolvedValue({ data: response });
-      await fetchDestinationByToken(destinationServiceUri, jwt, {
+      await fetchDestinationWithTokenRetrieval(destinationServiceUri, jwt, {
         destinationName
       });
       const expectedConfig: RawAxiosRequestConfig = {
@@ -509,7 +513,7 @@ describe('destination service', () => {
         .get('/destination-configuration/v1/destinations/timeoutTest')
         .reply(200, response);
       const spy = jest.spyOn(resilienceMethods, 'executeWithMiddleware');
-      await fetchDestinationByToken(destinationServiceUri, jwt, {
+      await fetchDestinationWithTokenRetrieval(destinationServiceUri, jwt, {
         destinationName: 'timeoutTest'
       });
       // Assertion for two anonymous functions in the middleware one of them is timeout the other CB.
@@ -555,7 +559,7 @@ describe('destination service', () => {
         .get('/destination-configuration/v1/destinations/HTTP-OAUTH')
         .reply(200, response);
       const spy = jest.spyOn(axios, 'request');
-      await fetchDestinationByToken(destinationServiceUri, jwt, {
+      await fetchDestinationWithTokenRetrieval(destinationServiceUri, jwt, {
         destinationName
       });
       const expectedConfig: RawAxiosRequestConfig = {
@@ -595,10 +599,14 @@ describe('destination service', () => {
         .get('/destination-configuration/v1/destinations/HTTP-BASIC')
         .reply(200, response);
 
-      const actual = await fetchDestinationByToken(destinationServiceUri, jwt, {
-        destinationName: 'HTTP-BASIC',
-        retry: true
-      });
+      const actual = await fetchDestinationWithTokenRetrieval(
+        destinationServiceUri,
+        jwt,
+        {
+          destinationName: 'HTTP-BASIC',
+          retry: true
+        }
+      );
       expect(actual).toEqual(parseDestination(response));
     });
 
@@ -617,7 +625,7 @@ describe('destination service', () => {
         .reply(200, response);
 
       await expect(
-        fetchDestinationByToken(destinationServiceUri, jwt, {
+        fetchDestinationWithTokenRetrieval(destinationServiceUri, jwt, {
           destinationName: 'HTTP-BASIC',
           retry: true
         })
@@ -660,10 +668,14 @@ describe('destination service', () => {
         .get('/destination-configuration/v1/destinations/HTTP-OAUTH')
         .reply(200, responseValidToken);
 
-      const actual = await fetchDestinationByToken(destinationServiceUri, jwt, {
-        destinationName: 'HTTP-OAUTH',
-        retry: true
-      });
+      const actual = await fetchDestinationWithTokenRetrieval(
+        destinationServiceUri,
+        jwt,
+        {
+          destinationName: 'HTTP-OAUTH',
+          retry: true
+        }
+      );
       expect(actual).toMatchObject(parseDestination(responseValidToken));
     });
 
@@ -690,10 +702,14 @@ describe('destination service', () => {
         .times(3)
         .reply(200, response);
 
-      const actual = await fetchDestinationByToken(destinationServiceUri, jwt, {
-        destinationName: 'HTTP-OAUTH',
-        retry: true
-      });
+      const actual = await fetchDestinationWithTokenRetrieval(
+        destinationServiceUri,
+        jwt,
+        {
+          destinationName: 'HTTP-OAUTH',
+          retry: true
+        }
+      );
       expect(actual.authTokens![0].error).toEqual('ERROR');
       expect(mock.isDone()).toBe(true);
     }, 10000);
@@ -766,7 +782,7 @@ describe('destination service', () => {
         .get('/destination-configuration/v1/destinations/FINAL-DESTINATION')
         .reply(200, response);
 
-      const actual = await fetchDestinationByToken(
+      const actual = await fetchDestinationWithTokenRetrieval(
         destinationServiceUri,
         jwt,
 
@@ -787,7 +803,7 @@ describe('destination service', () => {
         .reply(500);
 
       await expect(
-        fetchDestinationByToken(destinationServiceUri, jwt, {
+        fetchDestinationWithTokenRetrieval(destinationServiceUri, jwt, {
           destinationName
         })
       ).rejects.toThrowError();
@@ -809,7 +825,7 @@ describe('destination service', () => {
         .reply(400, response);
 
       await expect(() =>
-        fetchDestinationByToken(destinationServiceUri, jwt, {
+        fetchDestinationWithTokenRetrieval(destinationServiceUri, jwt, {
           destinationName
         })
       ).rejects.toThrowError();

--- a/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
@@ -272,7 +272,7 @@ describe('destination service', () => {
 
   describe('fetchCertificate', () => {
     it('fetches the subaccount certificate', async () => {
-      mockCertificateCall(nock, 'server-public-cert.pem', jwt, 'subaccount');
+      mockCertificateCall('server-public-cert.pem', jwt, 'subaccount');
 
       const actual = await fetchCertificate(
         destinationServiceUri,
@@ -287,7 +287,7 @@ describe('destination service', () => {
     });
 
     it('fetches the instance certificate', async () => {
-      mockCertificateCall(nock, 'server-public-cert.pem', jwt, 'instance');
+      mockCertificateCall('server-public-cert.pem', jwt, 'instance');
 
       const actual = await fetchCertificate(
         destinationServiceUri,
@@ -302,9 +302,8 @@ describe('destination service', () => {
     });
 
     it('fetches the subaccount first', async () => {
-      mockCertificateCall(nock, 'server-public-cert.pem', jwt, 'subaccount');
+      mockCertificateCall('server-public-cert.pem', jwt, 'subaccount');
       const mockInstance = mockCertificateCall(
-        nock,
         'server-public-cert.pem',
         jwt,
         'instance'
@@ -319,7 +318,7 @@ describe('destination service', () => {
     });
 
     it('returns undefined for non pem files', async () => {
-      mockCertificateCall(nock, 'server-public-cert.jks', jwt, 'subaccount');
+      mockCertificateCall('server-public-cert.jks', jwt, 'subaccount');
 
       const actual = await fetchCertificate(
         destinationServiceUri,

--- a/packages/connectivity/src/scp-cf/destination/destination-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.ts
@@ -124,29 +124,6 @@ export interface AuthAndExchangeTokens {
 }
 
 /**
- * Fetches a specific destination by name from the given URI, including authorization tokens.
- * For destinations with authenticationType OAuth2SAMLBearerAssertion, this call will trigger the OAuth2SAMLBearerFlow against the target destination.
- * In this pass the access token as string.
- * Fetches a specific destination with authenticationType OAuth2UserTokenExchange by name from the given URI, including authorization tokens.
- * @param destinationServiceUri - The URI of the destination service
- * @param token - The access token or AuthAndExchangeTokens if you want to include the X-user-token for OAuth2UserTokenExchange.
- * @param options - Options to use by retrieving destinations
- * @returns A Promise resolving to the destination
- * @internal
- */
-export async function fetchDestinationOld(
-  destinationServiceUri: string,
-  token: string | AuthAndExchangeTokens,
-  options: DestinationServiceOptions
-): Promise<Destination> {
-  return fetchDestinationByToken(
-    destinationServiceUri,
-    typeof token === 'string' ? { authHeaderJwt: token } : token,
-    options
-  );
-}
-
-/**
  * @internal
  */
 export async function fetchDestination(

--- a/packages/connectivity/src/scp-cf/destination/destination-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.ts
@@ -173,6 +173,16 @@ export async function fetchDestination(
       subaccount: response.data.owner?.SubaccountId ? [destination] : []
     };
   } catch (err) {
+    if (
+      err.response?.status === 404 &&
+      err.response?.data?.ErrorMessage ===
+        'Configuration with the specified name was not found'
+    ) {
+      return {
+        instance: [],
+        subaccount: []
+      };
+    }
     throw new ErrorWithCause(
       `Failed to fetch destination.${errorMessageFromResponse(err)}`,
       err

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -27,7 +27,7 @@ import {
   destinationBindingClientSecretMock,
   jku,
   mockClientCredentialsGrantCall,
-  mockFindDestinationCalls,
+  mockFetchDestinationCalls,
   mockServiceBindings,
   mockUserTokenGrantCall,
   privateKey,
@@ -285,9 +285,9 @@ describe('generic http client', () => {
       // Inside connectivity package we can use jest to mock jwtVerify and tokenAccessor
       // Between modules this is not possible and done via HTTP mocks instead
       mockJwtValidationAndServiceToken();
-      mockFindDestinationCalls(basicMultipleResponse[0], {
+      mockFetchDestinationCalls(basicMultipleResponse[0], {
         serviceToken: subscriberServiceToken,
-        mockAuthCall: false
+        mockWithTokenRetrievalCall: false
       });
 
       const response = await executeHttpRequest(

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -27,9 +27,8 @@ import {
   destinationBindingClientSecretMock,
   jku,
   mockClientCredentialsGrantCall,
-  mockInstanceDestinationsCall,
+  mockFindDestinationCalls,
   mockServiceBindings,
-  mockSubaccountDestinationsCall,
   mockUserTokenGrantCall,
   privateKey,
   providerServiceToken,
@@ -277,16 +276,6 @@ describe('generic http client', () => {
       );
     }
 
-    function mockDestinationService() {
-      mockInstanceDestinationsCall(nock, [], 200, subscriberServiceToken);
-      mockSubaccountDestinationsCall(
-        nock,
-        basicMultipleResponse,
-        200,
-        subscriberServiceToken
-      );
-    }
-
     it('passes the context properties to the middleware', async () => {
       const showContextMiddleware: HttpMiddleware =
         (opt: HttpMiddlewareOptions) => () =>
@@ -296,7 +285,10 @@ describe('generic http client', () => {
       // Inside connectivity package we can use jest to mock jwtVerify and tokenAccessor
       // Between modules this is not possible and done via HTTP mocks instead
       mockJwtValidationAndServiceToken();
-      mockDestinationService();
+      mockFindDestinationCalls(basicMultipleResponse[0], {
+        serviceToken: subscriberServiceToken,
+        mockAuthCall: false
+      });
 
       const response = await executeHttpRequest(
         {

--- a/packages/mail-client/package.json
+++ b/packages/mail-client/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "@types/nodemailer": "^6.4.14",
-    "typescript": "~5.3.3",
-    "nock": "^13.4.0"
+    "typescript": "~5.3.3"
   }
 }

--- a/packages/mail-client/src/mail-client.spec.ts
+++ b/packages/mail-client/src/mail-client.spec.ts
@@ -7,7 +7,7 @@ import {
 import { DestinationConfiguration } from '@sap-cloud-sdk/connectivity/internal';
 import * as tokenAccessor from '@sap-cloud-sdk/connectivity/dist/scp-cf/token-accessor';
 import {
-  mockFindDestinationCalls,
+  mockFetchDestinationCalls,
   mockServiceBindings,
   providerServiceToken
 } from '../../../test-resources/test/test-util';
@@ -76,7 +76,7 @@ describe('mail client', () => {
     jest
       .spyOn(tokenAccessor, 'serviceToken')
       .mockImplementation(() => Promise.resolve(providerServiceToken));
-    mockFindDestinationCalls(mailDestinationResponse);
+    mockFetchDestinationCalls(mailDestinationResponse);
 
     await expect(
       sendMail(
@@ -124,7 +124,7 @@ describe('mail client', () => {
       .spyOn(tokenAccessor, 'serviceToken')
       .mockImplementation(() => Promise.resolve(providerServiceToken));
 
-    mockFindDestinationCalls(mailDestinationResponse);
+    mockFetchDestinationCalls(mailDestinationResponse);
 
     await expect(
       sendMail(

--- a/packages/mail-client/src/mail-client.spec.ts
+++ b/packages/mail-client/src/mail-client.spec.ts
@@ -1,4 +1,3 @@
-import nock from 'nock';
 import nodemailer from 'nodemailer';
 import { SocksClient } from 'socks';
 import {
@@ -8,9 +7,8 @@ import {
 import { DestinationConfiguration } from '@sap-cloud-sdk/connectivity/internal';
 import * as tokenAccessor from '@sap-cloud-sdk/connectivity/dist/scp-cf/token-accessor';
 import {
-  mockInstanceDestinationsCall,
+  mockFindDestinationCalls,
   mockServiceBindings,
-  mockSubaccountDestinationsCall,
   providerServiceToken
 } from '../../../test-resources/test/test-util';
 import {
@@ -60,36 +58,29 @@ describe('mail client', () => {
       }
     };
 
-    const mailDestinationResponse: DestinationConfiguration[] = [
-      {
-        Name: 'MyMailDestination',
-        Type: 'MAIL',
-        Authentication: 'BasicAuthentication',
-        ProxyType: 'Internet',
-        User: 'user',
-        Password: 'password',
-        'mail.password': 'password',
-        'mail.user': 'user',
-        'mail.smtp.host': 'smtp.gmail.com',
-        'mail.smtp.port': '587'
-      }
-    ];
+    const mailDestinationResponse: DestinationConfiguration = {
+      Name: 'MyMailDestination',
+      Type: 'MAIL',
+      Authentication: 'BasicAuthentication',
+      ProxyType: 'Internet',
+      User: 'user',
+      Password: 'password',
+      'mail.password': 'password',
+      'mail.user': 'user',
+      'mail.smtp.host': 'smtp.gmail.com',
+      'mail.smtp.port': '587'
+    };
+
     mockServiceBindings();
     // the mockServiceToken() method does not work outside connectivity module.
     jest
       .spyOn(tokenAccessor, 'serviceToken')
       .mockImplementation(() => Promise.resolve(providerServiceToken));
-    mockInstanceDestinationsCall(nock, [], 200, providerServiceToken);
-    mockSubaccountDestinationsCall(
-      nock,
-      mailDestinationResponse,
-      200,
-      providerServiceToken
-    );
+    mockFindDestinationCalls(mailDestinationResponse);
 
     await expect(
       sendMail(
-        { destinationName: 'MyMailDestination' },
+        { destinationName: mailDestinationResponse.Name },
         [mailOptions1],
         mailClientOptions
       )
@@ -114,36 +105,30 @@ describe('mail client', () => {
       }
     };
 
-    const mailDestinationResponse: DestinationConfiguration[] = [
-      {
-        Name: 'MyMailDestination',
-        Type: 'MAIL',
-        Authentication: 'BasicAuthentication',
-        ProxyType: 'OnPremise',
-        User: 'user',
-        Password: 'password',
-        'mail.password': 'password',
-        'mail.user': 'user',
-        'mail.smtp.host': 'smtp.gmail.com',
-        'mail.smtp.port': '587'
-      }
-    ];
+    const mailDestinationResponse: DestinationConfiguration = {
+      Name: 'MyMailDestination',
+      Type: 'MAIL',
+      Authentication: 'BasicAuthentication',
+      ProxyType: 'OnPremise',
+      User: 'user',
+      Password: 'password',
+      'mail.password': 'password',
+      'mail.user': 'user',
+      'mail.smtp.host': 'smtp.gmail.com',
+      'mail.smtp.port': '587'
+    };
+
     mockServiceBindings();
     // the mockServiceToken() method does not work outside connectivity module.
     jest
       .spyOn(tokenAccessor, 'serviceToken')
       .mockImplementation(() => Promise.resolve(providerServiceToken));
-    mockInstanceDestinationsCall(nock, [], 200, providerServiceToken);
-    mockSubaccountDestinationsCall(
-      nock,
-      mailDestinationResponse,
-      200,
-      providerServiceToken
-    );
+
+    mockFindDestinationCalls(mailDestinationResponse);
 
     await expect(
       sendMail(
-        { destinationName: 'MyMailDestination' },
+        { destinationName: mailDestinationResponse.Name },
         [mailOptions1],
         mailClientOptions
       )

--- a/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
@@ -20,7 +20,7 @@ import {
   providerXsuaaUrl,
   providerServiceToken,
   createOriginalTestEntityDataWithLinks,
-  mockFindDestinationCalls
+  mockFetchDestinationCalls
 } from '../../../../test-resources/test/test-util';
 import { parseDestination } from '../../../connectivity/src/scp-cf/destination/destination';
 import {
@@ -334,7 +334,7 @@ describe('GetAllRequestBuilder', () => {
           .post('/oauth/token')
           .times(1)
           .reply(200, { access_token: providerServiceToken }),
-        ...mockFindDestinationCalls(certificateSingleResponse, {
+        ...mockFetchDestinationCalls(certificateSingleResponse, {
           serviceToken: onlyIssuerServiceToken
         }),
         nock(certificateSingleResponse.destinationConfiguration.URL!)

--- a/packages/openapi/src/openapi-request-builder.spec.ts
+++ b/packages/openapi/src/openapi-request-builder.spec.ts
@@ -15,7 +15,7 @@ import {
   onlyIssuerXsuaaUrl,
   providerXsuaaUrl,
   providerServiceToken,
-  mockFindDestinationCalls
+  mockFetchDestinationCalls
 } from '../../../test-resources/test/test-util';
 import { OpenApiRequestBuilder } from './openapi-request-builder';
 
@@ -174,7 +174,7 @@ describe('openapi-request-builder', () => {
         .post('/oauth/token')
         .times(1)
         .reply(200, { access_token: providerServiceToken }),
-      ...mockFindDestinationCalls(certificateSingleResponse, {
+      ...mockFetchDestinationCalls(certificateSingleResponse, {
         serviceToken: onlyIssuerServiceToken
       }),
       nock(certificateSingleResponse.destinationConfiguration.URL!)

--- a/test-packages/integration-tests/test/v2/request-builder.spec.ts
+++ b/test-packages/integration-tests/test/v2/request-builder.spec.ts
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken';
 import nock from 'nock';
 import { basicHeader } from '@sap-cloud-sdk/connectivity/internal';
-import { mockFindDestinationCalls } from '../../../../test-resources/test/test-util/destination-service-mocks';
+import { mockFetchDestinationCalls } from '../../../../test-resources/test/test-util/destination-service-mocks';
 import {
   destinationServiceUri,
   destinationBindingClientSecretMock,
@@ -153,9 +153,9 @@ describe('Request Builder', () => {
       destinationBindingClientSecretMock.credentials
     );
 
-    mockFindDestinationCalls(destination, {
+    mockFetchDestinationCalls(destination, {
       serviceToken: providerToken,
-      mockAuthCall: false
+      mockFetchDestinationWithTokenRetrieval: false
     });
 
     nock(destination.URL, {
@@ -617,7 +617,7 @@ describe('Request Builder', () => {
       destinationBindingClientSecretMock.credentials
     );
 
-    mockFindDestinationCalls(destination, {
+    mockFetchDestinationCalls(destination, {
       serviceToken: providerToken
     });
 

--- a/test-packages/integration-tests/test/v2/request-builder.spec.ts
+++ b/test-packages/integration-tests/test/v2/request-builder.spec.ts
@@ -155,7 +155,7 @@ describe('Request Builder', () => {
 
     mockFetchDestinationCalls(destination, {
       serviceToken: providerToken,
-      mockFetchDestinationWithTokenRetrieval: false
+      mockWithTokenRetrievalCall: false
     });
 
     nock(destination.URL, {

--- a/test-resources/test/test-util/destination-service-mocks.ts
+++ b/test-resources/test/test-util/destination-service-mocks.ts
@@ -228,27 +228,6 @@ export function mockFindDestinationCalls(
   return nockScopes;
 }
 
-export function mockSingleDestinationCallNew(
-  response: any,
-  token: string,
-  options?: {
-    uri?: string;
-    badheaders?: string[];
-  }
-) {
-  const { uri, badheaders } = {
-    uri: defaultDestinationServiceUri,
-    badheaders: ['X-tenant', 'X-user-token'],
-    ...options
-  };
-  return nock(uri, {
-    reqheaders: { authorization: `Bearer ${token}` },
-    badheaders
-  })
-    .get(`/destination-configuration/v1/destinations/${response.Name}`)
-    .reply(200, response);
-}
-
 export function mockSingleDestinationCall(
   nockRef: nockFunction,
   response: any,

--- a/test-resources/test/test-util/destination-service-mocks.ts
+++ b/test-resources/test/test-util/destination-service-mocks.ts
@@ -4,7 +4,6 @@ import {
   DestinationConfiguration,
   DestinationJson
 } from '@sap-cloud-sdk/connectivity';
-import { isDestinationConfiguration } from '@sap-cloud-sdk/connectivity/internal';
 import { destinationServiceUri as defaultDestinationServiceUri } from './environment-mocks';
 import { providerServiceToken } from './mocked-access-tokens';
 import { destinationSingleResponse } from './example-destination-service-responses';
@@ -160,6 +159,13 @@ function parseFindDestinationOptions(
     headers,
     metadataRespose
   };
+}
+
+// This function is needed to identify destination configurations for destinations of type HTTP as well as MAIL.
+function isDestinationConfiguration(
+  destination: any
+): destination is DestinationConfiguration {
+  return 'Name' in destination;
 }
 
 function parseDestination(destination: MockedDestinationConfiguration) {

--- a/test-resources/test/test-util/destination-service-mocks.ts
+++ b/test-resources/test/test-util/destination-service-mocks.ts
@@ -1,11 +1,18 @@
 import nock from 'nock';
 import * as sdkJwt from '@sap-cloud-sdk/connectivity/src/scp-cf/jwt';
-import { destinationServiceUri } from './environment-mocks';
+import {
+  DestinationConfiguration,
+  DestinationJson
+} from '@sap-cloud-sdk/connectivity';
+import { isDestinationConfiguration } from '@sap-cloud-sdk/connectivity/internal';
+import { destinationServiceUri as defaultDestinationServiceUri } from './environment-mocks';
+import { providerServiceToken } from './mocked-access-tokens';
+import { destinationSingleResponse } from './example-destination-service-responses';
 
 type nockFunction = (a: string, b: nock.Options) => nock.Scope;
 
 export function mockCertificateCall(
-  nockREf: nockFunction,
+  nockRef: nockFunction,
   certificateName: string,
   token: string,
   type: 'subaccount' | 'instance'
@@ -17,7 +24,7 @@ export function mockCertificateCall(
       'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNPRENDQWFFQ0ZHMWhzbll2NzV5UTZYVVNXQ1dlckYzaUZMaDRNQTBHQ1NxR1NJYjNEUUVCQ3dVQU1Gc3gKQ3pBSkJnTlZCQVlUQWtSRk1Rc3dDUVlEVlFRSURBSkVSVEVQTUEwR0ExVUVCd3dHUW1WeWJHbHVNUXd3Q2dZRApWUVFLREFOVFFWQXhEREFLQmdOVkJBc01BMU5CVURFU01CQUdBMVVFQXd3SmJHOWpZV3hvYjNOME1CNFhEVEl5Ck1EUXlNakUwTVRreU1sb1hEVEl5TURVeU1qRTBNVGt5TWxvd1d6RUxNQWtHQTFVRUJoTUNSRVV4Q3pBSkJnTlYKQkFnTUFrUkZNUTh3RFFZRFZRUUhEQVpDWlhKc2FXNHhEREFLQmdOVkJBb01BMU5CVURFTU1Bb0dBMVVFQ3d3RApVMEZRTVJJd0VBWURWUVFEREFsc2IyTmhiR2h2YzNRd2daOHdEUVlKS29aSWh2Y05BUUVCQlFBRGdZMEFNSUdKCkFvR0JBTFNhVS9IRU1YbEozSFpsZ3MyNGs5dVdTbnR4clVsZktybXNlaG01ZUM4ZlNHZzFaa1N3ajdOSCtQUGwKNTJleTk1V0N2cVBaU0cyZkFrc0FRamJnUy9qa2RhdUIyMjlmVGV4WVNub00vVHdoN0ZhVVRnQjhJd0JuS0pZTgphY1pUUklnZkZWWENxZEx6d0ZHWWYyWGprOWtETkRCanRTMy9STHlMbVY3b3dXK25BZ01CQUFFd0RRWUpLb1pJCmh2Y05BUUVMQlFBRGdZRUFYK0lUK0JsT2ZvbVc0NGlpb3ZpeXdkelMzeVdGbGdRazh3Q2VCWmltb3BNNEF2ZTEKaUJLbTlOZmpkam03allWcXhKOGU4cWl6SGxONy9qVEY2RzV3bnl3RmUzSGZGVHFoQTVPelY1THlxcngxV2RNcwpUNTNUdFFtK29RZFVOYW52SnVrOVZBTkVZKzVPYkc0OGdwL2JobXNrZ24vUkFQekRna25GMGFyOFFVVT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo='
   };
 
-  return nock(destinationServiceUri, {
+  return nock(defaultDestinationServiceUri, {
     reqheaders: {
       authorization: `Bearer ${token}`
     }
@@ -31,7 +38,7 @@ export function mockInstanceDestinationsCall(
   response: any,
   responseCode: number,
   accessToken: string,
-  uri: string = destinationServiceUri
+  uri: string = defaultDestinationServiceUri
 ) {
   return nockRef(uri, {
     reqheaders: {
@@ -47,7 +54,7 @@ export function mockSubaccountDestinationsCall(
   response: any,
   responseCode: number,
   accessToken: string,
-  uri: string = destinationServiceUri
+  uri: string = defaultDestinationServiceUri
 ) {
   return nockRef(uri, {
     reqheaders: {
@@ -57,20 +64,133 @@ export function mockSubaccountDestinationsCall(
     .get('/destination-configuration/v1/subaccountDestinations')
     .reply(responseCode, response);
 }
+export function mockFindDestinationCalls(
+  destination:
+    | (DestinationJson & {
+        owner: {
+          SubaccountId: string | null;
+          InstanceId: string | null;
+        };
+      })
+    | DestinationConfiguration,
+  options: {
+    responseCode?: number;
+    headers?: Record<string, any>;
+    destinationServiceUri?: string;
+    serviceToken?: string;
+    badheaders?: string[];
+    /**
+     * Mock a destination call with $skipTokenRetrieval. Defaults to `true`.
+     */
+    mockMetadataCall?: boolean;
+
+    /**
+     * Mock a destination call that includes the auth flow. If set to `true`, the metadata configuration will be reused.
+     * If a configuration is given, it overwrites the default.
+     */
+    mockAuthCall?:
+      | boolean
+      | {
+          response?: any;
+          responseCode?: number;
+          headers?: Record<string, any>;
+          badheaders?: string[];
+        };
+  } = {}
+): nock.Scope[] {
+  const {
+    responseCode,
+    destinationServiceUri,
+    badheaders,
+    serviceToken,
+    mockMetadataCall
+  } = {
+    responseCode: 200,
+    destinationServiceUri: defaultDestinationServiceUri,
+    badheaders: ['X-tenant', 'X-user-token'], // X-tenant only allowed for OAuth2ClientCredentials flow
+    serviceToken: providerServiceToken,
+    mockMetadataCall: true,
+    ...options
+  };
+
+  const headers = {
+    ...(serviceToken && {
+      authorization: `Bearer ${serviceToken}`
+    }),
+    ...options.headers
+  };
+
+  const mockAuthCall: Record<string, any> | false =
+    typeof options.mockAuthCall === 'object' || options.mockAuthCall === false
+      ? options.mockAuthCall
+      : {};
+
+  const response = isDestinationConfiguration(destination)
+    ? destinationSingleResponse([destination])
+    : destination;
+  const destinationName = response.destinationConfiguration.Name;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { authTokens, ...metadataRespose } = response;
+
+  const nockScopes: nock.Scope[] = [];
+  if (mockMetadataCall) {
+    nockScopes.push(
+      nock(destinationServiceUri, {
+        reqheaders: headers,
+        badheaders
+      })
+        .get(`/destination-configuration/v1/destinations/${destinationName}`)
+        .query({ $skipTokenRetrieval: true })
+        .reply(responseCode, metadataRespose)
+    );
+  }
+  if (mockAuthCall) {
+    const mockAuthCallOptions = {
+      response,
+      responseCode,
+      headers: { ...headers, ...mockAuthCall.headers },
+      badheaders,
+      ...mockAuthCall
+    };
+    nockScopes.push(
+      nock(destinationServiceUri, {
+        reqheaders: mockAuthCallOptions.headers,
+        badheaders: mockAuthCallOptions.badheaders
+      })
+        .get(`/destination-configuration/v1/destinations/${destinationName}`)
+        .reply(mockAuthCallOptions.responseCode, mockAuthCallOptions.response)
+    );
+  }
+  return nockScopes;
+}
 
 export function mockSingleDestinationCall(
   nockRef: nockFunction,
   response: any,
   responseCode: number,
   destName: string,
-  headers: Record<string, any>,
-  options?: { uri?: string; badheaders?: string[] }
+  headers: Record<string, any> = {},
+  options?: {
+    uri?: string;
+    badheaders?: string[];
+    skipTokenRetrieval?: boolean;
+  }
 ) {
-  return nockRef(options?.uri || destinationServiceUri, {
+  const { uri, badheaders, skipTokenRetrieval } = {
+    uri: defaultDestinationServiceUri,
+    badheaders: ['X-tenant', 'X-user-token'],
+    skipTokenRetrieval: false,
+    ...options
+  };
+  return nockRef(uri || defaultDestinationServiceUri, {
     reqheaders: headers,
-    badheaders: options?.badheaders || ['X-tenant', 'X-user-token'] // X-tenant only allowed for OAuth2ClientCredentials flow
+    badheaders: badheaders || ['X-tenant', 'X-user-token'] // X-tenant only allowed for OAuth2ClientCredentials flow
   })
     .get(`/destination-configuration/v1/destinations/${destName}`)
+    .query({
+      ...(skipTokenRetrieval && { $skipTokenRetrieval: skipTokenRetrieval })
+    })
     .reply(responseCode, response);
 }
 

--- a/test-resources/test/test-util/destination-service-mocks.ts
+++ b/test-resources/test/test-util/destination-service-mocks.ts
@@ -8,10 +8,7 @@ import { destinationServiceUri as defaultDestinationServiceUri } from './environ
 import { providerServiceToken } from './mocked-access-tokens';
 import { destinationSingleResponse } from './example-destination-service-responses';
 
-type nockFunction = (a: string, b: nock.Options) => nock.Scope;
-
 export function mockCertificateCall(
-  nockRef: nockFunction,
   certificateName: string,
   token: string,
   type: 'subaccount' | 'instance'
@@ -33,13 +30,12 @@ export function mockCertificateCall(
 }
 
 export function mockInstanceDestinationsCall(
-  nockRef: nockFunction,
   response: any,
   responseCode: number,
   accessToken: string,
   uri: string = defaultDestinationServiceUri
 ) {
-  return nockRef(uri, {
+  return nock(uri, {
     reqheaders: {
       Authorization: `Bearer ${accessToken}`
     }
@@ -49,13 +45,12 @@ export function mockInstanceDestinationsCall(
 }
 
 export function mockSubaccountDestinationsCall(
-  nockRef: nockFunction,
   response: any,
   responseCode: number,
   accessToken: string,
   uri: string = defaultDestinationServiceUri
 ) {
-  return nockRef(uri, {
+  return nock(uri, {
     reqheaders: {
       Authorization: `Bearer ${accessToken}`
     }

--- a/test-resources/test/test-util/destination-service-mocks.ts
+++ b/test-resources/test/test-util/destination-service-mocks.ts
@@ -228,30 +228,6 @@ export function mockFindDestinationCalls(
   return nockScopes;
 }
 
-export function mockSingleDestinationCall(
-  nockRef: nockFunction,
-  response: any,
-  responseCode: number,
-  destName: string,
-  headers: Record<string, any> = {},
-  options?: {
-    uri?: string;
-    badheaders?: string[];
-  }
-) {
-  const { uri, badheaders } = {
-    uri: defaultDestinationServiceUri,
-    badheaders: ['X-tenant', 'X-user-token'],
-    ...options
-  };
-  return nockRef(uri || defaultDestinationServiceUri, {
-    reqheaders: headers,
-    badheaders: badheaders || ['X-tenant', 'X-user-token'] // X-tenant only allowed for OAuth2ClientCredentials flow
-  })
-    .get(`/destination-configuration/v1/destinations/${destName}`)
-    .reply(responseCode, response);
-}
-
 export function mockVerifyJwt() {
   return jest
     .spyOn(sdkJwt, 'verifyJwt')

--- a/test-resources/test/test-util/destination-service-mocks.ts
+++ b/test-resources/test/test-util/destination-service-mocks.ts
@@ -177,6 +177,7 @@ export function mockFindDestinationCallsNotFound(
       ErrorMessage: 'Configuration with the specified name was not found'
     },
     responseCode: 404,
+    mockAuthCall: false,
     ...options
   });
 }

--- a/test-resources/test/test-util/destination-service-mocks.ts
+++ b/test-resources/test/test-util/destination-service-mocks.ts
@@ -228,6 +228,27 @@ export function mockFindDestinationCalls(
   return nockScopes;
 }
 
+export function mockSingleDestinationCallNew(
+  response: any,
+  token: string,
+  options?: {
+    uri?: string;
+    badheaders?: string[];
+  }
+) {
+  const { uri, badheaders } = {
+    uri: defaultDestinationServiceUri,
+    badheaders: ['X-tenant', 'X-user-token'],
+    ...options
+  };
+  return nock(uri, {
+    reqheaders: { authorization: `Bearer ${token}` },
+    badheaders
+  })
+    .get(`/destination-configuration/v1/destinations/${response.Name}`)
+    .reply(200, response);
+}
+
 export function mockSingleDestinationCall(
   nockRef: nockFunction,
   response: any,
@@ -237,13 +258,11 @@ export function mockSingleDestinationCall(
   options?: {
     uri?: string;
     badheaders?: string[];
-    skipTokenRetrieval?: boolean;
   }
 ) {
-  const { uri, badheaders, skipTokenRetrieval } = {
+  const { uri, badheaders } = {
     uri: defaultDestinationServiceUri,
     badheaders: ['X-tenant', 'X-user-token'],
-    skipTokenRetrieval: false,
     ...options
   };
   return nockRef(uri || defaultDestinationServiceUri, {
@@ -251,9 +270,6 @@ export function mockSingleDestinationCall(
     badheaders: badheaders || ['X-tenant', 'X-user-token'] // X-tenant only allowed for OAuth2ClientCredentials flow
   })
     .get(`/destination-configuration/v1/destinations/${destName}`)
-    .query({
-      ...(skipTokenRetrieval && { $skipTokenRetrieval: skipTokenRetrieval })
-    })
     .reply(responseCode, response);
 }
 

--- a/test-resources/test/test-util/example-destination-service-responses.ts
+++ b/test-resources/test/test-util/example-destination-service-responses.ts
@@ -145,7 +145,7 @@ export const onPremiseBasicMultipleResponse: DestinationConfiguration[] = [
   getOnPremDestination('BasicAuthentication')
 ];
 export const onPremiseBasicSingleResponse: DestinationJson =
-  destinationSingleResponse(oauthMultipleResponse);
+  destinationSingleResponse(onPremiseBasicMultipleResponse);
 
 export const onPremisePrincipalPropagationMultipleResponse: DestinationConfiguration[] =
   [getOnPremDestination('PrincipalPropagation')];

--- a/test-resources/test/test-util/example-destination-service-responses.ts
+++ b/test-resources/test/test-util/example-destination-service-responses.ts
@@ -53,21 +53,29 @@ function destinationWithAuthType(
 
 export function destinationSingleResponse(
   multipleResponse: DestinationConfiguration[],
-  type: 'Bearer' | 'SAML2.0' = 'Bearer'
-): DestinationJson {
+  type: 'Bearer' | 'SAML2.0' = 'Bearer',
+  skipTokenRetrieval = false
+): DestinationJson & {
+  owner: {
+    SubaccountId: string | null;
+    InstanceId: string | null;
+  };
+} {
   return {
     owner: {
       SubaccountId: 'a89ea924-d9c2-4eab-84fb-3ffcaadf5d24',
       InstanceId: null
     },
     destinationConfiguration: multipleResponse[0],
-    authTokens: [
-      {
-        type,
-        value: 'token',
-        expires_in: '3600'
-      }
-    ]
+    ...(skipTokenRetrieval && {
+      authTokens: [
+        {
+          type,
+          value: 'token',
+          expires_in: '3600'
+        }
+      ]
+    })
   };
 }
 

--- a/test-resources/test/test-util/token-accessor-mocks.ts
+++ b/test-resources/test/test-util/token-accessor-mocks.ts
@@ -10,9 +10,9 @@ import {
   subscriberUserToken
 } from './mocked-access-tokens';
 
-export function expectAllMocksUsed(nocks: nock.Scope[]) {
-  nocks.forEach(nock1 => {
-    expect(nock1.isDone()).toBe(true);
+export function expectAllMocksUsed(scopes: nock.Scope[]) {
+  scopes.forEach(scope => {
+    expect(scope.isDone()).toBe(true);
   });
 }
 

--- a/test-resources/test/tsconfig.json
+++ b/test-resources/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "include": ["./**/*.ts"],
   "exclude": []
 }


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#1158.

Fetch (and cache, if needed) only one destination instead of all available destinations. With this we can currently make just one request for the metadata, instead of 2.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
