### PR TITLE
chore: Remove `toAuthorizationHeader` and `assoc` function

### DIFF
--- a/packages/connectivity/src/scp-cf/authorization-header.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.ts
@@ -46,11 +46,6 @@ export function getAuthHeader(
   }
 }
 
-function toAuthorizationHeader(
-  authorization: string
-): AuthenticationHeaderCloud {
-  return { authorization };
-}
 function headerFromTokens(
   authenticationType: AuthenticationType,
   authTokens?: DestinationAuthToken[] | null
@@ -75,7 +70,7 @@ function headerFromTokens(
   }
   const authToken = usableTokens[0];
   // The value property of the destination service has already the pattern e.g. "Bearer Token" so it can be used directly.
-  return toAuthorizationHeader(authToken.http_header.value);
+  return { authorization: authToken.http_header.value };
 }
 
 function headerFromBasicAuthDestination(
@@ -87,9 +82,9 @@ function headerFromBasicAuthDestination(
     );
   }
 
-  return toAuthorizationHeader(
-    basicHeader(destination.username, destination.password)
-  );
+  return {
+    authorization: basicHeader(destination.username, destination.password)
+  };
 }
 
 /**
@@ -175,7 +170,7 @@ async function getAuthenticationRelatedHeaders(
     case null:
     case undefined:
       logger.warn(
-        'No authentication type is specified on the destination! Assuming "NoAuthentication".'
+        'No authentication type is specified on the destination. Assuming "NoAuthentication".'
       );
       return;
     case 'NoAuthentication':

--- a/packages/connectivity/src/scp-cf/destination/destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination.ts
@@ -1,4 +1,4 @@
-import { assoc, Xor } from '@sap-cloud-sdk/util';
+import { Xor } from '@sap-cloud-sdk/util';
 import {
   DestinationFetchOptions,
   isDestinationFetchOptions
@@ -207,7 +207,10 @@ function setOriginalProperties(destination: Destination): Destination {
   const originalProperties = destination.originalProperties
     ? destination.originalProperties
     : destination;
-  return assoc('originalProperties', originalProperties, destination);
+  return {
+    ...destination,
+    originalProperties
+  };
 }
 
 function setDefaultAuthenticationFallback(
@@ -215,7 +218,10 @@ function setDefaultAuthenticationFallback(
 ): Destination {
   return destination.authentication
     ? destination
-    : assoc('authentication', getAuthenticationType(destination), destination);
+    : {
+        ...destination,
+        authentication: getAuthenticationType(destination)
+      };
 }
 
 /**
@@ -237,10 +243,12 @@ export function parseCertificate(
 function parseCertificates(
   destination: Record<string, any>
 ): Record<string, any> {
-  const certificates = destination.certificates
-    ? destination.certificates.map(parseCertificate)
-    : [];
-  return assoc('certificates', certificates, destination);
+  return {
+    ...destination,
+    certificates: (destination.certificates || []).map(certificate =>
+      parseCertificate(certificate)
+    )
+  };
 }
 
 function parseAuthToken(authToken: Record<string, any>): DestinationAuthToken {
@@ -256,18 +264,21 @@ function parseAuthToken(authToken: Record<string, any>): DestinationAuthToken {
 function parseAuthTokens(
   destination: Record<string, any>
 ): Record<string, any> {
-  const authTokens = destination.authTokens
-    ? destination.authTokens.map(parseAuthToken)
-    : [];
-  return assoc('authTokens', authTokens, destination);
+  return {
+    ...destination,
+    authTokens: (destination.authTokens || []).map(token =>
+      parseAuthToken(token)
+    )
+  };
 }
 
 function setTrustAll(destination: Destination): Destination {
-  return assoc(
-    'isTrustingAllCertificates',
-    parseTrustAll(destination.isTrustingAllCertificates),
-    destination
-  );
+  return {
+    ...destination,
+    isTrustingAllCertificates: parseTrustAll(
+      destination.isTrustingAllCertificates
+    )
+  };
 }
 
 function parseTrustAll(isTrustingAllCertificates?: string | boolean): boolean {

--- a/packages/util/src/object.ts
+++ b/packages/util/src/object.ts
@@ -88,7 +88,7 @@ export const exclude = <T extends Record<string, unknown>>(
  * @param value - Value to be added.
  * @param obj - Object the key value pair is added to.
  * @returns The object with the key value pair added.
- * @deprecated  Since v3.13.0. Will not be replaced.
+ * @deprecated  Since v3.12.1. Will not be replaced.
  */
 export const assoc = <T>(
   key: string,

--- a/packages/util/src/object.ts
+++ b/packages/util/src/object.ts
@@ -88,6 +88,7 @@ export const exclude = <T extends Record<string, unknown>>(
  * @param value - Value to be added.
  * @param obj - Object the key value pair is added to.
  * @returns The object with the key value pair added.
+ * @deprecated  Since v3.13.0. Will not be replaced.
  */
 export const assoc = <T>(
   key: string,


### PR DESCRIPTION
I noticed this unnecessary function while investigating a user issue and I found it harder to read than necessary.