### PR TITLE
fix: Fetch destination array by type in `fetchDestinationWithoutTokenRetrieval` 

### DIFF
--- a/.changeset/seven-shoes-do.md
+++ b/.changeset/seven-shoes-do.md
@@ -2,4 +2,4 @@
 "@sap-cloud-sdk/connectivity": patch
 ---
 
-[Fixed Issue] Fix `fetchDestinationWithoutTokenRetrieval` to correctly return instance and subaccount destinations array
+[Fixed Issue] Fix `fetchDestinationWithoutTokenRetrieval` to correctly return instance and subaccount destinations.

--- a/.changeset/seven-shoes-do.md
+++ b/.changeset/seven-shoes-do.md
@@ -1,0 +1,5 @@
+---
+"@sap-cloud-sdk/connectivity": patch
+---
+
+[Fixed Issue] Fix `fetchDestinationWithoutTokenRetrieval` to correctly return instance and subaccount destinations array

--- a/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
@@ -12,6 +12,7 @@ import { DestinationConfiguration, parseDestination } from './destination';
 import {
   fetchCertificate,
   fetchDestinationWithTokenRetrieval,
+  fetchDestinationWithoutTokenRetrieval,
   fetchDestinations
 } from './destination-service';
 import { Destination } from './destination-service-types';
@@ -829,6 +830,42 @@ describe('destination service', () => {
           destinationName
         })
       ).rejects.toThrowError();
+    });
+  });
+
+  describe('fetchDestinationWithoutTokenRetrieval', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('returns correct destination by type based on owner property in response', async () => {
+      const destinationName = 'HTTP-BASIC';
+      const response = {
+        owner: {
+          SubaccountId: 'a89ea924-d9c2-4eab-84fb-3ffcaadf5d24',
+          InstanceId: '60f1cc00-6c94-4ada-ba16-495325060b54'
+        },
+        destinationConfiguration: basicDestination
+      };
+      nock(destinationServiceUri, {
+        reqheaders: {
+          authorization: `Bearer ${jwt}`
+        }
+      })
+        .get(
+          '/destination-configuration/v1/destinations/HTTP-BASIC?$skipTokenRetrieval=true'
+        )
+        .reply(200, response);
+
+      const actual = await fetchDestinationWithoutTokenRetrieval(
+        destinationName,
+        destinationServiceUri,
+        jwt
+      );
+      expect(actual).toMatchObject({
+        subaccount: [],
+        instance: [parseDestination(response.destinationConfiguration)]
+      });
     });
   });
 });

--- a/packages/connectivity/src/scp-cf/destination/destination-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.ts
@@ -157,7 +157,10 @@ export async function fetchDestinationWithoutTokenRetrieval(
 
     return {
       instance: response.data.owner?.InstanceId ? [destination] : [],
-      subaccount: response.data.owner?.SubaccountId ? [destination] : []
+      subaccount:
+        !response.data.owner?.InstanceId && response.data.owner?.SubaccountId
+          ? [destination]
+          : []
     };
   } catch (err) {
     if (


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes https://github.com/SAP/cloud-sdk-backlog/issues/1190

Fix check based on which subaccount destination array is returned. This leads to the warning log appearing if there is only one destination at instance level and not at sub-account level.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
