### PR TITLE
chore: Update slack-notify

### DIFF
--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -42,4 +42,5 @@ jobs:
           SLACK_MESSAGE: 'Test failed'
           MSG_MINIMAL: event,actions url
           SLACK_COLOR: ${{ job.status }}
+          SLACK_MSG_AUTHOR: ' '
           SLACK_ICON: https://sap.github.io/cloud-sdk/img/logo.png

--- a/.github/workflows/blackduck.yml
+++ b/.github/workflows/blackduck.yml
@@ -34,13 +34,12 @@ jobs:
           DETECT_YARN_DEPENDENCY_TYPES_EXCLUDED: NON_PRODUCTION
       - if: failure() || cancelled()
         name: Slack Notify
-        uses: rtCamp/action-slack-notify@v2.2.1
+        uses: rtCamp/action-slack-notify@v2.3.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: SDK Pipeline Bot
           SLACK_TITLE: Blackduck scan ${{ job.status }}
-          SLACK_MESSAGE: ' '
+          SLACK_MESSAGE: 'Test failed'
           MSG_MINIMAL: event,actions url
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MSG_AUTHOR: ' '
           SLACK_ICON: https://sap.github.io/cloud-sdk/img/logo.png

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,15 +50,14 @@ jobs:
       - run: yarn test:type
       - if: ${{ github.event_name != 'pull_request' && (failure() || cancelled()) }}
         name: Slack Notify
-        uses: rtCamp/action-slack-notify@v2.2.1
+        uses: rtCamp/action-slack-notify@v2.3.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: SDK Pipeline Bot
           SLACK_TITLE: Build tests ${{ job.status }} (${{ matrix.version }})
-          SLACK_MESSAGE: ' '
+          SLACK_MESSAGE: 'Test failed'
           MSG_MINIMAL: event,actions url
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MSG_AUTHOR: ' '
           SLACK_ICON: https://sap.github.io/cloud-sdk/img/logo.png
 
   checks:
@@ -92,15 +91,14 @@ jobs:
         name: License Check
       - if: ${{ github.event_name != 'pull_request' && (failure() || cancelled()) }}
         name: Slack Notify
-        uses: rtCamp/action-slack-notify@v2.2.1
+        uses: rtCamp/action-slack-notify@v2.3.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: SDK Pipeline Bot
           SLACK_TITLE: Build checks ${{ job.status }} (${{ matrix.version }})
-          SLACK_MESSAGE: ' '
+          SLACK_MESSAGE: 'Test failed'
           MSG_MINIMAL: event,actions url
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MSG_AUTHOR: ' '
           SLACK_ICON: https://sap.github.io/cloud-sdk/img/logo.png
 
   e2e-tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
           SLACK_MESSAGE: 'Test failed'
           MSG_MINIMAL: event,actions url
           SLACK_COLOR: ${{ job.status }}
+          SLACK_MSG_AUTHOR: ' '
           SLACK_ICON: https://sap.github.io/cloud-sdk/img/logo.png
 
   checks:
@@ -99,6 +100,7 @@ jobs:
           SLACK_MESSAGE: 'Test failed'
           MSG_MINIMAL: event,actions url
           SLACK_COLOR: ${{ job.status }}
+          SLACK_MSG_AUTHOR: ' '
           SLACK_ICON: https://sap.github.io/cloud-sdk/img/logo.png
 
   e2e-tests:

--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -16,13 +16,12 @@ jobs:
           token: '${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}'
       - if: failure() || cancelled()
         name: Slack Notify
-        uses: rtCamp/action-slack-notify@v2.2.1
+        uses: rtCamp/action-slack-notify@v2.3.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: SDK Pipeline Bot
           SLACK_TITLE: Fosstars scan ${{ job.status }}
-          SLACK_MESSAGE: ' '
+          SLACK_MESSAGE: 'Test failed'
           MSG_MINIMAL: event,actions url
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MSG_AUTHOR: ' '
           SLACK_ICON: https://sap.github.io/cloud-sdk/img/logo.png

--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -24,4 +24,5 @@ jobs:
           SLACK_MESSAGE: 'Test failed'
           MSG_MINIMAL: event,actions url
           SLACK_COLOR: ${{ job.status }}
+          SLACK_MSG_AUTHOR: ' '
           SLACK_ICON: https://sap.github.io/cloud-sdk/img/logo.png

--- a/.github/workflows/memory-tests.yml
+++ b/.github/workflows/memory-tests.yml
@@ -46,4 +46,5 @@ jobs:
           SLACK_MESSAGE: 'Test failed'
           MSG_MINIMAL: event,actions url
           SLACK_COLOR: ${{ job.status }}
+          SLACK_MSG_AUTHOR: ' '
           SLACK_ICON: https://sap.github.io/cloud-sdk/img/logo.png

--- a/.github/workflows/memory-tests.yml
+++ b/.github/workflows/memory-tests.yml
@@ -38,13 +38,12 @@ jobs:
         name: compare v2 and canary
       - if: failure() || cancelled()
         name: Slack Notify
-        uses: rtCamp/action-slack-notify@v2.2.1
+        uses: rtCamp/action-slack-notify@v2.3.0
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: SDK Pipeline Bot
           SLACK_TITLE: Memory tests ${{ job.status }}
-          SLACK_MESSAGE: ' '
+          SLACK_MESSAGE: 'Test failed'
           MSG_MINIMAL: event,actions url
           SLACK_COLOR: ${{ job.status }}
-          SLACK_MSG_AUTHOR: ' '
           SLACK_ICON: https://sap.github.io/cloud-sdk/img/logo.png


### PR DESCRIPTION
With this PR, we update the slack action to 2.3.0, 2.3.0 created a breaking change, where we now have to fill the message and author with actual values.