### PR TITLE
fix: Fix custom request config type

### DIFF
--- a/.changeset/five-socks-confess.md
+++ b/.changeset/five-socks-confess.md
@@ -1,0 +1,6 @@
+---
+"@sap-cloud-sdk/odata-common": patch
+"@sap-cloud-sdk/openapi": patch
+---
+
+[Fixed Issue] Fix type in `addCustomRequestConfiguration` method to accept values of type `any`.

--- a/packages/odata-common/src/request-builder/request-builder-base.ts
+++ b/packages/odata-common/src/request-builder/request-builder-base.ts
@@ -102,7 +102,7 @@ export abstract class MethodRequestBuilder<
    * @returns The request builder itself, to facilitate method chaining.
    */
   addCustomRequestConfiguration(
-    requestConfiguration: Record<string, string>
+    requestConfiguration: Record<string, any>
   ): this {
     this.requestConfig.addCustomRequestConfiguration(requestConfiguration);
     return this;

--- a/packages/odata-common/src/request/odata-request-config.ts
+++ b/packages/odata-common/src/request/odata-request-config.ts
@@ -119,7 +119,7 @@ export abstract class ODataRequestConfig {
    * @param requestConfiguration - Key-value pairs where the key is the name of a request configuration and the value is the respective value.
    */
   addCustomRequestConfiguration(
-    requestConfiguration: Record<string, string>
+    requestConfiguration: Record<string, any>
   ): void {
     Object.entries(requestConfiguration).forEach(([key, value]) => {
       this.customRequestConfiguration[key] = value;

--- a/packages/openapi/src/openapi-request-builder.spec.ts
+++ b/packages/openapi/src/openapi-request-builder.spec.ts
@@ -273,8 +273,8 @@ describe('openapi-request-builder', () => {
     const requestBuilder = new OpenApiRequestBuilder('get', '/test');
     const response = await requestBuilder
       .addCustomRequestConfiguration({
-         responseType: 'arraybuffer',
-         timeout: 1000
+        responseType: 'arraybuffer',
+        timeout: 1000
       })
       .executeRaw(destination);
     expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(

--- a/packages/openapi/src/openapi-request-builder.spec.ts
+++ b/packages/openapi/src/openapi-request-builder.spec.ts
@@ -272,7 +272,10 @@ describe('openapi-request-builder', () => {
   it('addCustomRequestConfig', async () => {
     const requestBuilder = new OpenApiRequestBuilder('get', '/test');
     const response = await requestBuilder
-      .addCustomRequestConfiguration({ responseType: 'arraybuffer' })
+      .addCustomRequestConfiguration({
+         responseType: 'arraybuffer',
+         timeout: 1000
+      })
       .executeRaw(destination);
     expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(
       sanitizeDestination(destination),
@@ -283,7 +286,8 @@ describe('openapi-request-builder', () => {
         headers: { requestConfig: {} },
         params: { requestConfig: {} },
         data: undefined,
-        responseType: 'arraybuffer'
+        responseType: 'arraybuffer',
+        timeout: 1000
       },
       { fetchCsrfToken: false }
     );

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -66,7 +66,7 @@ export class OpenApiRequestBuilder<ResponseT = any> {
    * @returns The request builder itself, to facilitate method chaining.
    */
   addCustomRequestConfiguration(
-    requestConfiguration: Record<string, string>
+    requestConfiguration: Record<string, any>
   ): this {
     Object.entries(requestConfiguration).forEach(([key, value]) => {
       this.customRequestConfiguration[key] = value;


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Relates to https://github.com/SAP/cloud-sdk-js/issues/4488

The `addCustomRequestConfiguration` method on a request builder accepts an object in the form of Record<string, string>. However axios accepts other types than string as well.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
