### PR TITLE
chore: expose getTenantId function

### DIFF
--- a/packages/connectivity/src/index.ts
+++ b/packages/connectivity/src/index.ts
@@ -58,7 +58,8 @@ export {
   PartialDestinationFetchOptions,
   ServiceBindingTransformOptions,
   transformServiceBindingToDestination,
-  getAllDestinationsFromDestinationService
+  getAllDestinationsFromDestinationService,
+  getTenantId
 } from './scp-cf';
 
 export type {

--- a/packages/connectivity/src/scp-cf/client-credentials-token-cache.ts
+++ b/packages/connectivity/src/scp-cf/client-credentials-token-cache.ts
@@ -11,17 +11,17 @@ const ClientCredentialsTokenCache = (
   cache: Cache<ClientCredentialsResponse>
 ) => ({
   getToken: (
-    tenantId: string | undefined,
+    getTenantId: string | undefined,
     clientId: string
   ): ClientCredentialsResponse | undefined =>
-    cache.get(getCacheKey(tenantId, clientId)),
+    cache.get(getCacheKey(getTenantId, clientId)),
 
   cacheToken: (
-    tenantId: string | undefined,
+    getTenantId: string | undefined,
     clientId: string,
     token: ClientCredentialsResponse
   ): void => {
-    cache.set(getCacheKey(tenantId, clientId), {
+    cache.set(getCacheKey(getTenantId, clientId), {
       entry: token,
       expires: token.expires_in
         ? Date.now() + token.expires_in * 1000
@@ -36,15 +36,15 @@ const ClientCredentialsTokenCache = (
 
 /** *
  * @internal
- * @param tenantId - The ID of the tenant to cache the token for.
+ * @param getTenantId - The ID of the tenant to cache the token for.
  * @param clientId - ClientId to fetch the token
  * @returns the token
  */
 export function getCacheKey(
-  tenantId: string | undefined,
+  getTenantId: string | undefined,
   clientId: string
 ): string | undefined {
-  if (!tenantId) {
+  if (!getTenantId) {
     logger.warn(
       'Cannot create cache key for client credentials token cache. The given tenant ID is undefined.'
     );
@@ -56,7 +56,7 @@ export function getCacheKey(
     );
     return;
   }
-  return [tenantId, clientId].join(':');
+  return [getTenantId, clientId].join(':');
 }
 
 /**

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.ts
@@ -164,7 +164,10 @@ export function getDestinationCacheKey(
   isolationStrategy: IsolationStrategy = 'tenant-user'
 ): string | undefined {
   if (isolationStrategy === 'tenant') {
-    return getTenantCacheKey(destinationName, getTenantId(getJwtForTenant(token)));
+    return getTenantCacheKey(
+      destinationName,
+      getTenantId(getJwtForTenant(token))
+    );
   }
   if (isolationStrategy === 'tenant-user') {
     return getTenantUserCacheKey(

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.ts
@@ -1,5 +1,5 @@
 import { createLogger, first } from '@sap-cloud-sdk/util';
-import { tenantId, userId } from '../jwt';
+import { getTenantId, userId } from '../jwt';
 import { JwtPayload } from '../jsonwebtoken-type';
 import { AsyncCache, AsyncCacheInterface } from '../async-cache';
 import { Destination } from './destination-service-types';
@@ -164,12 +164,12 @@ export function getDestinationCacheKey(
   isolationStrategy: IsolationStrategy = 'tenant-user'
 ): string | undefined {
   if (isolationStrategy === 'tenant') {
-    return getTenantCacheKey(destinationName, tenantId(getJwtForTenant(token)));
+    return getTenantCacheKey(destinationName, getTenantId(getJwtForTenant(token)));
   }
   if (isolationStrategy === 'tenant-user') {
     return getTenantUserCacheKey(
       destinationName,
-      tenantId(getJwtForTenant(token)),
+      getTenantId(getJwtForTenant(token)),
       userId(getJwtForUser(token))
     );
   }

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
@@ -242,12 +242,12 @@ describe('register-destination', () => {
       const logger = createLogger('register-destination');
       jest.spyOn(logger, 'error');
 
-      const dummyTenantId = 'provider-tenant';
+      const dummygetTenantId = 'provider-tenant';
 
       await registerDestination(testDestination, { jwt: signedJwt({}) });
       const registeredDestination = await registerDestinationCache.destination
         .getCacheInstance()
-        .get(`${dummyTenantId}::${testDestination.name}`);
+        .get(`${dummygetTenantId}::${testDestination.name}`);
 
       expect(registeredDestination).toEqual(testDestination);
 
@@ -261,12 +261,12 @@ describe('register-destination', () => {
       const logger = createLogger('register-destination');
       jest.spyOn(logger, 'debug');
 
-      const dummyTenantId = 'provider-tenant';
+      const dummygetTenantId = 'provider-tenant';
 
       await registerDestination(testDestination);
       const registeredDestination = await registerDestinationCache.destination
         .getCacheInstance()
-        .get(`${dummyTenantId}::${testDestination.name}`);
+        .get(`${dummygetTenantId}::${testDestination.name}`);
 
       expect(registeredDestination).toEqual(testDestination);
 

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
@@ -21,7 +21,7 @@ const logger = createLogger({
 /**
  * @internal
  */
-const defaultTenantId = 'provider-tenant';
+const defaultgetTenantId = 'provider-tenant';
 
 /**
  * Represents options to configure how a destination should be registered.
@@ -73,7 +73,7 @@ function getJwtForCaching(options: RegisterDestinationOptions | undefined) {
         'Could not determine tenant from XSUAA, identity or destination service binding. Destination is registered without tenant information.'
       );
     }
-    return { zid: defaultTenantId };
+    return { zid: defaultgetTenantId };
   }
   return jwt;
 }

--- a/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
@@ -521,7 +521,7 @@ describe('destination service', () => {
       expect(spy).toHaveBeenCalledWith(
         [expect.any(Function), expect.any(Function)],
         {
-          context: expect.objectContaining({ tenantId: 'tenant' }),
+          context: expect.objectContaining({ getTenantId: 'tenant' }),
           fn: expect.any(Function),
           fnArgument: expect.objectContaining({ baseURL: expect.any(String) })
         }

--- a/packages/connectivity/src/scp-cf/destination/destination-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.ts
@@ -16,7 +16,7 @@ import * as asyncRetry from 'async-retry';
 import { decodeJwt, wrapJwtInHeader } from '../jwt';
 import { urlAndAgent } from '../../http-agent';
 import { buildAuthorizationHeaders } from '../authorization-header';
-import { getTenantIdWithFallback } from '../tenant';
+import { getgetTenantIdWithFallback } from '../tenant';
 import {
   DestinationConfiguration,
   DestinationJson,
@@ -80,7 +80,7 @@ export async function fetchDestinations(
   const headers = wrapJwtInHeader(serviceToken).headers;
 
   return callDestinationEndpoint(
-    { uri: targetUri, tenantId: getTenantFromTokens(serviceToken) },
+    { uri: targetUri, getTenantId: getTenantFromTokens(serviceToken) },
     headers
   )
     .then(response => {
@@ -148,7 +148,7 @@ export async function fetchDestinationWithoutTokenRetrieval(
 
   try {
     const response = await callDestinationEndpoint(
-      { uri: targetUri, tenantId: getTenantFromTokens(serviceToken) },
+      { uri: targetUri, getTenantId: getTenantFromTokens(serviceToken) },
       { Authorization: `Bearer ${serviceToken}` }
     );
     const destination = parseDestination(
@@ -211,13 +211,13 @@ export async function fetchCertificate(
 
   try {
     const response = await callCertificateEndpoint(
-      { uri: accountUri, tenantId: getTenantFromTokens(token) },
+      { uri: accountUri, getTenantId: getTenantFromTokens(token) },
       header
     ).catch(() =>
       callCertificateEndpoint(
         {
           uri: instanceUri,
-          tenantId: getTenantFromTokens(token)
+          getTenantId: getTenantFromTokens(token)
         },
         header
       )
@@ -234,12 +234,12 @@ export async function fetchCertificate(
 function getTenantFromTokens(token: AuthAndExchangeTokens | string): string {
   let tenant: string | undefined;
   if (typeof token === 'string') {
-    tenant = getTenantIdWithFallback(token);
+    tenant = getgetTenantIdWithFallback(token);
   } else {
     tenant =
       token.exchangeTenant || // represents the tenant as string already see https://api.sap.com/api/SAP_CP_CF_Connectivity_Destination/resource
-      getTenantIdWithFallback(token.exchangeHeaderJwt) ||
-      getTenantIdWithFallback(token.authHeaderJwt);
+      getgetTenantIdWithFallback(token.exchangeHeaderJwt) ||
+      getgetTenantIdWithFallback(token.authHeaderJwt);
   }
 
   if (!tenant) {
@@ -282,7 +282,7 @@ export async function fetchDestinationWithTokenRetrieval(
     : authHeader;
 
   return callDestinationEndpoint(
-    { uri: targetUri, tenantId: getTenantFromTokens(token) },
+    { uri: targetUri, getTenantId: getTenantFromTokens(token) },
     authHeader,
     options
   )

--- a/packages/connectivity/src/scp-cf/environment-accessor/environment-accessor-types.ts
+++ b/packages/connectivity/src/scp-cf/environment-accessor/environment-accessor-types.ts
@@ -44,7 +44,7 @@ export type ServiceCredentials = {
 export type DestinationServiceCredentials = ServiceCredentials & {
   identityzone: string;
   instanceid: string;
-  tenantid: string;
+  getTenantId: string;
   tenantmode: string;
   uaadomain: string;
   uri: string;
@@ -60,7 +60,7 @@ export type XsuaaServiceCredentials = ServiceCredentials & {
   identityzone: string;
   identityzoneid: string;
   sburl: string;
-  tenantid: string;
+  getTenantId: string;
   tenantmode: string;
   uaadomain: string;
   url: string;

--- a/packages/connectivity/src/scp-cf/jwt.spec.ts
+++ b/packages/connectivity/src/scp-cf/jwt.spec.ts
@@ -291,14 +291,14 @@ describe('jwt', () => {
     it("returns the XSUAA service binding's tenant ID as `zid`, if JWT is not present and binding is present", () => {
       mockServiceBindings({ xsuaaBinding: true });
       expect(decodeOrMakeJwt(undefined)).toEqual({
-        zid: xsuaaBindingMock.credentials.tenantid
+        zid: xsuaaBindingMock.credentials.getTenantId
       });
     });
 
     it("returns the destination service binding's tenant ID, if JWT, XSUAA and identity service bindings are missing", () => {
       mockServiceBindings({ xsuaaBinding: false });
       expect(decodeOrMakeJwt(undefined)).toEqual({
-        zid: destinationBindingClientSecretMock.credentials.tenantid
+        zid: destinationBindingClientSecretMock.credentials.getTenantId
       });
     });
   });

--- a/packages/connectivity/src/scp-cf/jwt.ts
+++ b/packages/connectivity/src/scp-cf/jwt.ts
@@ -32,12 +32,13 @@ export function userId({ user_id }: JwtPayload): string {
 }
 
 /**
- * @internal
  * Get the tenant ID of a decoded JWT, based on its `zid` or if not available `app_tid` property.
  * @param jwtPayload - Token payload to read the tenant ID from.
+ * @param jwtPayload.zid - The zone ID, representing the tenant in the XSUAA token.
+ * @param jwtPayload.app_tid - The app tenant ID, representing the tenant in the IAS token.
  * @returns The tenant ID, if available.
  */
-export function tenantId({ zid, app_tid }: JwtPayload): string {
+export function getTenantId({ zid, app_tid }: JwtPayload): string {
   logger.debug(`JWT zid is: ${zid}, app_tid is: ${app_tid}.`);
   return zid ?? app_tid;
 }
@@ -258,27 +259,27 @@ export function decodeOrMakeJwt(
 ): JwtPayload | undefined {
   if (jwt) {
     const decodedJwt = typeof jwt === 'string' ? decodeJwt(jwt) : jwt;
-    if (tenantId(decodedJwt)) {
+    if (getTenantId(decodedJwt)) {
       return decodedJwt;
     }
   }
 
-  const providerTenantId = getTenantIdFromBinding();
+  const providergetTenantId = getgetTenantIdFromBinding();
 
   // This is returning a JWT with an XSUAA style zid.
   // It might make sense to check whether the binding was IAS and then rather return app_tid, as it would be in a IAS token.
-  if (providerTenantId) {
-    return { zid: providerTenantId };
+  if (providergetTenantId) {
+    return { zid: providergetTenantId };
   }
 }
 /**
  * @internal
  * @returns The tenant identifier from the XSUAA, identity or destination service binding.
  */
-export function getTenantIdFromBinding(): string | undefined {
+export function getgetTenantIdFromBinding(): string | undefined {
   return (
-    getServiceCredentials('xsuaa')?.tenantid ||
+    getServiceCredentials('xsuaa')?.getTenantId ||
     getServiceCredentials('identity')?.app_tid ||
-    getServiceCredentials('destination')?.tenantid
+    getServiceCredentials('destination')?.getTenantId
   );
 }

--- a/packages/connectivity/src/scp-cf/tenant.spec.ts
+++ b/packages/connectivity/src/scp-cf/tenant.spec.ts
@@ -1,34 +1,34 @@
 import { signedJwt } from '../../../../test-resources/test/test-util';
-import { getTenantIdWithFallback } from './tenant';
+import { getgetTenantIdWithFallback } from './tenant';
 
 describe('tenant builder from JWT', () => {
-  describe('getTenantIdWithFallback', () => {
+  describe('getgetTenantIdWithFallback', () => {
     afterEach(() => {
       delete process.env['VCAP_SERVICES'];
     });
 
     it('returns the `zid` from a JWT, if present', () => {
       expect(
-        getTenantIdWithFallback({ user_id: 'user', zid: 'tenant' })
+        getgetTenantIdWithFallback({ user_id: 'user', zid: 'tenant' })
       ).toEqual('tenant');
     });
 
     it('returns subdomain of `iss` from a JWT, if present', () => {
       expect(
-        getTenantIdWithFallback({
+        getgetTenantIdWithFallback({
           user_id: 'user',
           iss: 'http://dummy-iss.com'
         })
       ).toEqual('dummy-iss');
     });
 
-    it('returns undefined for tenantid when custom JWT contains neither `zid` nor `iss`', () => {
-      expect(getTenantIdWithFallback({ user_id: 'user' })).toBeUndefined();
+    it('returns undefined for getTenantId when custom JWT contains neither `zid` nor `iss`', () => {
+      expect(getgetTenantIdWithFallback({ user_id: 'user' })).toBeUndefined();
     });
 
     it('returns the `zid` from am encoded JWT', () => {
       expect(
-        getTenantIdWithFallback(signedJwt({ user_id: 'user', zid: 'tenant' }))
+        getgetTenantIdWithFallback(signedJwt({ user_id: 'user', zid: 'tenant' }))
       ).toEqual('tenant');
     });
   });

--- a/packages/connectivity/src/scp-cf/tenant.spec.ts
+++ b/packages/connectivity/src/scp-cf/tenant.spec.ts
@@ -28,7 +28,9 @@ describe('tenant builder from JWT', () => {
 
     it('returns the `zid` from am encoded JWT', () => {
       expect(
-        getgetTenantIdWithFallback(signedJwt({ user_id: 'user', zid: 'tenant' }))
+        getgetTenantIdWithFallback(
+          signedJwt({ user_id: 'user', zid: 'tenant' })
+        )
       ).toEqual('tenant');
     });
   });

--- a/packages/connectivity/src/scp-cf/tenant.ts
+++ b/packages/connectivity/src/scp-cf/tenant.ts
@@ -1,5 +1,5 @@
 import { JwtPayload } from './jsonwebtoken-type';
-import { decodeJwt, tenantId } from './jwt';
+import { decodeJwt, getTenantId } from './jwt';
 import { getIssuerSubdomain } from './subdomain-replacer';
 
 /**
@@ -8,15 +8,15 @@ import { getIssuerSubdomain } from './subdomain-replacer';
  * @returns The tenant ID, if available.
  * @internal
  */
-export function getTenantIdWithFallback(
+export function getgetTenantIdWithFallback(
   token: string | JwtPayload | undefined
 ): string | undefined {
   const decodedJwt = token ? decodeJwt(token) : {};
-  return tenantId(decodedJwt) || getIssuerSubdomain(decodedJwt) || undefined;
+  return getTenantId(decodedJwt) || getIssuerSubdomain(decodedJwt) || undefined;
 }
 
 /**
- * Compare two decoded JWTs based on their `tenantId`s.
+ * Compare two decoded JWTs based on their `getTenantId`s.
  * @param userTokenPayload - User JWT payload.
  * @param providerTokenPayload - Provider JWT payload.
  * @returns Whether the tenant is identical.
@@ -26,5 +26,5 @@ export function isIdenticalTenant(
   userTokenPayload: JwtPayload,
   providerTokenPayload: JwtPayload
 ): boolean {
-  return tenantId(userTokenPayload) === tenantId(providerTokenPayload);
+  return getTenantId(userTokenPayload) === getTenantId(providerTokenPayload);
 }

--- a/packages/connectivity/src/scp-cf/token-accessor.spec.ts
+++ b/packages/connectivity/src/scp-cf/token-accessor.spec.ts
@@ -299,7 +299,7 @@ describe('token accessor', () => {
       const token = signedJwt({ dummy: 'content' });
 
       clientCredentialsTokenCache.cacheToken(
-        destinationBindingClientSecretMock.credentials.tenantid,
+        destinationBindingClientSecretMock.credentials.getTenantId,
         destinationBindingClientSecretMock.credentials.clientid,
         { access_token: token } as ClientCredentialsResponse
       );
@@ -328,7 +328,7 @@ describe('token accessor', () => {
 
       expect(
         clientCredentialsTokenCache.getToken(
-          destinationBindingClientSecretMock.credentials.tenantid,
+          destinationBindingClientSecretMock.credentials.getTenantId,
           destinationBindingClientSecretMock.credentials.clientid
         )
       ).toEqual(token);

--- a/packages/connectivity/src/scp-cf/token-accessor.ts
+++ b/packages/connectivity/src/scp-cf/token-accessor.ts
@@ -1,6 +1,6 @@
 import { ErrorWithCause } from '@sap-cloud-sdk/util';
 import { JwtPayload } from './jsonwebtoken-type';
-import { getTenantIdFromBinding } from './jwt';
+import { getgetTenantIdFromBinding } from './jwt';
 import { CachingOptions } from './cache';
 import { clientCredentialsTokenCache } from './client-credentials-token-cache';
 import { resolveServiceBinding } from './environment-accessor';
@@ -9,7 +9,7 @@ import {
   XsuaaServiceCredentials
 } from './environment-accessor/environment-accessor-types';
 import { getClientCredentialsToken, getUserToken } from './xsuaa-service';
-import { getTenantIdWithFallback } from './tenant';
+import { getgetTenantIdWithFallback } from './tenant';
 
 /**
  * Returns an access token that can be used to call the given service. The token is fetched via a client credentials grant with the credentials of the given service.
@@ -39,8 +39,8 @@ export async function serviceToken(
   const serviceBinding = resolveServiceBinding(service);
   const serviceCredentials = serviceBinding.credentials;
   const tenant = options?.jwt
-    ? getTenantIdWithFallback(options?.jwt)
-    : getTenantIdFromBinding();
+    ? getgetTenantIdWithFallback(options?.jwt)
+    : getgetTenantIdFromBinding();
 
   if (opts.useCache) {
     const cachedToken = clientCredentialsTokenCache.getToken(

--- a/packages/connectivity/src/scp-cf/xsuaa-service.ts
+++ b/packages/connectivity/src/scp-cf/xsuaa-service.ts
@@ -54,7 +54,8 @@ export async function getClientCredentialsToken(
     fnArgument,
     context: {
       uri: fnArgument.serviceCredentials.url,
-      getTenantId: fnArgument.zoneId ?? fnArgument.serviceCredentials.getTenantId
+      getTenantId:
+        fnArgument.zoneId ?? fnArgument.serviceCredentials.getTenantId
     }
   }).catch(err => {
     throw new Error(

--- a/packages/connectivity/src/scp-cf/xsuaa-service.ts
+++ b/packages/connectivity/src/scp-cf/xsuaa-service.ts
@@ -8,7 +8,7 @@ import {
 import { ClientCredentialsResponse } from './xsuaa-service-types';
 import { getXsuaaService, resolveServiceBinding } from './environment-accessor';
 import { getIssuerSubdomain } from './subdomain-replacer';
-import { decodeJwt, tenantId } from './jwt';
+import { decodeJwt, getTenantId } from './jwt';
 
 interface XsuaaParameters {
   subdomain: string | null;
@@ -30,7 +30,7 @@ export async function getClientCredentialsToken(
   const jwt = userJwt ? decodeJwt(userJwt) : {};
   const fnArgument: XsuaaParameters = {
     subdomain: getIssuerSubdomain(jwt) || null,
-    zoneId: tenantId(jwt) || null,
+    zoneId: getTenantId(jwt) || null,
     serviceCredentials: resolveServiceBinding(service).credentials
   };
 
@@ -54,7 +54,7 @@ export async function getClientCredentialsToken(
     fnArgument,
     context: {
       uri: fnArgument.serviceCredentials.url,
-      tenantId: fnArgument.zoneId ?? fnArgument.serviceCredentials.tenantid
+      getTenantId: fnArgument.zoneId ?? fnArgument.serviceCredentials.getTenantId
     }
   }).catch(err => {
     throw new Error(
@@ -78,7 +78,7 @@ export function getUserToken(
   const jwt = decodeJwt(userJwt);
   const fnArgument: XsuaaParameters = {
     subdomain: getIssuerSubdomain(jwt) || null,
-    zoneId: tenantId(jwt) || null,
+    zoneId: getTenantId(jwt) || null,
     serviceCredentials: service.credentials,
     userJwt
   };
@@ -104,7 +104,7 @@ export function getUserToken(
     fnArgument,
     context: {
       uri: service.credentials.url,
-      tenantId: fnArgument.zoneId ?? service.credentials.tenantid
+      getTenantId: fnArgument.zoneId ?? service.credentials.getTenantId
     }
   }).catch(err => {
     throw new Error(

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -307,7 +307,7 @@ describe('generic http client', () => {
       expect(response.data).toEqual({
         destinationName: 'FINAL-DESTINATION',
         jwt: subscriberUserToken,
-        tenantId: 'subscriber',
+        getTenantId: 'subscriber',
         uri: 'https://my.system.example.com'
       });
     });

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -12,7 +12,7 @@ import {
   getAdditionalHeaders,
   getAdditionalQueryParameters,
   getProxyConfig,
-  getTenantIdWithFallback,
+  getgetTenantIdWithFallback,
   HttpDestination,
   resolveDestination
 } from '@sap-cloud-sdk/connectivity/internal';
@@ -108,7 +108,7 @@ export function execute(executeFn: ExecuteHttpRequestFn<HttpResponse>) {
         jwt: destination.jwt,
         uri: resolvedDestination.url,
         destinationName: resolvedDestination.name ?? undefined,
-        tenantId: getTenantIdWithFallback(destination.jwt)
+        getTenantId: getgetTenantIdWithFallback(destination.jwt)
       }
     });
   };

--- a/packages/resilience/src/circuit-breaker.spec.ts
+++ b/packages/resilience/src/circuit-breaker.spec.ts
@@ -26,7 +26,7 @@ describe('circuit-breaker', () => {
     };
     const context: MiddlewareContext<RawAxiosRequestConfig> = {
       uri: host,
-      tenantId: 'myTestTenant'
+      getTenantId: 'myTestTenant'
     };
     const keepCalling = true;
     while (keepCalling) {
@@ -78,7 +78,7 @@ describe('circuit-breaker', () => {
     };
     const context: MiddlewareContext<RawAxiosRequestConfig> = {
       uri: host,
-      tenantId: 'myTestTenant'
+      getTenantId: 'myTestTenant'
     };
 
     let keepCalling = !mock.isDone();
@@ -110,7 +110,7 @@ describe('circuit-breaker', () => {
     };
     const context: MiddlewareContext<RawAxiosRequestConfig> = {
       uri: host,
-      tenantId: 'tenant1'
+      getTenantId: 'tenant1'
     };
 
     await executeWithMiddleware<
@@ -127,7 +127,7 @@ describe('circuit-breaker', () => {
       AxiosResponse,
       MiddlewareContext<RawAxiosRequestConfig>
     >([circuitBreaker()], {
-      context: { ...context, tenantId: 'tenant2' },
+      context: { ...context, getTenantId: 'tenant2' },
       fn: request,
       fnArgument: requestConfig
     });
@@ -160,7 +160,7 @@ describe('circuit-breaker', () => {
     ) => MiddlewareContext<RawAxiosRequestConfig> = requestConfig => ({
       fnArgument: requestConfig,
       uri: host,
-      tenantId: 'tenant1'
+      getTenantId: 'tenant1'
     });
 
     await executeWithMiddleware<
@@ -203,7 +203,7 @@ describe('circuit-breaker', () => {
     };
     const context: MiddlewareContext<RawAxiosRequestConfig> = {
       uri: host,
-      tenantId: 'myTestTenant'
+      getTenantId: 'myTestTenant'
     };
 
     let keepCalling = !mock.isDone();

--- a/packages/resilience/src/circuit-breaker.ts
+++ b/packages/resilience/src/circuit-breaker.ts
@@ -38,8 +38,8 @@ function httpErrorFilter(error: AxiosError): boolean {
 function circuitBreakerKeyBuilder<
   ArgumentT,
   ContextT extends MiddlewareContext<ArgumentT>
->({ uri, tenantId = 'tenant_id' }: ContextT): string {
-  return `${uri}::${tenantId}`;
+>({ uri, getTenantId = 'tenant_id' }: ContextT): string {
+  return `${uri}::${getTenantId}`;
 }
 
 /**

--- a/packages/resilience/src/middleware.spec.ts
+++ b/packages/resilience/src/middleware.spec.ts
@@ -7,7 +7,7 @@ import {
 
 describe('middleware', () => {
   const logger = createLogger('middleware');
-  const context = { uri: 'dummyUri', tenantId: 'dummyTenant' };
+  const context = { uri: 'dummyUri', getTenantId: 'dummyTenant' };
 
   const beforeMiddlewareBuilder = appendString =>
     function (

--- a/packages/resilience/src/middleware.ts
+++ b/packages/resilience/src/middleware.ts
@@ -28,7 +28,7 @@ export interface MiddlewareContext<ArgumentT> {
   /**
    * Tenant identifier.
    */
-  readonly tenantId: string | undefined;
+  readonly getTenantId: string | undefined;
 }
 
 /**

--- a/packages/resilience/src/resilience.spec.ts
+++ b/packages/resilience/src/resilience.spec.ts
@@ -42,7 +42,7 @@ describe('combined resilience features', () => {
       executeWithMiddleware([retry(2), timeout(600)], {
         context: {
           uri: 'https://example.com',
-          tenantId: 'dummy-tenant'
+          getTenantId: 'dummy-tenant'
         },
         fnArgument: requestConfig,
         fn: request
@@ -68,7 +68,7 @@ describe('combined resilience features', () => {
     const response = await executeWithMiddleware([retry(2), timeout(200)], {
       context: {
         uri: 'https://example.com',
-        tenantId: 'dummy-tenant'
+        getTenantId: 'dummy-tenant'
       },
       fnArgument: config,
       fn: request
@@ -92,7 +92,7 @@ describe('combined resilience features', () => {
     };
     const context: MiddlewareContext<RawAxiosRequestConfig> = {
       uri: host,
-      tenantId: 'myTestTenant'
+      getTenantId: 'myTestTenant'
     };
 
     const keepCalling = true;
@@ -144,7 +144,7 @@ describe('combined resilience features', () => {
     };
     const context: MiddlewareContext<RawAxiosRequestConfig> = {
       uri: host,
-      tenantId: 'myTestTenant'
+      getTenantId: 'myTestTenant'
     };
     await expect(
       executeWithMiddleware<
@@ -177,7 +177,7 @@ describe('combined resilience features', () => {
     };
     const context: MiddlewareContext<RawAxiosRequestConfig> = {
       uri: host,
-      tenantId: 'myTestTenant'
+      getTenantId: 'myTestTenant'
     };
     await expect(
       executeWithMiddleware<

--- a/packages/resilience/src/retry.spec.ts
+++ b/packages/resilience/src/retry.spec.ts
@@ -30,7 +30,7 @@ describe('retry', () => {
       executeWithMiddleware([retry(0)], {
         context: {
           uri: 'https://example.com',
-          tenantId: 'dummy-tenant'
+          getTenantId: 'dummy-tenant'
         },
         fnArgument: requestConfig,
         fn: request
@@ -53,7 +53,7 @@ describe('retry', () => {
 
     await expect(
       executeWithMiddleware([retry(1)], {
-        context: { uri: 'https://example.com', tenantId: 'dummy-tenant' },
+        context: { uri: 'https://example.com', getTenantId: 'dummy-tenant' },
         fnArgument: requestConfig,
         fn: request
       })
@@ -77,7 +77,7 @@ describe('retry', () => {
 
     await expect(
       executeWithMiddleware([retry(2)], {
-        context: { uri: 'https://example.com', tenantId: 'dummy-tenant' },
+        context: { uri: 'https://example.com', getTenantId: 'dummy-tenant' },
         fnArgument: requestConfig,
         fn: request
       })
@@ -101,7 +101,7 @@ describe('retry', () => {
       executeWithMiddleware([retry(7)], {
         context: {
           uri: 'https://example.com',
-          tenantId: 'dummy-tenant'
+          getTenantId: 'dummy-tenant'
         },
         fn: request,
         fnArgument: requestConfig
@@ -128,7 +128,7 @@ describe('retry', () => {
       executeWithMiddleware([retry(7)], {
         context: {
           uri: 'https://example.com',
-          tenantId: 'dummy-tenant'
+          getTenantId: 'dummy-tenant'
         },
         fn: request,
         fnArgument: requestConfig
@@ -153,7 +153,7 @@ describe('retry', () => {
 
     await expect(
       executeWithMiddleware([retry(1)], {
-        context: { uri: 'https://example.com', tenantId: 'dummy-tenant' },
+        context: { uri: 'https://example.com', getTenantId: 'dummy-tenant' },
         fnArgument: requestConfig,
         fn: request
       })

--- a/packages/resilience/src/timeout.spec.ts
+++ b/packages/resilience/src/timeout.spec.ts
@@ -25,7 +25,7 @@ describe('timeout', () => {
       executeWithMiddleware([timeout(delayInResponse * 0.5)], {
         context: {
           uri: 'https://example.com',
-          tenantId: 'dummy-tenant'
+          getTenantId: 'dummy-tenant'
         },
         fnArgument: requestConfig,
         fn: request
@@ -40,7 +40,7 @@ describe('timeout', () => {
         {
           context: {
             uri: 'https://example.com',
-            tenantId: 'dummy-tenant'
+            getTenantId: 'dummy-tenant'
           },
           fnArgument: requestConfig,
           fn: request
@@ -69,7 +69,7 @@ describe('timeout', () => {
     const response = await executeWithMiddleware([timeout()], {
       context: {
         uri: 'https://example.com',
-        tenantId: 'dummy-tenant'
+        getTenantId: 'dummy-tenant'
       },
       fnArgument: requestConfig,
       fn: request
@@ -81,7 +81,7 @@ describe('timeout', () => {
       executeWithMiddleware([timeout()], {
         context: {
           uri: 'https://example.com',
-          tenantId: 'dummy-tenant',
+          getTenantId: 'dummy-tenant',
           fnArgument: requestConfig
         },
         fnArgument: requestConfig,

--- a/test-resources/test/test-util/environment-mocks.ts
+++ b/test-resources/test/test-util/environment-mocks.ts
@@ -32,7 +32,7 @@ export const xsuaaBindingMock: Service = {
     verificationkey: publicKey,
     uaadomain: uaaDomain,
     subaccountid: 'a89ea924-d9c2-4eab-84fb-3ffcaadf5d24',
-    tenantid: 'a89ea924-d9c2-4eab-84fb-3ffcaadf5d24',
+    getTenantId: 'a89ea924-d9c2-4eab-84fb-3ffcaadf5d24',
     zoneid: 'a89ea924-d9c2-4eab-84fb-3ffcaadf5d24',
     serviceInstanceId: '7f58b7bc-c4e3-4f58-8bc6-fb473942817f'
   }
@@ -50,7 +50,7 @@ export const destinationBindingClientSecretMock: Service = {
     url: providerXsuaaUrl,
     uaadomain: uaaDomain,
     xsappname: 'myapp',
-    tenantid: 'app-tenant-id'
+    getTenantId: 'app-tenant-id'
   }
 };
 


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

With this PR, we are renaming `tenantId` to `getTenantId` and are exposing it to users, so that they have additional convenience, especially when setting tenant headers, which is a requirement for multi-tenant applications running against on-premise transparent proxy destinations.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
