### PR TITLE
feat: Add mutli-tenancy support for on-premise mail destinations

### DIFF
--- a/.changeset/long-rivers-wait.md
+++ b/.changeset/long-rivers-wait.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/mail-client': minor
+---
+
+[New Funcionality] Add support for multi-tenancy for on-premise mail destinations.

--- a/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
@@ -6,7 +6,9 @@ import {
 } from '../../../../test-resources/test/test-util/environment-mocks';
 import {
   providerServiceToken,
-  providerUserToken
+  providerUserToken,
+  subscriberServiceToken,
+  subscriberUserToken
 } from '../../../../test-resources/test/test-util/mocked-access-tokens';
 import { mockServiceToken } from '../../../../test-resources/test/test-util/token-accessor-mocks';
 import { mockClientCredentialsGrantCall } from '../../../../test-resources/test/test-util/xsuaa-service-mocks';
@@ -169,6 +171,34 @@ describe('connectivity-service', () => {
       };
 
       const withProxy = await addProxyConfigurationOnPrem(input);
+      expect(withProxy).toEqual(expected);
+    });
+
+    it('adds a proxy configuration containing a subscriberServiceToken', async () => {
+      mockServiceBindings();
+      mockServiceToken();
+
+      const input: Destination = {
+        url: 'https://example.com',
+        proxyType: 'OnPremise',
+        type: 'MAIL'
+      };
+
+      const expected: Destination = {
+        url: 'https://example.com',
+        proxyType: 'OnPremise',
+        type: 'MAIL',
+        proxyConfiguration: {
+          ...connectivitySocksProxyConfigMock,
+          'proxy-authorization': subscriberServiceToken
+        }
+      };
+
+      const requiredSubscriberToken = getRequiredSubscriberToken({
+        userJwt: getJwtPair(subscriberUserToken)
+      });
+
+      const withProxy = await addProxyConfigurationOnPrem(input,  requiredSubscriberToken);
       expect(withProxy).toEqual(expected);
     });
   });

--- a/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
@@ -198,7 +198,10 @@ describe('connectivity-service', () => {
         userJwt: getJwtPair(subscriberUserToken)
       });
 
-      const withProxy = await addProxyConfigurationOnPrem(input,  requiredSubscriberToken);
+      const withProxy = await addProxyConfigurationOnPrem(
+        input,
+        requiredSubscriberToken
+      );
       expect(withProxy).toEqual(expected);
     });
   });

--- a/packages/connectivity/src/scp-cf/connectivity-service.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.ts
@@ -69,7 +69,9 @@ export function httpProxyHostAndPort(): HostAndPort {
  * @internal
  * @returns Socks Proxy Configuration
  */
-export async function socksProxyHostAndPort(jwt?: Required<SubscriberToken>): Promise<ProxyConfiguration> {
+export async function socksProxyHostAndPort(
+  jwt?: Required<SubscriberToken>
+): Promise<ProxyConfiguration> {
   const service = readConnectivityServiceBinding();
   const connectivityServiceToken = await serviceToken(service, { jwt });
   return {

--- a/packages/connectivity/src/scp-cf/connectivity-service.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.ts
@@ -31,7 +31,7 @@ export async function addProxyConfigurationOnPrem(
   if (destination.type === 'MAIL') {
     return {
       ...destination,
-      proxyConfiguration: await socksProxyHostAndPort()
+      proxyConfiguration: await socksProxyHostAndPort(subscriberToken)
     };
   }
 
@@ -69,9 +69,9 @@ export function httpProxyHostAndPort(): HostAndPort {
  * @internal
  * @returns Socks Proxy Configuration
  */
-export async function socksProxyHostAndPort(): Promise<ProxyConfiguration> {
+export async function socksProxyHostAndPort(jwt?: Required<SubscriberToken>): Promise<ProxyConfiguration> {
   const service = readConnectivityServiceBinding();
-  const connectivityServiceToken = await serviceToken(service);
+  const connectivityServiceToken = await serviceToken(service, { jwt });
   return {
     host: service.credentials.onpremise_proxy_host,
     port: parseInt(service.credentials.onpremise_socks5_proxy_port),


### PR DESCRIPTION
With this PR, we add multi-tenancy support for on-premise mail destinations, by fetching tenant-aware connectivity service tokens.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
