### PR TITLE
feat: Support PEM certificates for ClientCertificateAuthentication

### DIFF
--- a/.changeset/tasty-shoes-joke.md
+++ b/.changeset/tasty-shoes-joke.md
@@ -1,0 +1,5 @@
+---
+"@sap-cloud-sdk/connectivity": minor
+---
+
+[New Functionality] Support certificates in PEM format for `ClientCertificateAuthentication`.

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -142,8 +142,8 @@ export function buildHttpRequestConfigWithOrigin(
 }
 
 /**
- * This method does nothing and is only there to indicated that the call was made by Odata or OpenApi client and encoding is already done on filter and key parameters.
- * @param params - Parameters which are returned
+ * This method does nothing and is only there to indicate that the call was made by an OData or OpenApi client and encoding is already done on filter and key parameters.
+ * @param params - Parameters which are returned.
  * @returns The parameters as they are without encoding.
  * @internal
  */


### PR DESCRIPTION
Currently I am using the whole file for both the key and certificate. That way we don’t have to parse the content of the certificate and it seems that the https agent can parse it on its own.