### PR TITLE
chore: (really) fix canary build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Show input from dispatch event
         run: echo "Canary release flag ${{ inputs.canary-release }}"
   tests:
-    if: inputs.canary-release == 'false'
+    if: inputs.canary-release == true
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,8 @@ on:
         description: 'Release canary version (skips tests and checks)'
         type: boolean
         required: false
-        default: false
+        # This looks like a boolean, but it's actually a string
+        default: 'false'
 
 jobs:
   log:
@@ -24,7 +25,7 @@ jobs:
       - name: Show input from dispatch event
         run: echo "Canary release flag ${{ github.event.inputs.canary-release }}"
   tests:
-    if: fromJson(github.event.inputs.canary-release) == false
+    if: github.event.inputs.canary-release == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,13 @@ on:
         default: false
 
 jobs:
+  log:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show input from dispatch event
+        run: echo "Canary release flag ${{ github.event.inputs.canary-release }}"
+      - name: Show input from dispatch event
+        run: echo "Skip checks flag ${{ github.event.inputs.skip-checks }}"
   tests:
     if: github.event.inputs.skip-checks == false
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Show input from dispatch event
-        run: echo "Canary release flag ${{ github.event.inputs.canary-release }}"
+        run: echo "Canary release flag ${{ inputs.canary-release }}"
   tests:
     if: inputs.canary-release == 'false'
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ on:
         description: 'Release canary version (skips tests and checks)'
         type: boolean
         required: false
-        # This looks like a boolean, but it's actually a string
         default: false
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Show input from dispatch event
         run: echo "Canary release flag ${{ inputs.canary-release }}"
   tests:
-    if: inputs.canary-release == true
+    if: inputs.canary-release == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -50,7 +50,7 @@ jobs:
       - run: yarn test:build-packages
       - run: yarn test:type
   checks:
-    if: ${{ inputs.canary-release == false }}
+    if: inputs.canary-release == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -79,7 +79,7 @@ jobs:
       - run: yarn check:license
         name: License Check
   e2e-tests:
-    if: github.event.inputs.canary-release == false
+    if: inputs.canary-release == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -141,7 +141,7 @@ jobs:
     # execute canary release if:
     # either the canary-release was scheduled and the canary-pre-check step resulted in skip-release=false
     # or the canary-release input is true
-    if: always() && (needs.canary-release-pre-check.outputs.skip-release == 'false' || github.event.inputs.canary-release == true)
+    if: always() && (needs.canary-release-pre-check.outputs.skip-release == 'false' || inputs.canary-release == true)
     runs-on: ubuntu-latest
     needs: [canary-release-pre-check]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Show input from dispatch event
         run: echo "Skip checks flag ${{ github.event.inputs.skip-checks }}"
   tests:
-    if: github.event.inputs.skip-checks == 'false'
+    if: ${{ github.event.inputs.skip-checks == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Show input from dispatch event
         run: echo "Skip checks flag ${{ github.event.inputs.skip-checks }}"
   tests:
-    if: github.event.inputs.skip-checks == false
+    if: github.event.inputs.skip-checks == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         node-version: [18]
     steps:
       - name: Show input from dispatch event
-        run: echo "Canary release flag ${{ github.event.inputs.canary-release }}"
+        run: echo "Canary release flag ${{ inputs.canary-release }}"
       - uses: actions/checkout@v3
       - run: git fetch --depth=1
       - uses: actions/setup-node@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,9 +140,7 @@ jobs:
     # execute canary release if:
     # either the canary-release was scheduled and the canary-pre-check step resulted in skip-release=false
     # or the canary-release input is true
-    if: |
-      needs.canary-release-pre-check.outputs.skip-release == 'false' ||
-      always() && github.event.inputs.canary-release == true
+    if: always() && (needs.canary-release-pre-check.outputs.skip-release == 'false' || github.event.inputs.canary-release == true)
     runs-on: ubuntu-latest
     needs: [canary-release-pre-check]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       canary-release:
-        description: 'Canary release after build'
-        type: boolean
-        required: false
-        default: false
-      skip-checks:
-        description: 'Skip tests and checks'
+        description: 'Release canary version (skips tests and checks)'
         type: boolean
         required: false
         default: false
@@ -28,10 +23,8 @@ jobs:
     steps:
       - name: Show input from dispatch event
         run: echo "Canary release flag ${{ github.event.inputs.canary-release }}"
-      - name: Show input from dispatch event
-        run: echo "Skip checks flag ${{ github.event.inputs.skip-checks }}"
   tests:
-    if: ${{ github.event.inputs.skip-checks == false }}
+    if: fromJson(github.event.inputs.canary-release) == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -56,7 +49,7 @@ jobs:
       - run: yarn test:build-packages
       - run: yarn test:type
   checks:
-    if: github.event.inputs.skip-checks == false
+    if: github.event.inputs.canary-release == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -85,7 +78,7 @@ jobs:
       - run: yarn check:license
         name: License Check
   e2e-tests:
-    if: github.event.inputs.skip-checks == false
+    if: github.event.inputs.canary-release == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
         required: false
         # This looks like a boolean, but it's actually a string
-        default: 'false'
+        default: false
 
 jobs:
   log:
@@ -25,7 +25,7 @@ jobs:
       - name: Show input from dispatch event
         run: echo "Canary release flag ${{ github.event.inputs.canary-release }}"
   tests:
-    if: github.event.inputs.canary-release == 'false'
+    if: inputs.canary-release == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Show input from dispatch event
         run: echo "Canary release flag ${{ github.event.inputs.canary-release }}"
   tests:
-    if: inputs.canary-release == false
+    if: inputs.canary-release == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -50,7 +50,7 @@ jobs:
       - run: yarn test:build-packages
       - run: yarn test:type
   checks:
-    if: github.event.inputs.canary-release == false
+    if: ${{ inputs.canary-release == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -8,7 +8,7 @@ on:
         required: false
 
 env:
-  INPUT_MAJOR_VERSION: ${{ github.event.inputs.majorVersion }}
+  INPUT_MAJOR_VERSION: ${{ inputs.majorVersion }}
 
 jobs:
   bump:


### PR DESCRIPTION
I found that we were using the events api (`github.event.inputs`), which always gives you a string and I replaced it with the context api (`intputs`) that preserves the type.
This does not explain why it was previously necessary to compare to a boolean on strings, but I guess it has something to do with how it is compared and that `github.event.inputs.skip-checks` was falsy.

Also, I remoed the skip-check and always skip checks when running the canary build