### PR TITLE
fix: Filter for operations which do not have OperationImport 

### DIFF
--- a/.changeset/light-insects-bow.md
+++ b/.changeset/light-insects-bow.md
@@ -1,0 +1,5 @@
+---
+"@sap-cloud-sdk/generator": minor
+---
+
+[Fix] Filter for operations without OperationImport. Unnecessay warning logs are no longer generated.

--- a/packages/generator/src/edmx-to-vdm/v4/operation.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/operation.ts
@@ -124,13 +124,18 @@ export function filterAndTransformOperations(
     operation => (operation.IsBound.toLowerCase() === 'true') === isBound
   );
 
-  const [withoutOperation, withOperation] = splitMissingOperation(
+  const [withoutOperation] = splitMissingOperation(
+    operationImports,
+    operations
+  );
+
+  const [, boundWithOperation] = splitMissingOperation(
     operationImports,
     filteredByBoundOperations
   );
 
   const [validOperations, operationsWithoutRequiredParameters] =
-    splitMissingParameter(withOperation);
+    splitMissingParameter(boundWithOperation);
 
   if (operationsWithoutRequiredParameters.length) {
     logger.warn(


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Due to a wrong implementation of filtering operations without OperationImport, unnecessary warnings were being logged during odata generation. Instead of checking all `EdmxOperation[]`, only those with `isBound` flag were being checked. This is now rectified and aforementioned warnings are no longer generated.

Closes SAP/cloud-sdk-backlog#1199

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
