### PR TITLE
chore: update service credentials typing

### DIFF
--- a/.changeset/nervous-dolls-bow.md
+++ b/.changeset/nervous-dolls-bow.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Compatibility Note] Add `url` to `ServiceCredentials` type as it is a required property.

--- a/packages/connectivity/src/scp-cf/environment-accessor/environment-accessor-types.ts
+++ b/packages/connectivity/src/scp-cf/environment-accessor/environment-accessor-types.ts
@@ -26,6 +26,7 @@ export interface Service {
  */
 export type ServiceCredentials = {
   [other: string]: any;
+  url: string;
   clientid: string;
 } & (
   | {

--- a/packages/connectivity/src/scp-cf/environment-accessor/xsuaa.ts
+++ b/packages/connectivity/src/scp-cf/environment-accessor/xsuaa.ts
@@ -73,7 +73,10 @@ export function getXsuaaService(options?: {
   const cacheKey = `${credentials.clientid}:${disableCache}`;
 
   if (!xsuaaServices[cacheKey]) {
-    xsuaaServices[cacheKey] = new XsuaaService(credentials, serviceConfig);
+    xsuaaServices[cacheKey] = new XsuaaService(
+      credentials as XsuaaServiceCredentials,
+      serviceConfig
+    );
   }
   return xsuaaServices[cacheKey];
 }


### PR DESCRIPTION
xssec now comes with typings. Once they have fixed some bugs in the first version this is an issue that will still come up:
1. `ServiceCredentials` have a required property `url`.
2. We need to pass `XsuaaServiceCredentials` to the constructor of `XsuaaService`.

I checked - in this state we should be compatible, so the next dependabot PR with the fixes should automatically pass.