### PR TITLE
chore: fix PR check

### DIFF
--- a/.changeset/silver-melons-tell.md
+++ b/.changeset/silver-melons-tell.md
@@ -1,5 +1,0 @@
----
-"@sap-cloud-sdk/connectivity": minor
----
-
-[New Functionality] dummy

--- a/.changeset/silver-melons-tell.md
+++ b/.changeset/silver-melons-tell.md
@@ -1,0 +1,5 @@
+---
+"@sap-cloud-sdk/connectivity": minor
+---
+
+[New Functionality] dummy

--- a/.github/actions/check-pr/index.js
+++ b/.github/actions/check-pr/index.js
@@ -127,7 +127,8 @@ function getAllowedBumps(preamble, isBreaking) {
 function hasMatchingChangeset(allowedBumps, changedFileContents) {
     return __awaiter(this, void 0, void 0, function () {
         return __generator(this, function (_a) {
-            console.log('allowedBumps', allowedBumps);
+            (0, core_1.info)('allowedBumps');
+            (0, core_1.info)(allowedBumps.join('\n'));
             if (allowedBumps.length) {
                 return [2 /*return*/, changedFileContents.some(function (fileContent) {
                         return allowedBumps.some(function (bump) {
@@ -147,7 +148,7 @@ function extractChangedFilesContents() {
                 case 0:
                     changedFilesStr = (0, core_1.getInput)('changed-files').trim();
                     changedFiles = changedFilesStr ? changedFilesStr.split(' ') : [];
-                    console.log(changedFiles);
+                    (0, core_1.info)(changedFiles.join('\n'));
                     return [4 /*yield*/, Promise.all(changedFiles.map(function (file) { return (0, promises_1.readFile)(file, 'utf-8'); }))];
                 case 1:
                     fileContents = _a.sent();

--- a/.github/actions/check-pr/index.js
+++ b/.github/actions/check-pr/index.js
@@ -127,13 +127,10 @@ function getAllowedBumps(preamble, isBreaking) {
 function hasMatchingChangeset(allowedBumps, changedFileContents) {
     return __awaiter(this, void 0, void 0, function () {
         return __generator(this, function (_a) {
-            (0, core_1.info)('allowedBumps');
-            (0, core_1.info)(allowedBumps.join('\n'));
             if (allowedBumps.length) {
                 return [2 /*return*/, changedFileContents.some(function (fileContent) {
-                        (0, core_1.info)(fileContent);
                         return allowedBumps.some(function (bump) {
-                            return new RegExp("\"@sap-cloud-sdk/.*\": ".concat(bump)).test(fileContent);
+                            return new RegExp("(\"|')@sap-cloud-sdk/.*(\"|'): ".concat(bump)).test(fileContent);
                         });
                     })];
             }
@@ -149,7 +146,6 @@ function extractChangedFilesContents() {
                 case 0:
                     changedFilesStr = (0, core_1.getInput)('changed-files').trim();
                     changedFiles = changedFilesStr ? changedFilesStr.split(' ') : [];
-                    (0, core_1.info)(changedFiles.join('\n'));
                     return [4 /*yield*/, Promise.all(changedFiles.map(function (file) { return (0, promises_1.readFile)(file, 'utf-8'); }))];
                 case 1:
                     fileContents = _a.sent();

--- a/.github/actions/check-pr/index.js
+++ b/.github/actions/check-pr/index.js
@@ -127,17 +127,15 @@ function getAllowedBumps(preamble, isBreaking) {
 function hasMatchingChangeset(allowedBumps, changedFileContents) {
     return __awaiter(this, void 0, void 0, function () {
         return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0:
-                    if (!allowedBumps.length) return [3 /*break*/, 2];
-                    return [4 /*yield*/, changedFileContents];
-                case 1: return [2 /*return*/, (_a.sent()).some(function (fileContent) {
+            console.log('allowedBumps', allowedBumps);
+            if (allowedBumps.length) {
+                return [2 /*return*/, changedFileContents.some(function (fileContent) {
                         return allowedBumps.some(function (bump) {
                             return new RegExp("'@sap-cloud-sdk/.*': ".concat(bump)).test(fileContent);
                         });
                     })];
-                case 2: return [2 /*return*/, true];
             }
+            return [2 /*return*/, true];
         });
     });
 }
@@ -149,6 +147,7 @@ function extractChangedFilesContents() {
                 case 0:
                     changedFilesStr = (0, core_1.getInput)('changed-files').trim();
                     changedFiles = changedFilesStr ? changedFilesStr.split(' ') : [];
+                    console.log(changedFiles);
                     return [4 /*yield*/, Promise.all(changedFiles.map(function (file) { return (0, promises_1.readFile)(file, 'utf-8'); }))];
                 case 1:
                     fileContents = _a.sent();

--- a/.github/actions/check-pr/index.js
+++ b/.github/actions/check-pr/index.js
@@ -133,7 +133,7 @@ function hasMatchingChangeset(allowedBumps, changedFileContents) {
                 return [2 /*return*/, changedFileContents.some(function (fileContent) {
                         (0, core_1.info)(fileContent);
                         return allowedBumps.some(function (bump) {
-                            return new RegExp("'@sap-cloud-sdk/.*': ".concat(bump)).test(fileContent);
+                            return new RegExp("\"@sap-cloud-sdk/.*\": ".concat(bump)).test(fileContent);
                         });
                     })];
             }

--- a/.github/actions/check-pr/index.js
+++ b/.github/actions/check-pr/index.js
@@ -131,6 +131,7 @@ function hasMatchingChangeset(allowedBumps, changedFileContents) {
             (0, core_1.info)(allowedBumps.join('\n'));
             if (allowedBumps.length) {
                 return [2 /*return*/, changedFileContents.some(function (fileContent) {
+                        (0, core_1.info)(fileContent);
                         return allowedBumps.some(function (bump) {
                             return new RegExp("'@sap-cloud-sdk/.*': ".concat(bump)).test(fileContent);
                         });

--- a/build-packages/check-pr/validators.spec.ts
+++ b/build-packages/check-pr/validators.spec.ts
@@ -80,5 +80,11 @@ describe('check-pr', () => {
       await validateChangesets('chore!', '', true, fileContents);
       expect(process.exitCode).toEqual(0);
     });
+
+    it('should validate with matched changesets in double quotes', async () => {
+      const fileContents = ['"@sap-cloud-sdk/generator": major'];
+      await validateChangesets('chore!', '', true, fileContents);
+      expect(process.exitCode).toEqual(0);
+    });
   });
 });

--- a/build-packages/check-pr/validators.ts
+++ b/build-packages/check-pr/validators.ts
@@ -99,6 +99,7 @@ async function extractChangedFilesContents(): Promise<string[]> {
   const changedFilesStr = getInput('changed-files').trim();
   const changedFiles = changedFilesStr ? changedFilesStr.split(' ') : [];
   console.log(changedFiles);
+
   const fileContents = await Promise.all(
     changedFiles.map(file => readFile(file, 'utf-8'))
   );

--- a/build-packages/check-pr/validators.ts
+++ b/build-packages/check-pr/validators.ts
@@ -86,11 +86,12 @@ async function hasMatchingChangeset(
   info('allowedBumps');
   info(allowedBumps.join('\n'));
   if (allowedBumps.length) {
-    return changedFileContents.some(fileContent =>
-      allowedBumps.some(bump =>
-        new RegExp(`'@sap-cloud-sdk\/.*': ${bump}`).test(fileContent)
-      )
-    );
+    return changedFileContents.some(fileContent => {
+      info(fileContent);
+      return allowedBumps.some(bump =>
+        new RegExp(`'@sap-cloud-sdk/.*': ${bump}`).test(fileContent)
+      );
+    });
   }
 
   return true;

--- a/build-packages/check-pr/validators.ts
+++ b/build-packages/check-pr/validators.ts
@@ -89,7 +89,7 @@ async function hasMatchingChangeset(
     return changedFileContents.some(fileContent => {
       info(fileContent);
       return allowedBumps.some(bump =>
-        new RegExp(`'@sap-cloud-sdk/.*': ${bump}`).test(fileContent)
+        new RegExp(`"@sap-cloud-sdk/.*": ${bump}`).test(fileContent)
       );
     });
   }

--- a/build-packages/check-pr/validators.ts
+++ b/build-packages/check-pr/validators.ts
@@ -83,15 +83,12 @@ async function hasMatchingChangeset(
   allowedBumps: string[],
   changedFileContents: string[]
 ): Promise<boolean> {
-  info('allowedBumps');
-  info(allowedBumps.join('\n'));
   if (allowedBumps.length) {
-    return changedFileContents.some(fileContent => {
-      info(fileContent);
-      return allowedBumps.some(bump =>
-        new RegExp(`"@sap-cloud-sdk/.*": ${bump}`).test(fileContent)
-      );
-    });
+    return changedFileContents.some(fileContent =>
+      allowedBumps.some(bump =>
+        new RegExp(`("|')@sap-cloud-sdk/.*("|'): ${bump}`).test(fileContent)
+      )
+    );
   }
 
   return true;
@@ -100,8 +97,6 @@ async function hasMatchingChangeset(
 async function extractChangedFilesContents(): Promise<string[]> {
   const changedFilesStr = getInput('changed-files').trim();
   const changedFiles = changedFilesStr ? changedFilesStr.split(' ') : [];
-  info(changedFiles.join('\n'));
-
   const fileContents = await Promise.all(
     changedFiles.map(file => readFile(file, 'utf-8'))
   );

--- a/build-packages/check-pr/validators.ts
+++ b/build-packages/check-pr/validators.ts
@@ -83,7 +83,8 @@ async function hasMatchingChangeset(
   allowedBumps: string[],
   changedFileContents: string[]
 ): Promise<boolean> {
-  console.log('allowedBumps', allowedBumps);
+  info('allowedBumps');
+  info(allowedBumps.join('\n'));
   if (allowedBumps.length) {
     return changedFileContents.some(fileContent =>
       allowedBumps.some(bump =>
@@ -98,7 +99,7 @@ async function hasMatchingChangeset(
 async function extractChangedFilesContents(): Promise<string[]> {
   const changedFilesStr = getInput('changed-files').trim();
   const changedFiles = changedFilesStr ? changedFilesStr.split(' ') : [];
-  console.log(changedFiles);
+  info(changedFiles.join('\n'));
 
   const fileContents = await Promise.all(
     changedFiles.map(file => readFile(file, 'utf-8'))

--- a/build-packages/check-pr/validators.ts
+++ b/build-packages/check-pr/validators.ts
@@ -83,8 +83,9 @@ async function hasMatchingChangeset(
   allowedBumps: string[],
   changedFileContents: string[]
 ): Promise<boolean> {
+  console.log('allowedBumps', allowedBumps);
   if (allowedBumps.length) {
-    return (await changedFileContents).some(fileContent =>
+    return changedFileContents.some(fileContent =>
       allowedBumps.some(bump =>
         new RegExp(`'@sap-cloud-sdk\/.*': ${bump}`).test(fileContent)
       )
@@ -97,6 +98,7 @@ async function hasMatchingChangeset(
 async function extractChangedFilesContents(): Promise<string[]> {
   const changedFilesStr = getInput('changed-files').trim();
   const changedFiles = changedFilesStr ? changedFilesStr.split(' ') : [];
+  console.log(changedFiles);
   const fileContents = await Promise.all(
     changedFiles.map(file => readFile(file, 'utf-8'))
   );


### PR DESCRIPTION
PR checks recently started failing. I found that this is due to the `"` instead of `'` in the changesets. This PR allows both.

Closes https://github.com/SAP/cloud-sdk-backlog/issues/1185

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
