### PR TITLE
chore: Remove unnecessary passing of deprecated credentials option

### DIFF
--- a/packages/connectivity/src/scp-cf/connectivity-service.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.ts
@@ -71,10 +71,7 @@ export function httpProxyHostAndPort(): HostAndPort {
  */
 export async function socksProxyHostAndPort(): Promise<ProxyConfiguration> {
   const service = readConnectivityServiceBinding();
-  const connectivityServiceCredentials = service.credentials;
-  const connectivityServiceToken = await serviceToken(service, {
-    xsuaaCredentials: connectivityServiceCredentials
-  } as any);
+  const connectivityServiceToken = await serviceToken(service);
   return {
     host: service.credentials.onpremise_proxy_host,
     port: parseInt(service.credentials.onpremise_socks5_proxy_port),


### PR DESCRIPTION
I accidentally found this usage of the credentials. This has been deprecated for a while, must have slipped through the review.