### PR TITLE
chore: expose getTenantId function

### DIFF
--- a/.changeset/quick-points-return.md
+++ b/.changeset/quick-points-return.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[New Functionality] Added getTenantId function for convenience.

--- a/.changeset/quick-points-return.md
+++ b/.changeset/quick-points-return.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/connectivity': minor
 ---
 
-[New Functionality] Added getTenantId function for convenience.
+[New Functionality] Add `getTenantId()` function for convenience.

--- a/packages/connectivity/src/index.ts
+++ b/packages/connectivity/src/index.ts
@@ -58,7 +58,8 @@ export {
   PartialDestinationFetchOptions,
   ServiceBindingTransformOptions,
   transformServiceBindingToDestination,
-  getAllDestinationsFromDestinationService
+  getAllDestinationsFromDestinationService,
+  getTenantId
 } from './scp-cf';
 
 export type {

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.ts
@@ -1,5 +1,5 @@
 import { createLogger, first } from '@sap-cloud-sdk/util';
-import { tenantId, userId } from '../jwt';
+import { userId } from '../jwt';
 import { JwtPayload } from '../jsonwebtoken-type';
 import { AsyncCache, AsyncCacheInterface } from '../async-cache';
 import { Destination } from './destination-service-types';
@@ -164,7 +164,10 @@ export function getDestinationCacheKey(
   isolationStrategy: IsolationStrategy = 'tenant-user'
 ): string | undefined {
   if (isolationStrategy === 'tenant') {
-    return getTenantCacheKey(destinationName, getTenantId(getJwtForTenant(token)));
+    return getTenantCacheKey(
+      destinationName,
+      getTenantId(getJwtForTenant(token))
+    );
   }
   if (isolationStrategy === 'tenant-user') {
     return getTenantUserCacheKey(

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.ts
@@ -164,12 +164,12 @@ export function getDestinationCacheKey(
   isolationStrategy: IsolationStrategy = 'tenant-user'
 ): string | undefined {
   if (isolationStrategy === 'tenant') {
-    return getTenantCacheKey(destinationName, tenantId(getJwtForTenant(token)));
+    return getTenantCacheKey(destinationName, getTenantId(getJwtForTenant(token)));
   }
   if (isolationStrategy === 'tenant-user') {
     return getTenantUserCacheKey(
       destinationName,
-      tenantId(getJwtForTenant(token)),
+      getTenantId(getJwtForTenant(token)),
       userId(getJwtForUser(token))
     );
   }

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.ts
@@ -1,5 +1,5 @@
 import { createLogger, first } from '@sap-cloud-sdk/util';
-import { userId } from '../jwt';
+import { getTenantId, userId } from '../jwt';
 import { JwtPayload } from '../jsonwebtoken-type';
 import { AsyncCache, AsyncCacheInterface } from '../async-cache';
 import { Destination } from './destination-service-types';

--- a/packages/connectivity/src/scp-cf/jwt.ts
+++ b/packages/connectivity/src/scp-cf/jwt.ts
@@ -38,7 +38,7 @@ export function userId({ user_id }: JwtPayload): string {
  * @param jwtPayload.app_tid - The app tenant ID, representing the tenant in the IAS token.
  * @returns The tenant ID, if available.
  */
-export function getgetTenantId({ zid, app_tid }: JwtPayload): string {
+export function getTenantId({ zid, app_tid }: JwtPayload): string {
   logger.debug(`JWT zid is: ${zid}, app_tid is: ${app_tid}.`);
   return zid ?? app_tid;
 }

--- a/packages/connectivity/src/scp-cf/jwt.ts
+++ b/packages/connectivity/src/scp-cf/jwt.ts
@@ -31,17 +31,17 @@ export function userId({ user_id }: JwtPayload): string {
   return user_id;
 }
 
+/* eslint-disable jsdoc/check-param-names, jsdoc/require-param */
 /**
  * Get the tenant ID of a decoded JWT, based on its `zid` or if not available `app_tid` property.
  * @param jwtPayload - Token payload to read the tenant ID from.
- * @param jwtPayload.zid - The zone ID, representing the tenant in the XSUAA token.
- * @param jwtPayload.app_tid - The app tenant ID, representing the tenant in the IAS token.
  * @returns The tenant ID, if available.
  */
 export function getTenantId({ zid, app_tid }: JwtPayload): string {
   logger.debug(`JWT zid is: ${zid}, app_tid is: ${app_tid}.`);
   return zid ?? app_tid;
 }
+/* eslint-enable jsdoc/check-param-names, jsdoc/require-param */
 
 /**
  * @internal

--- a/packages/connectivity/src/scp-cf/jwt.ts
+++ b/packages/connectivity/src/scp-cf/jwt.ts
@@ -32,12 +32,13 @@ export function userId({ user_id }: JwtPayload): string {
 }
 
 /**
- * @internal
  * Get the tenant ID of a decoded JWT, based on its `zid` or if not available `app_tid` property.
  * @param jwtPayload - Token payload to read the tenant ID from.
+ * @param jwtPayload.zid - The zone ID, representing the tenant in the XSUAA token.
+ * @param jwtPayload.app_tid - The app tenant ID, representing the tenant in the IAS token.
  * @returns The tenant ID, if available.
  */
-export function tenantId({ zid, app_tid }: JwtPayload): string {
+export function getgetTenantId({ zid, app_tid }: JwtPayload): string {
   logger.debug(`JWT zid is: ${zid}, app_tid is: ${app_tid}.`);
   return zid ?? app_tid;
 }
@@ -258,7 +259,7 @@ export function decodeOrMakeJwt(
 ): JwtPayload | undefined {
   if (jwt) {
     const decodedJwt = typeof jwt === 'string' ? decodeJwt(jwt) : jwt;
-    if (tenantId(decodedJwt)) {
+    if (getTenantId(decodedJwt)) {
       return decodedJwt;
     }
   }

--- a/packages/connectivity/src/scp-cf/tenant.ts
+++ b/packages/connectivity/src/scp-cf/tenant.ts
@@ -1,5 +1,6 @@
+import { getTenantId } from '..';
 import { JwtPayload } from './jsonwebtoken-type';
-import { decodeJwt, tenantId } from './jwt';
+import { decodeJwt } from './jwt';
 import { getIssuerSubdomain } from './subdomain-replacer';
 
 /**
@@ -12,7 +13,7 @@ export function getTenantIdWithFallback(
   token: string | JwtPayload | undefined
 ): string | undefined {
   const decodedJwt = token ? decodeJwt(token) : {};
-  return tenantId(decodedJwt) || getIssuerSubdomain(decodedJwt) || undefined;
+  return getTenantId(decodedJwt) || getIssuerSubdomain(decodedJwt) || undefined;
 }
 
 /**
@@ -26,5 +27,5 @@ export function isIdenticalTenant(
   userTokenPayload: JwtPayload,
   providerTokenPayload: JwtPayload
 ): boolean {
-  return tenantId(userTokenPayload) === tenantId(providerTokenPayload);
+  return getTenantId(userTokenPayload) === getTenantId(providerTokenPayload);
 }

--- a/packages/connectivity/src/scp-cf/tenant.ts
+++ b/packages/connectivity/src/scp-cf/tenant.ts
@@ -1,6 +1,5 @@
-import { getTenantId } from '..';
 import { JwtPayload } from './jsonwebtoken-type';
-import { decodeJwt } from './jwt';
+import { decodeJwt, getTenantId } from './jwt';
 import { getIssuerSubdomain } from './subdomain-replacer';
 
 /**

--- a/packages/connectivity/src/scp-cf/xsuaa-service.ts
+++ b/packages/connectivity/src/scp-cf/xsuaa-service.ts
@@ -8,7 +8,7 @@ import {
 import { ClientCredentialsResponse } from './xsuaa-service-types';
 import { getXsuaaService, resolveServiceBinding } from './environment-accessor';
 import { getIssuerSubdomain } from './subdomain-replacer';
-import { decodeJwt } from './jwt';
+import { decodeJwt, getTenantId } from './jwt';
 
 interface XsuaaParameters {
   subdomain: string | null;

--- a/packages/connectivity/src/scp-cf/xsuaa-service.ts
+++ b/packages/connectivity/src/scp-cf/xsuaa-service.ts
@@ -8,7 +8,7 @@ import {
 import { ClientCredentialsResponse } from './xsuaa-service-types';
 import { getXsuaaService, resolveServiceBinding } from './environment-accessor';
 import { getIssuerSubdomain } from './subdomain-replacer';
-import { decodeJwt, tenantId } from './jwt';
+import { decodeJwt } from './jwt';
 
 interface XsuaaParameters {
   subdomain: string | null;
@@ -30,7 +30,7 @@ export async function getClientCredentialsToken(
   const jwt = userJwt ? decodeJwt(userJwt) : {};
   const fnArgument: XsuaaParameters = {
     subdomain: getIssuerSubdomain(jwt) || null,
-    zoneId: tenantId(jwt) || null,
+    zoneId: getTenantId(jwt) || null,
     serviceCredentials: resolveServiceBinding(service).credentials
   };
 
@@ -78,7 +78,7 @@ export function getUserToken(
   const jwt = decodeJwt(userJwt);
   const fnArgument: XsuaaParameters = {
     subdomain: getIssuerSubdomain(jwt) || null,
-    zoneId: tenantId(jwt) || null,
+    zoneId: getTenantId(jwt) || null,
     serviceCredentials: service.credentials,
     userJwt
   };


### PR DESCRIPTION
With this PR, we are renaming tenantId to getTenantId and are exposing it to users, so that they have additional convenience, especially when setting tenant headers, which is a requirement for multi-tenant applications running against on-premise transparent proxy destinations.