### PR TITLE
chore: fix xsuaa service cache and subdomain

### DIFF
--- a/packages/connectivity/src/scp-cf/environment-accessor/xsuaa.spec.ts
+++ b/packages/connectivity/src/scp-cf/environment-accessor/xsuaa.spec.ts
@@ -1,5 +1,10 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import { getXsuaaServiceCredentials } from './xsuaa';
+import {
+  clearXsuaaServices,
+  getXsuaaService,
+  getXsuaaServiceCredentials
+} from './xsuaa';
+import { ServiceCredentials } from './environment-accessor-types';
 
 const clientId = 'sb-jwt-app';
 
@@ -17,45 +22,111 @@ const services = {
   ]
 };
 
-describe('getXsuaaServiceCredentials', () => {
-  beforeEach(() => {
-    process.env.VCAP_SERVICES = JSON.stringify(services);
-  });
-
-  afterEach(() => {
-    jest.resetAllMocks();
-    delete process.env.VCAP_SERVICES;
-  });
-
-  it('throws an error if no match can be found', () => {
-    process.env.VCAP_SERVICES = JSON.stringify({
-      xsuaa: [
-        { name: 'xsuaa1', label: 'xsuaa' },
-        { name: 'xsuaa2', label: 'xsuaa' }
-      ]
+describe('xsuaa', () => {
+  describe('getXsuaaServiceCredentials()', () => {
+    beforeEach(() => {
+      process.env.VCAP_SERVICES = JSON.stringify(services);
     });
 
-    expect(() =>
-      getXsuaaServiceCredentials()
-    ).toThrowErrorMatchingInlineSnapshot(
-      '"Could not find XSUAA service binding."'
-    );
-  });
-
-  it('logs a message if multiple credentials were found', () => {
-    const logger = createLogger('environment-accessor');
-    const warnSpy = jest.spyOn(logger, 'warn');
-
-    process.env.VCAP_SERVICES = JSON.stringify({
-      xsuaa: [
-        { name: 'xsuaa1', label: 'xsuaa', credentials: { xsappname: 'app1' } },
-        { name: 'xsuaa2', label: 'xsuaa', credentials: { xsappname: 'app2' } }
-      ]
+    afterEach(() => {
+      jest.resetAllMocks();
+      delete process.env.VCAP_SERVICES;
     });
 
-    getXsuaaServiceCredentials();
-    expect(warnSpy).toHaveBeenCalledWith(
-      "Found multiple bindings for service 'xsuaa'. App names:\n\t- app1\n\t- app2\nChoosing first one ('app1')."
-    );
+    it('throws an error if no match can be found', () => {
+      process.env.VCAP_SERVICES = JSON.stringify({
+        xsuaa: [
+          { name: 'xsuaa1', label: 'xsuaa' },
+          { name: 'xsuaa2', label: 'xsuaa' }
+        ]
+      });
+
+      expect(() =>
+        getXsuaaServiceCredentials()
+      ).toThrowErrorMatchingInlineSnapshot(
+        '"Could not find XSUAA service binding."'
+      );
+    });
+
+    it('logs a message if multiple credentials were found', () => {
+      const logger = createLogger('environment-accessor');
+      const warnSpy = jest.spyOn(logger, 'warn');
+
+      process.env.VCAP_SERVICES = JSON.stringify({
+        xsuaa: [
+          {
+            name: 'xsuaa1',
+            label: 'xsuaa',
+            credentials: { xsappname: 'app1' }
+          },
+          { name: 'xsuaa2', label: 'xsuaa', credentials: { xsappname: 'app2' } }
+        ]
+      });
+
+      getXsuaaServiceCredentials();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Found multiple bindings for service 'xsuaa'. App names:\n\t- app1\n\t- app2\nChoosing first one ('app1')."
+      );
+    });
+  });
+
+  describe('getXsuaaService()', () => {
+    afterEach(() => {
+      clearXsuaaServices();
+    });
+
+    it('creates a new service instance', () => {
+      expect(
+        getXsuaaService({
+          credentials: createServiceCredentials()
+        })
+      ).toBeDefined();
+    });
+
+    it('retrieves the same service instance for the same credentials', () => {
+      expect(
+        getXsuaaService({
+          credentials: createServiceCredentials()
+        })
+      ).toBe(
+        getXsuaaService({
+          credentials: createServiceCredentials()
+        })
+      );
+    });
+
+    it('retrieves different service instances for the different credentials', () => {
+      expect(
+        getXsuaaService({
+          credentials: createServiceCredentials()
+        })
+      ).not.toBe(
+        getXsuaaService({
+          credentials: createServiceCredentials('another-clientid')
+        })
+      );
+    });
+
+    it('retrieves different service instances for the same credentials, but different caching behavior', () => {
+      expect(
+        getXsuaaService({
+          credentials: createServiceCredentials()
+        })
+      ).not.toBe(
+        getXsuaaService({
+          credentials: createServiceCredentials(),
+          disableCache: true
+        })
+      );
+    });
   });
 });
+
+function createServiceCredentials(clientid = 'clientid'): ServiceCredentials {
+  return {
+    clientid,
+    xsappname: 'xsappname',
+    uaadomain: 'uaadomain',
+    url: 'https://tenant.authentication.sap.hana.ondemand.com'
+  } as unknown as ServiceCredentials;
+}

--- a/packages/connectivity/src/scp-cf/environment-accessor/xsuaa.ts
+++ b/packages/connectivity/src/scp-cf/environment-accessor/xsuaa.ts
@@ -70,7 +70,7 @@ export function getXsuaaService(options?: {
       }
     : undefined;
 
-  const cacheKey = `${credentials.serviceInstanceId}:${disableCache}`;
+  const cacheKey = `${credentials.clientid}:${disableCache}`;
 
   if (!xsuaaServices[cacheKey]) {
     xsuaaServices[cacheKey] = new XsuaaService(credentials, serviceConfig);

--- a/packages/connectivity/src/scp-cf/xsuaa-service.ts
+++ b/packages/connectivity/src/scp-cf/xsuaa-service.ts
@@ -38,8 +38,10 @@ export async function getClientCredentialsToken(
     const xsuaaService = getXsuaaService({
       credentials: arg.serviceCredentials
     });
+
     return xsuaaService.fetchClientCredentialsToken({
-      tenant: arg.zoneId || arg.subdomain
+      // tenant is the subdomain, not tenant ID
+      tenant: arg.subdomain
     });
   };
 
@@ -86,7 +88,8 @@ export function getUserToken(
       credentials: arg.serviceCredentials
     });
     return xsuaaService.fetchJwtBearerToken({
-      tenant: arg.zoneId,
+      // tenant is the subdomain, not tenant ID
+      tenant: arg.subdomain,
       jwt: arg.userJwt
     });
   };


### PR DESCRIPTION
Fix the xsuaa service cache key to be applicable to all services. `serviceInstanceId` does not exist in the destination service credentials.
Also, our E2E tests detected, that the way we consume the token fetching functions from xssec is incorrect. `tenant` is the `subdomain` not the tenant ID as we assumed.