### PR TITLE
fix: fix generated types for object schemas

### DIFF
--- a/.changeset/giant-dolls-arrive.md
+++ b/.changeset/giant-dolls-arrive.md
@@ -1,0 +1,5 @@
+---
+"@sap-cloud-sdk/openapi-generator": patch
+---
+
+[Fixed Issue] Fix types in generated OpenAPI schemas to have proper types instead of type `any`.

--- a/packages/openapi-generator/src/file-serializer/schema.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/schema.spec.ts
@@ -102,7 +102,7 @@ describe('serializeSchema for object schemas', () => {
     ).toMatchInlineSnapshot(`
       "{
             'simpleProperty': number;
-          } | Record<string, string>"
+          } & Record<string, string>"
     `);
   });
 });

--- a/packages/openapi-generator/src/file-serializer/schema.ts
+++ b/packages/openapi-generator/src/file-serializer/schema.ts
@@ -66,27 +66,16 @@ function serializeObjectSchema(schema: OpenApiObjectSchema): string {
     return 'Record<string, any>';
   }
 
-  const types: string[] = [];
-  if (schema.properties.length) {
-    types.push(serializeObjectSchemaForProperties(schema.properties));
-  }
-
+  const serializedProperties = schema.properties.map(property =>
+    serializePropertyWithDocumentation(property)
+  );
   if (schema.additionalProperties) {
-    types.push(
-      `Record<string, ${serializeSchema(schema.additionalProperties)}>`
+    serializedProperties.push(
+      `[key: string]: ${serializeSchema(schema.additionalProperties)};`
     );
   }
-
-  return types.join(' | ');
-}
-
-function serializeObjectSchemaForProperties(
-  properties: OpenApiObjectSchemaProperty[]
-): string {
   return codeBlock`{
-      ${properties
-        .map(property => serializePropertyWithDocumentation(property))
-        .join(unixEOL)}
+      ${serializedProperties.join(unixEOL)}
     }`;
 }
 

--- a/packages/openapi-generator/src/file-serializer/schema.ts
+++ b/packages/openapi-generator/src/file-serializer/schema.ts
@@ -77,7 +77,7 @@ function serializeObjectSchema(schema: OpenApiObjectSchema): string {
     );
   }
 
