### PR TITLE
fix: fix default encoding in openapi

### DIFF
--- a/.changeset/light-cats-tickle.md
+++ b/.changeset/light-cats-tickle.md
@@ -1,0 +1,5 @@
+---
+"@sap-cloud-sdk/openapi": patch
+---
+
+[Fixed Issue] Fix incorrect encoding of query parameters in OpenAPI requests. Query parameters (except for additional custom parameters) are now encoded by default. To change this behavior overwrite the `parameterEncoder` in the request options.

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -53,7 +53,7 @@ import {
   buildRequestWithMergedHeadersAndQueryParameters,
   encodeAllParameters,
   executeHttpRequest,
-  encodeTypedClientRequest,
+  odataTypedClientParameterEncoder,
   executeHttpRequestWithOrigin,
   buildHttpRequestConfigWithOrigin
 } from './http-client';
@@ -1082,7 +1082,7 @@ If the parameters from multiple origins use the same key, the priority is 1. Cus
       const actual = await buildRequestWithMergedHeadersAndQueryParameters(
         {
           ...requestWithParameters,
-          parameterEncoder: encodeTypedClientRequest
+          parameterEncoder: odataTypedClientParameterEncoder
         },
         destinationWithParameters,
         {} as DestinationHttpRequestConfig
@@ -1091,7 +1091,7 @@ If the parameters from multiple origins use the same key, the priority is 1. Cus
         method: 'get',
         url: '/api/entity',
         headers: {},
-        parameterEncoder: encodeTypedClientRequest,
+        parameterEncoder: odataTypedClientParameterEncoder,
         params: {
           customParam: 'a/b',
           requestParam: 'a/b',

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -53,7 +53,7 @@ import {
   buildRequestWithMergedHeadersAndQueryParameters,
   encodeAllParameters,
   executeHttpRequest,
-  odataTypedClientParameterEncoder,
+  oDataTypedClientParameterEncoder,
   executeHttpRequestWithOrigin,
   buildHttpRequestConfigWithOrigin
 } from './http-client';
@@ -1082,7 +1082,7 @@ If the parameters from multiple origins use the same key, the priority is 1. Cus
       const actual = await buildRequestWithMergedHeadersAndQueryParameters(
         {
           ...requestWithParameters,
-          parameterEncoder: odataTypedClientParameterEncoder
+          parameterEncoder: oDataTypedClientParameterEncoder
         },
         destinationWithParameters,
         {} as DestinationHttpRequestConfig
@@ -1091,7 +1091,7 @@ If the parameters from multiple origins use the same key, the priority is 1. Cus
         method: 'get',
         url: '/api/entity',
         headers: {},
-        parameterEncoder: odataTypedClientParameterEncoder,
+        parameterEncoder: oDataTypedClientParameterEncoder,
         params: {
           customParam: 'a/b',
           requestParam: 'a/b',

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -148,7 +148,7 @@ export function buildHttpRequestConfigWithOrigin(
  * @returns The parameters as they are without encoding.
  * @internal
  */
-export const odataTypedClientParameterEncoder: ParameterEncoder = (
+export const oDataTypedClientParameterEncoder: ParameterEncoder = (
   params: Record<string, any>
 ) => params;
 
@@ -169,8 +169,8 @@ function encodeQueryParameters(options: {
 
 function isOdataTypedClientParameterEncoder(
   parameterEncoder: ParameterEncoder
-): parameterEncoder is typeof odataTypedClientParameterEncoder {
-  return parameterEncoder.name === odataTypedClientParameterEncoder.name;
+): parameterEncoder is typeof oDataTypedClientParameterEncoder {
+  return parameterEncoder.name === oDataTypedClientParameterEncoder.name;
 }
 
 function getEncodedParameters(

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -143,7 +143,7 @@ export function buildHttpRequestConfigWithOrigin(
 }
 
 /**
- * This method does nothing and is only there to indicate that the call was made by an typed OData client and encoding already happened on in the client.
+ * This method does nothing and is only there to indicate that the call was made by a typed OData client and encoding already happened in the client.
  * @param params - Parameters which are returned.
  * @returns The parameters as they are without encoding.
  * @internal

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -20,6 +20,7 @@ import { executeWithMiddleware } from '@sap-cloud-sdk/resilience/internal';
 import {
   createLogger,
   ErrorWithCause,
+  isNullish,
   sanitizeRecord,
   unixEOL
 } from '@sap-cloud-sdk/util';
@@ -142,12 +143,12 @@ export function buildHttpRequestConfigWithOrigin(
 }
 
 /**
- * This method does nothing and is only there to indicate that the call was made by an OData or OpenApi client and encoding is already done on filter and key parameters.
+ * This method does nothing and is only there to indicate that the call was made by an typed OData client and encoding already happened on in the client.
  * @param params - Parameters which are returned.
  * @returns The parameters as they are without encoding.
  * @internal
  */
-export const encodeTypedClientRequest: ParameterEncoder = (
+export const odataTypedClientParameterEncoder: ParameterEncoder = (
   params: Record<string, any>
 ) => params;
 
@@ -166,16 +167,10 @@ function encodeQueryParameters(options: {
   );
 }
 
-function isGenericClientDefault(
-  parameterEncoder: ParameterEncoder | undefined
-): parameterEncoder is undefined {
-  return !parameterEncoder;
-}
-
-function isTypedClient(
+function isOdataTypedClientParameterEncoder(
   parameterEncoder: ParameterEncoder
-): parameterEncoder is typeof encodeTypedClientRequest {
-  return parameterEncoder.name === encodeTypedClientRequest.name;
+): parameterEncoder is typeof odataTypedClientParameterEncoder {
+  return parameterEncoder.name === odataTypedClientParameterEncoder.name;
 }
 
 function getEncodedParameters(
@@ -183,7 +178,7 @@ function getEncodedParameters(
   requestConfig: HttpRequestConfigWithOrigin
 ): OriginOptionsInternal {
   const { parameterEncoder } = requestConfig;
-  if (isGenericClientDefault(parameterEncoder)) {
+  if (isNullish(parameterEncoder)) {
     return encodeQueryParameters({
       parameters,
       parameterEncoder: encodeAllParameters,
@@ -191,7 +186,7 @@ function getEncodedParameters(
     });
   }
 
-  if (isTypedClient(parameterEncoder)) {
+  if (isOdataTypedClientParameterEncoder(parameterEncoder)) {
     return encodeQueryParameters({
       parameters,
       parameterEncoder: encodeAllParameters,
@@ -199,7 +194,7 @@ function getEncodedParameters(
     });
   }
 
-  // Custom encoder provided for generic client -> use it for all origins
+  // Custom encoder provided by user -> use it for all origins
   return encodeQueryParameters({ parameters, parameterEncoder, exclude: [] });
 }
 

--- a/packages/odata-common/src/request/odata-request-config.ts
+++ b/packages/odata-common/src/request/odata-request-config.ts
@@ -1,6 +1,6 @@
 import { mergeIgnoreCase } from '@sap-cloud-sdk/util';
 import {
-  encodeTypedClientRequest,
+  oDataTypedClientParameterEncoder,
   HttpMiddleware
 } from '@sap-cloud-sdk/http-client/internal';
 import type { ParameterEncoder } from '@sap-cloud-sdk/http-client/internal';
@@ -22,7 +22,7 @@ export abstract class ODataRequestConfig {
     accept: 'application/json'
   };
 
-  readonly parameterEncoder: ParameterEncoder = encodeTypedClientRequest;
+  readonly parameterEncoder: ParameterEncoder = oDataTypedClientParameterEncoder;
 
   private _customHeaders: Record<string, string> = {};
   private _customQueryParameters: Record<string, string> = {};

--- a/packages/odata-common/src/request/odata-request-config.ts
+++ b/packages/odata-common/src/request/odata-request-config.ts
@@ -22,7 +22,8 @@ export abstract class ODataRequestConfig {
     accept: 'application/json'
   };
 
-  readonly parameterEncoder: ParameterEncoder = oDataTypedClientParameterEncoder;
+  readonly parameterEncoder: ParameterEncoder =
+    oDataTypedClientParameterEncoder;
 
   private _customHeaders: Record<string, string> = {};
   private _customQueryParameters: Record<string, string> = {};

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -13,7 +13,9 @@ import { ODataRequest } from './odata-request';
 describe('OData Request', () => {
   it('should be noParamEncoder', async () => {
     const request = createRequest(ODataGetAllRequestConfig);
-    expect(request.config.parameterEncoder).toBe(oDataTypedClientParameterEncoder);
+    expect(request.config.parameterEncoder).toBe(
+      oDataTypedClientParameterEncoder
+    );
   });
 
   describe('serviceUrl', () => {

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from 'uuid';
-import { encodeTypedClientRequest } from '@sap-cloud-sdk/http-client/internal';
+import { oDataTypedClientParameterEncoder } from '@sap-cloud-sdk/http-client/internal';
 import { commonODataUri } from '@sap-cloud-sdk/test-services-odata-common/common-request-config';
 import {
   CommonEntity,
@@ -13,7 +13,7 @@ import { ODataRequest } from './odata-request';
 describe('OData Request', () => {
   it('should be noParamEncoder', async () => {
     const request = createRequest(ODataGetAllRequestConfig);
-    expect(request.config.parameterEncoder).toBe(encodeTypedClientRequest);
+    expect(request.config.parameterEncoder).toBe(oDataTypedClientParameterEncoder);
   });
 
   describe('serviceUrl', () => {

--- a/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
@@ -1,7 +1,7 @@
 import nock from 'nock';
 import * as httpClient from '@sap-cloud-sdk/http-client';
 import { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
-import { encodeTypedClientRequest } from '@sap-cloud-sdk/http-client/dist/http-client';
+import { oDataTypedClientParameterEncoder } from '@sap-cloud-sdk/http-client/dist/http-client';
 import { asc, desc } from '@sap-cloud-sdk/odata-common';
 import { timeout } from '@sap-cloud-sdk/resilience';
 import {
@@ -356,7 +356,7 @@ describe('GetAllRequestBuilder', () => {
               'content-type': 'application/json'
             }
           },
-          parameterEncoder: encodeTypedClientRequest,
+          parameterEncoder: oDataTypedClientParameterEncoder,
           params: {
             requestConfig: {}
           },

--- a/packages/openapi/src/openapi-request-builder.spec.ts
+++ b/packages/openapi/src/openapi-request-builder.spec.ts
@@ -256,7 +256,7 @@ describe('openapi-request-builder', () => {
   it('encodes query parameters', async () => {
     jest.spyOn(resilienceInternal, 'executeWithMiddleware');
     const requestBuilder = new OpenApiRequestBuilder('get', '/test', {
-      queryParameters: { id: '^test' }
+      queryParameters: { 'id^': '^test' }
     });
 
     await requestBuilder.executeRaw(destination);
@@ -264,7 +264,7 @@ describe('openapi-request-builder', () => {
     expect(resilienceInternal.executeWithMiddleware).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        fnArgument: expect.objectContaining({ params: { id: '%5Etest' } })
+        fnArgument: expect.objectContaining({ params: { 'id%5E': '%5Etest' } })
       })
     );
   });

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -22,7 +22,6 @@ import {
 import {
   filterCustomRequestConfig,
   OriginOptions,
-  encodeTypedClientRequest,
   HttpMiddleware
 } from '@sap-cloud-sdk/http-client/internal';
 
@@ -31,10 +30,6 @@ import {
  * @typeParam ResponseT - Type of the response for the request.
  */
 export class OpenApiRequestBuilder<ResponseT = any> {
-  private static isPlaceholder(pathPart: string): boolean {
-    return /^\{.+\}$/.test(pathPart);
-  }
-
   private customHeaders: Record<string, string> = {};
   private customRequestConfiguration: Record<string, string> = {};
   private _fetchCsrfToken = true;
@@ -155,7 +150,6 @@ export class OpenApiRequestBuilder<ResponseT = any> {
       headers: this.getHeaders(),
       params: this.getParameters(),
       middleware: this._middlewares,
-      parameterEncoder: encodeTypedClientRequest,
       data: this.parameters?.body
     };
     return {
@@ -165,7 +159,7 @@ export class OpenApiRequestBuilder<ResponseT = any> {
   }
 
   private getHeaders(): OriginOptions {
-    if (Object.keys(this.customHeaders).length > 0) {
+    if (Object.keys(this.customHeaders).length) {
       return { custom: this.customHeaders, requestConfig: {} };
     }
     return { requestConfig: {} };


### PR DESCRIPTION
Currently the OpenAPI requestbuilder erroneously does not encode query parameters by default. 
This PR fixes that.

Closes SAP/cloud-sdk-backlog#1182.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