-  return types.join(' | ');
+  return types.join(' & ');
 }
 
 function serializeObjectSchemaForProperties(

--- a/packages/openapi-generator/src/file-serializer/schema.ts
+++ b/packages/openapi-generator/src/file-serializer/schema.ts
@@ -66,16 +66,27 @@ function serializeObjectSchema(schema: OpenApiObjectSchema): string {
     return 'Record<string, any>';
   }
 
-  const serializedProperties = schema.properties.map(property =>
-    serializePropertyWithDocumentation(property)
-  );
+  const types: string[] = [];
+  if (schema.properties.length) {
+    types.push(serializeObjectSchemaForProperties(schema.properties));
+  }
+
   if (schema.additionalProperties) {
-    serializedProperties.push(
-      `[key: string]: ${serializeSchema(schema.additionalProperties)};`
+    types.push(
+      `Record<string, ${serializeSchema(schema.additionalProperties)}>`
     );
   }
+
+  return types.join(' | ');
+}
+
+function serializeObjectSchemaForProperties(
+  properties: OpenApiObjectSchemaProperty[]
+): string {
   return codeBlock`{
-      ${serializedProperties.join(unixEOL)}
+      ${properties
+        .map(property => serializePropertyWithDocumentation(property))
+        .join(unixEOL)}
     }`;
 }
 

--- a/test-packages/test-services-openapi/swagger-yaml-service/schema/test-entity.d.ts
+++ b/test-packages/test-services-openapi/swagger-yaml-service/schema/test-entity.d.ts
@@ -6,15 +6,13 @@
 /**
  * Representation of the 'TestEntity' schema.
  */
-export type TestEntity =
-  | {
-      /**
-       * A string property
-       */
-      stringProperty?: string;
-      /**
-       * An integer property
-       */
-      integerProperty?: number;
-    }
-  | Record<string, any>;
+export type TestEntity = {
+  /**
+   * A string property
+   */
+  stringProperty?: string;
+  /**
+   * An integer property
+   */
+  integerProperty?: number;
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/swagger-yaml-service/schema/test-entity.ts
+++ b/test-packages/test-services-openapi/swagger-yaml-service/schema/test-entity.ts
@@ -7,15 +7,13 @@
 /**
  * Representation of the 'TestEntity' schema.
  */
-export type TestEntity =
-  | {
-      /**
-       * A string property
-       */
-      stringProperty?: string;
-      /**
-       * An integer property
-       */
-      integerProperty?: number;
-    }
-  | Record<string, any>;
+export type TestEntity = {
+  /**
+   * A string property
+   */
+  stringProperty?: string;
+  /**
+   * An integer property
+   */
+  integerProperty?: number;
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/test-service/schema/complex-test-entity.d.ts
+++ b/test-packages/test-services-openapi/test-service/schema/complex-test-entity.d.ts
@@ -8,47 +8,34 @@ import type { TestEntity } from './test-entity';
 /**
  * Representation of the 'ComplexTestEntity' schema.
  */
-export type ComplexTestEntity =
-  | {
-      referenceProperty?: SimpleTestEntity;
-      arrayProperty?:
-        | {
-            item?: string;
-          }
-        | Record<string, any>[];
-      uniqueItemsProperty?: Set<string>;
-      requiredPropertiesProperty?:
-        | {
-            optionalProperty?: string;
-            requiredProperty: string;
-          }
-        | Record<string, any>;
-      enumProperty?: 'one' | 'two';
-      oneOfProperty?: SimpleTestEntity | TestEntity;
-      allOfProperty?:
-        | (SimpleTestEntity & {
-            additionalProperty?: string;
-          })
-        | Record<string, any>;
-      anyOfProperty?:
-        | SimpleTestEntity
-        | {
-            additionalProperty?: string;
-          }
-        | Record<string, any>;
-      notProperty?: any;
-      objectPropertyWithNoAdditionalProperties?: {
-        specifiedProperty?: string;
-      };
-      objectPropertyWithAdditionalProperties?:
-        | {
-            specifiedProperty?: string;
-          }
-        | Record<string, any>;
-      objectPropertyWithNumberAdditionalProperties?:
-        | {
-            specifiedProperty?: string;
-          }
-        | Record<string, number>;
-    }
-  | Record<string, any>;
+export type ComplexTestEntity = {
+  referenceProperty?: SimpleTestEntity;
+  arrayProperty?: {
+    item?: string;
+  } & Record<string, any>[];
+  uniqueItemsProperty?: Set<string>;
+  requiredPropertiesProperty?: {
+    optionalProperty?: string;
+    requiredProperty: string;
+  } & Record<string, any>;
+  enumProperty?: 'one' | 'two';
+  oneOfProperty?: SimpleTestEntity | TestEntity;
+  allOfProperty?: SimpleTestEntity & {
+    additionalProperty?: string;
+  } & Record<string, any>;
+  anyOfProperty?:
+    | SimpleTestEntity
+    | ({
+        additionalProperty?: string;
+      } & Record<string, any>);
+  notProperty?: any;
+  objectPropertyWithNoAdditionalProperties?: {
+    specifiedProperty?: string;
+  };
+  objectPropertyWithAdditionalProperties?: {
+    specifiedProperty?: string;
+  } & Record<string, any>;
+  objectPropertyWithNumberAdditionalProperties?: {
+    specifiedProperty?: string;
+  } & Record<string, number>;
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/test-service/schema/complex-test-entity.ts
+++ b/test-packages/test-services-openapi/test-service/schema/complex-test-entity.ts
@@ -8,47 +8,34 @@ import type { TestEntity } from './test-entity';
 /**
  * Representation of the 'ComplexTestEntity' schema.
  */
-export type ComplexTestEntity =
-  | {
-      referenceProperty?: SimpleTestEntity;
-      arrayProperty?:
-        | {
-            item?: string;
-          }
-        | Record<string, any>[];
-      uniqueItemsProperty?: Set<string>;
-      requiredPropertiesProperty?:
-        | {
-            optionalProperty?: string;
-            requiredProperty: string;
-          }
-        | Record<string, any>;
-      enumProperty?: 'one' | 'two';
-      oneOfProperty?: SimpleTestEntity | TestEntity;
-      allOfProperty?:
-        | (SimpleTestEntity & {
-            additionalProperty?: string;
-          })
-        | Record<string, any>;
-      anyOfProperty?:
-        | SimpleTestEntity
-        | {
-            additionalProperty?: string;
-          }
-        | Record<string, any>;
-      notProperty?: any;
-      objectPropertyWithNoAdditionalProperties?: {
-        specifiedProperty?: string;
-      };
-      objectPropertyWithAdditionalProperties?:
-        | {
-            specifiedProperty?: string;
-          }
-        | Record<string, any>;
-      objectPropertyWithNumberAdditionalProperties?:
-        | {
-            specifiedProperty?: string;
-          }
-        | Record<string, number>;
-    }
-  | Record<string, any>;
+export type ComplexTestEntity = {
+  referenceProperty?: SimpleTestEntity;
+  arrayProperty?: {
+    item?: string;
+  } & Record<string, any>[];
+  uniqueItemsProperty?: Set<string>;
+  requiredPropertiesProperty?: {
+    optionalProperty?: string;
+    requiredProperty: string;
+  } & Record<string, any>;
+  enumProperty?: 'one' | 'two';
+  oneOfProperty?: SimpleTestEntity | TestEntity;
+  allOfProperty?: SimpleTestEntity & {
+    additionalProperty?: string;
+  } & Record<string, any>;
+  anyOfProperty?:
+    | SimpleTestEntity
+    | ({
+        additionalProperty?: string;
+      } & Record<string, any>);
+  notProperty?: any;
+  objectPropertyWithNoAdditionalProperties?: {
+    specifiedProperty?: string;
+  };
+  objectPropertyWithAdditionalProperties?: {
+    specifiedProperty?: string;
+  } & Record<string, any>;
+  objectPropertyWithNumberAdditionalProperties?: {
+    specifiedProperty?: string;
+  } & Record<string, number>;
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/test-service/schema/cyclic-child.d.ts
+++ b/test-packages/test-services-openapi/test-service/schema/cyclic-child.d.ts
@@ -7,8 +7,6 @@ import type { CyclicParent } from './cyclic-parent';
 /**
  * Representation of the 'CyclicChild' schema.
  */
-export type CyclicChild =
-  | {
-      parent?: CyclicParent;
-    }
-  | Record<string, any>;
+export type CyclicChild = {
+  parent?: CyclicParent;
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/test-service/schema/cyclic-child.ts
+++ b/test-packages/test-services-openapi/test-service/schema/cyclic-child.ts
@@ -7,8 +7,6 @@ import type { CyclicParent } from './cyclic-parent';
 /**
  * Representation of the 'CyclicChild' schema.
  */
-export type CyclicChild =
-  | {
-      parent?: CyclicParent;
-    }
-  | Record<string, any>;
+export type CyclicChild = {
+  parent?: CyclicParent;
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/test-service/schema/cyclic-parent.d.ts
+++ b/test-packages/test-services-openapi/test-service/schema/cyclic-parent.d.ts
@@ -7,8 +7,6 @@ import type { CyclicChild } from './cyclic-child';
 /**
  * Representation of the 'CyclicParent' schema.
  */
-export type CyclicParent =
-  | {
-      children?: CyclicChild[];
-    }
-  | Record<string, any>;
+export type CyclicParent = {
+  children?: CyclicChild[];
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/test-service/schema/cyclic-parent.ts
+++ b/test-packages/test-services-openapi/test-service/schema/cyclic-parent.ts
@@ -7,8 +7,6 @@ import type { CyclicChild } from './cyclic-child';
 /**
  * Representation of the 'CyclicParent' schema.
  */
-export type CyclicParent =
-  | {
-      children?: CyclicChild[];
-    }
-  | Record<string, any>;
+export type CyclicParent = {
+  children?: CyclicChild[];
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/test-service/schema/schema-123456.d.ts
+++ b/test-packages/test-services-openapi/test-service/schema/schema-123456.d.ts
@@ -6,11 +6,9 @@
 /**
  * Representation of the 'Schema123456' schema.
  */
-export type Schema123456 =
-  | {
-      /**
-       * @example "Schema name only integers"
-       */
-      someProperty?: string;
-    }
-  | Record<string, any>;
+export type Schema123456 = {
+  /**
+   * @example "Schema name only integers"
+   */
+  someProperty?: string;
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/test-service/schema/schema-123456.ts
+++ b/test-packages/test-services-openapi/test-service/schema/schema-123456.ts
@@ -7,11 +7,9 @@
 /**
  * Representation of the 'Schema123456' schema.
  */
-export type Schema123456 =
-  | {
-      /**
-       * @example "Schema name only integers"
-       */
-      someProperty?: string;
-    }
-  | Record<string, any>;
+export type Schema123456 = {
+  /**
+   * @example "Schema name only integers"
+   */
+  someProperty?: string;
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/test-service/schema/simple-test-entity.d.ts
+++ b/test-packages/test-services-openapi/test-service/schema/simple-test-entity.d.ts
@@ -6,11 +6,9 @@
 /**
  * SimpleTestEntity schema
  */
-export type SimpleTestEntity =
-  | {
-      /**
-       * @example "Example string"
-       */
-      stringProperty: string;
-    }
-  | Record<string, any>;
+export type SimpleTestEntity = {
+  /**
+   * @example "Example string"
+   */
+  stringProperty: string;
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/test-service/schema/simple-test-entity.ts
+++ b/test-packages/test-services-openapi/test-service/schema/simple-test-entity.ts
@@ -7,11 +7,9 @@
 /**
  * SimpleTestEntity schema
  */
-export type SimpleTestEntity =
-  | {
-      /**
-       * @example "Example string"
-       */
-      stringProperty: string;
-    }
-  | Record<string, any>;
+export type SimpleTestEntity = {
+  /**
+   * @example "Example string"
+   */
+  stringProperty: string;
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/test-service/schema/test-entity.d.ts
+++ b/test-packages/test-services-openapi/test-service/schema/test-entity.d.ts
@@ -7,48 +7,46 @@ import type { SimpleTestEntity } from './simple-test-entity';
 /**
  * TestEntity schema
  */
-export type TestEntity =
-  | {
-      /**
-       * @example "d290f1ee-6c54-4b01-90e6-d701748f0851"
-       * Format: "uuid".
-       */
-      keyProperty: string;
-      /**
-       * @example "Example string"
-       */
-      stringProperty?: string;
-      /**
-       * @example "2016-08-29"
-       * Format: "date".
-       */
-      dateProperty?: string;
-      /**
-       * @example "2016-08-29T09:12:33.001Z"
-       * Format: "date-time".
-       */
-      dateTimeProperty?: string;
-      /**
-       * @example 1
-       * Format: "int32".
-       */
-      int32Property?: number;
-      /**
-       * @example 1
-       * Format: "int64".
-       */
-      int64Property?: number;
-      /**
-       * @example 1
-       * Format: "float".
-       */
-      floatProperty?: number;
-      /**
-       * @example 1
-       * Format: "double".
-       */
-      doubleProperty?: number;
-      linkedSimpleTestEntity?: SimpleTestEntity;
-      linkedSimpleTestEntityCollection?: SimpleTestEntity[];
-    }
-  | Record<string, any>;
+export type TestEntity = {
+  /**
+   * @example "d290f1ee-6c54-4b01-90e6-d701748f0851"
+   * Format: "uuid".
+   */
+  keyProperty: string;
+  /**
+   * @example "Example string"
+   */
+  stringProperty?: string;
+  /**
+   * @example "2016-08-29"
+   * Format: "date".
+   */
+  dateProperty?: string;
+  /**
+   * @example "2016-08-29T09:12:33.001Z"
+   * Format: "date-time".
+   */
+  dateTimeProperty?: string;
+  /**
+   * @example 1
+   * Format: "int32".
+   */
+  int32Property?: number;
+  /**
+   * @example 1
+   * Format: "int64".
+   */
+  int64Property?: number;
+  /**
+   * @example 1
+   * Format: "float".
+   */
+  floatProperty?: number;
+  /**
+   * @example 1
+   * Format: "double".
+   */
+  doubleProperty?: number;
+  linkedSimpleTestEntity?: SimpleTestEntity;
+  linkedSimpleTestEntityCollection?: SimpleTestEntity[];
+} & Record<string, any>;

--- a/test-packages/test-services-openapi/test-service/schema/test-entity.ts
+++ b/test-packages/test-services-openapi/test-service/schema/test-entity.ts
@@ -7,48 +7,46 @@ import type { SimpleTestEntity } from './simple-test-entity';
 /**
  * TestEntity schema
  */
-export type TestEntity =
-  | {
-      /**
-       * @example "d290f1ee-6c54-4b01-90e6-d701748f0851"
-       * Format: "uuid".
-       */
-      keyProperty: string;
-      /**
-       * @example "Example string"
-       */
-      stringProperty?: string;
-      /**
-       * @example "2016-08-29"
-       * Format: "date".
-       */
-      dateProperty?: string;
-      /**
-       * @example "2016-08-29T09:12:33.001Z"
-       * Format: "date-time".
-       */
-      dateTimeProperty?: string;
-      /**
-       * @example 1
-       * Format: "int32".
-       */
-      int32Property?: number;
-      /**
-       * @example 1
-       * Format: "int64".
-       */
-      int64Property?: number;
-      /**
-       * @example 1
-       * Format: "float".
-       */
-      floatProperty?: number;
-      /**
-       * @example 1
-       * Format: "double".
-       */
-      doubleProperty?: number;
-      linkedSimpleTestEntity?: SimpleTestEntity;
-      linkedSimpleTestEntityCollection?: SimpleTestEntity[];
-    }
-  | Record<string, any>;
+export type TestEntity = {
+  /**
+   * @example "d290f1ee-6c54-4b01-90e6-d701748f0851"
+   * Format: "uuid".
+   */
+  keyProperty: string;
+  /**
+   * @example "Example string"
+   */
+  stringProperty?: string;
+  /**
+   * @example "2016-08-29"
+   * Format: "date".
+   */
+  dateProperty?: string;
+  /**
+   * @example "2016-08-29T09:12:33.001Z"
+   * Format: "date-time".
+   */
+  dateTimeProperty?: string;
+  /**
+   * @example 1
+   * Format: "int32".
+   */
+  int32Property?: number;
+  /**
+   * @example 1
+   * Format: "int64".
+   */
+  int64Property?: number;
+  /**
+   * @example 1
+   * Format: "float".
+   */
+  floatProperty?: number;
+  /**
+   * @example 1
+   * Format: "double".
+   */
+  doubleProperty?: number;
+  linkedSimpleTestEntity?: SimpleTestEntity;
+  linkedSimpleTestEntityCollection?: SimpleTestEntity[];
+} & Record<string, any>;

--- a/test-packages/type-tests/test/openapi/schema.test-d.ts
+++ b/test-packages/type-tests/test/openapi/schema.test-d.ts
@@ -1,0 +1,7 @@
+import { SimpleTestEntity } from '@sap-cloud-sdk/test-services-openapi/test-service';
+import { expectType } from 'tsd';
+
+const simpleTestEntity: SimpleTestEntity = { stringProperty: 'prop' };
+
+expectType<string>(simpleTestEntity.stringProperty);
+expectType<any>(simpleTestEntity.additionalProperty);


### PR DESCRIPTION
This allows additional properties in objects, without making other properties have type `any`.

Closes https://github.com/SAP/cloud-sdk-backlog/issues/1184