### PR TITLE
chore: Adjust client generated comments to follow eslint rules

### DIFF
--- a/packages/eslint-config/flat-config.js
+++ b/packages/eslint-config/flat-config.js
@@ -3,14 +3,12 @@ const jsdoc = require('eslint-plugin-jsdoc');
 const regex = require('eslint-plugin-regex');
 const unusedImports = require('eslint-plugin-unused-imports');
 const importeslint = require('eslint-plugin-import');
-const prettierRecommended = require('eslint-plugin-prettier/recommended');
 const tseslint = require('typescript-eslint');
 const eslint = require('@eslint/js');
 
 const flatConfig = [
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
-  prettierRecommended,
   {
     linterOptions: {
       reportUnusedDisableDirectives: 'warn'

--- a/packages/generator/src/batch/function.ts
+++ b/packages/generator/src/batch/function.ts
@@ -23,7 +23,7 @@ export function batchFunction(
             {
               name: 'requests',
               type: 'MethodRequestBuilderBase<ODataRequestConfig>[]',
-              description: 'The requests of the batch'
+              description: 'The requests of the batch.'
             }
           ],
           returns: {
@@ -82,7 +82,7 @@ export function changesetFunction(
             {
               name: 'requests',
               type: `Write${service.className}RequestBuilder[]`,
-              description: 'The requests of the change set'
+              description: 'The requests of the change set.'
             }
           ],
           returns: {

--- a/packages/generator/src/entity/class.ts
+++ b/packages/generator/src/entity/class.ts
@@ -94,7 +94,7 @@ function keys(entity: VdmEntity): PropertyDeclarationStructure {
       .map(key => `'${key.originalName}'`)
       .join(',')}]`,
     docs: [
-      addLeadingNewline(`All key fields of the ${entity.className} entity`)
+      addLeadingNewline(`All key fields of the ${entity.className} entity.`)
     ]
   };
 }

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airlines.d.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airlines.d.ts
@@ -26,7 +26,7 @@ export declare class Airlines<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the Airlines entity
+   * All key fields of the Airlines entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airlines.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airlines.js
@@ -25,7 +25,7 @@ Airlines._entityName = 'Airlines';
  */
 Airlines._defaultBasePath = 'V4/(S(duh2c3dgb1c5lzc0bqwgyekc))/TripPinServiceRW/';
 /**
- * All key fields of the Airlines entity
+ * All key fields of the Airlines entity.
  */
 Airlines._keys = ['AirlineCode'];
 //# sourceMappingURL=Airlines.js.map

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airlines.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airlines.ts
@@ -28,7 +28,7 @@ export class Airlines<T extends DeSerializers = DefaultDeSerializers>
   static override _defaultBasePath =
     'V4/(S(duh2c3dgb1c5lzc0bqwgyekc))/TripPinServiceRW/';
   /**
-   * All key fields of the Airlines entity
+   * All key fields of the Airlines entity.
    */
   static _keys = ['AirlineCode'];
   /**

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airports.d.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airports.d.ts
@@ -27,7 +27,7 @@ export declare class Airports<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the Airports entity
+   * All key fields of the Airports entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airports.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airports.js
@@ -25,7 +25,7 @@ Airports._entityName = 'Airports';
  */
 Airports._defaultBasePath = 'V4/(S(duh2c3dgb1c5lzc0bqwgyekc))/TripPinServiceRW/';
 /**
- * All key fields of the Airports entity
+ * All key fields of the Airports entity.
  */
 Airports._keys = ['IcaoCode'];
 //# sourceMappingURL=Airports.js.map

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airports.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Airports.ts
@@ -29,7 +29,7 @@ export class Airports<T extends DeSerializers = DefaultDeSerializers>
   static override _defaultBasePath =
     'V4/(S(duh2c3dgb1c5lzc0bqwgyekc))/TripPinServiceRW/';
   /**
-   * All key fields of the Airports entity
+   * All key fields of the Airports entity.
    */
   static _keys = ['IcaoCode'];
   /**

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/BatchRequest.d.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/BatchRequest.d.ts
@@ -24,7 +24,7 @@ import {
 } from './index';
 /**
  * Batch builder for operations supported on the Microsoft O Data Service Sample Trippin In Memory Models Service.
- * @param requests The requests of the batch
+ * @param requests The requests of the batch.
  * @returns A request builder for batch.
  */
 export declare function batch<DeSerializersT extends DeSerializers>(
@@ -41,7 +41,7 @@ export declare function batch<DeSerializersT extends DeSerializers>(
 ): ODataBatchRequestBuilder<DeSerializersT>;
 /**
  * Change set constructor consists of write operations supported on the Microsoft O Data Service Sample Trippin In Memory Models Service.
- * @param requests The requests of the change set
+ * @param requests The requests of the change set.
  * @returns A change set for batch.
  */
 export declare function changeset<DeSerializersT extends DeSerializers>(

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/BatchRequest.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/BatchRequest.ts
@@ -26,7 +26,7 @@ import {
 
 /**
  * Batch builder for operations supported on the Microsoft O Data Service Sample Trippin In Memory Models Service.
- * @param requests The requests of the batch
+ * @param requests The requests of the batch.
  * @returns A request builder for batch.
  */
 export function batch<DeSerializersT extends DeSerializers>(
@@ -63,7 +63,7 @@ export function batch<DeSerializersT extends DeSerializers>(
 
 /**
  * Change set constructor consists of write operations supported on the Microsoft O Data Service Sample Trippin In Memory Models Service.
- * @param requests The requests of the change set
+ * @param requests The requests of the change set.
  * @returns A change set for batch.
  */
 export function changeset<DeSerializersT extends DeSerializers>(

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/People.d.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/People.d.ts
@@ -29,7 +29,7 @@ export declare class People<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the People entity
+   * All key fields of the People entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/People.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/People.js
@@ -25,7 +25,7 @@ People._entityName = 'People';
  */
 People._defaultBasePath = 'V4/(S(duh2c3dgb1c5lzc0bqwgyekc))/TripPinServiceRW/';
 /**
- * All key fields of the People entity
+ * All key fields of the People entity.
  */
 People._keys = ['UserName'];
 //# sourceMappingURL=People.js.map

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/People.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/People.ts
@@ -31,7 +31,7 @@ export class People<T extends DeSerializers = DefaultDeSerializers>
   static override _defaultBasePath =
     'V4/(S(duh2c3dgb1c5lzc0bqwgyekc))/TripPinServiceRW/';
   /**
-   * All key fields of the People entity
+   * All key fields of the People entity.
    */
   static _keys = ['UserName'];
   /**

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Photos.d.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Photos.d.ts
@@ -26,7 +26,7 @@ export declare class Photos<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the Photos entity
+   * All key fields of the Photos entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Photos.js
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Photos.js
@@ -25,7 +25,7 @@ Photos._entityName = 'Photos';
  */
 Photos._defaultBasePath = 'V4/(S(duh2c3dgb1c5lzc0bqwgyekc))/TripPinServiceRW/';
 /**
- * All key fields of the Photos entity
+ * All key fields of the Photos entity.
  */
 Photos._keys = ['Id'];
 //# sourceMappingURL=Photos.js.map

--- a/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Photos.ts
+++ b/test-packages/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/Photos.ts
@@ -28,7 +28,7 @@ export class Photos<T extends DeSerializers = DefaultDeSerializers>
   static override _defaultBasePath =
     'V4/(S(duh2c3dgb1c5lzc0bqwgyekc))/TripPinServiceRW/';
   /**
-   * All key fields of the Photos entity
+   * All key fields of the Photos entity.
    */
   static _keys = ['Id'];
   /**

--- a/test-packages/test-services-e2e/v4/test-service/BatchRequest.d.ts
+++ b/test-packages/test-services-e2e/v4/test-service/BatchRequest.d.ts
@@ -31,7 +31,7 @@ import {
 } from './index';
 /**
  * Batch builder for operations supported on the Test Service.
- * @param requests The requests of the batch
+ * @param requests The requests of the batch.
  * @returns A request builder for batch.
  */
 export declare function batch<DeSerializersT extends DeSerializers>(
@@ -48,7 +48,7 @@ export declare function batch<DeSerializersT extends DeSerializers>(
 ): ODataBatchRequestBuilder<DeSerializersT>;
 /**
  * Change set constructor consists of write operations supported on the Test Service.
- * @param requests The requests of the change set
+ * @param requests The requests of the change set.
  * @returns A change set for batch.
  */
 export declare function changeset<DeSerializersT extends DeSerializers>(

--- a/test-packages/test-services-e2e/v4/test-service/BatchRequest.ts
+++ b/test-packages/test-services-e2e/v4/test-service/BatchRequest.ts
@@ -33,7 +33,7 @@ import {
 
 /**
  * Batch builder for operations supported on the Test Service.
- * @param requests The requests of the batch
+ * @param requests The requests of the batch.
  * @returns A request builder for batch.
  */
 export function batch<DeSerializersT extends DeSerializers>(
@@ -70,7 +70,7 @@ export function batch<DeSerializersT extends DeSerializers>(
 
 /**
  * Change set constructor consists of write operations supported on the Test Service.
- * @param requests The requests of the change set
+ * @param requests The requests of the change set.
  * @returns A change set for batch.
  */
 export function changeset<DeSerializersT extends DeSerializers>(

--- a/test-packages/test-services-e2e/v4/test-service/TestEntity.d.ts
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntity.d.ts
@@ -29,7 +29,7 @@ export declare class TestEntity<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntity entity
+   * All key fields of the TestEntity entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-e2e/v4/test-service/TestEntity.js
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntity.js
@@ -65,7 +65,7 @@ TestEntity._entityName = 'TestEntity';
  */
 TestEntity._defaultBasePath = '/odata/test-service';
 /**
- * All key fields of the TestEntity entity
+ * All key fields of the TestEntity entity.
  */
 TestEntity._keys = ['KeyTestEntity'];
 //# sourceMappingURL=TestEntity.js.map

--- a/test-packages/test-services-e2e/v4/test-service/TestEntity.ts
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntity.ts
@@ -36,7 +36,7 @@ export class TestEntity<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/odata/test-service';
   /**
-   * All key fields of the TestEntity entity
+   * All key fields of the TestEntity entity.
    */
   static _keys = ['KeyTestEntity'];
   /**

--- a/test-packages/test-services-e2e/v4/test-service/TestEntity50Prop.d.ts
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntity50Prop.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntity50Prop<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntity50Prop entity
+   * All key fields of the TestEntity50Prop entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-e2e/v4/test-service/TestEntity50Prop.js
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntity50Prop.js
@@ -25,7 +25,7 @@ TestEntity50Prop._entityName = 'TestEntity50Prop';
  */
 TestEntity50Prop._defaultBasePath = '/odata/test-service';
 /**
- * All key fields of the TestEntity50Prop entity
+ * All key fields of the TestEntity50Prop entity.
  */
 TestEntity50Prop._keys = ['KeyTestEntity50Prop'];
 //# sourceMappingURL=TestEntity50Prop.js.map

--- a/test-packages/test-services-e2e/v4/test-service/TestEntity50Prop.ts
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntity50Prop.ts
@@ -27,7 +27,7 @@ export class TestEntity50Prop<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/odata/test-service';
   /**
-   * All key fields of the TestEntity50Prop entity
+   * All key fields of the TestEntity50Prop entity.
    */
   static _keys = ['KeyTestEntity50Prop'];
   /**

--- a/test-packages/test-services-e2e/v4/test-service/TestEntityLink.d.ts
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntityLink.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityLink<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityLink entity
+   * All key fields of the TestEntityLink entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-e2e/v4/test-service/TestEntityLink.js
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntityLink.js
@@ -25,7 +25,7 @@ TestEntityLink._entityName = 'TestEntityLink';
  */
 TestEntityLink._defaultBasePath = '/odata/test-service';
 /**
- * All key fields of the TestEntityLink entity
+ * All key fields of the TestEntityLink entity.
  */
 TestEntityLink._keys = ['KeyTestEntityLink', 'KeyToTestEntity'];
 //# sourceMappingURL=TestEntityLink.js.map

--- a/test-packages/test-services-e2e/v4/test-service/TestEntityLink.ts
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntityLink.ts
@@ -27,7 +27,7 @@ export class TestEntityLink<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/odata/test-service';
   /**
-   * All key fields of the TestEntityLink entity
+   * All key fields of the TestEntityLink entity.
    */
   static _keys = ['KeyTestEntityLink', 'KeyToTestEntity'];
   /**

--- a/test-packages/test-services-e2e/v4/test-service/TestEntityWithMultipleKeys.d.ts
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntityWithMultipleKeys.d.ts
@@ -29,7 +29,7 @@ export declare class TestEntityWithMultipleKeys<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityWithMultipleKeys entity
+   * All key fields of the TestEntityWithMultipleKeys entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-e2e/v4/test-service/TestEntityWithMultipleKeys.js
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntityWithMultipleKeys.js
@@ -55,7 +55,7 @@ TestEntityWithMultipleKeys._entityName = 'TestEntityWithMultipleKeys';
  */
 TestEntityWithMultipleKeys._defaultBasePath = '/odata/test-service';
 /**
- * All key fields of the TestEntityWithMultipleKeys entity
+ * All key fields of the TestEntityWithMultipleKeys entity.
  */
 TestEntityWithMultipleKeys._keys = [
     'KeyTestEntityWithMultipleKeys',

--- a/test-packages/test-services-e2e/v4/test-service/TestEntityWithMultipleKeys.ts
+++ b/test-packages/test-services-e2e/v4/test-service/TestEntityWithMultipleKeys.ts
@@ -34,7 +34,7 @@ export class TestEntityWithMultipleKeys<
    */
   static override _defaultBasePath = '/odata/test-service';
   /**
-   * All key fields of the TestEntityWithMultipleKeys entity
+   * All key fields of the TestEntityWithMultipleKeys entity.
    */
   static _keys = [
     'KeyTestEntityWithMultipleKeys',

--- a/test-packages/test-services-odata-v2/multiple-schemas-service/BatchRequest.d.ts
+++ b/test-packages/test-services-odata-v2/multiple-schemas-service/BatchRequest.d.ts
@@ -16,7 +16,7 @@ import {
 import { MultiSchemaTestEntity } from './index';
 /**
  * Batch builder for operations supported on the Multiple Schemas Service.
- * @param requests The requests of the batch
+ * @param requests The requests of the batch.
  * @returns A request builder for batch.
  */
 export declare function batch<DeSerializersT extends DeSerializers>(
@@ -33,7 +33,7 @@ export declare function batch<DeSerializersT extends DeSerializers>(
 ): ODataBatchRequestBuilder<DeSerializersT>;
 /**
  * Change set constructor consists of write operations supported on the Multiple Schemas Service.
- * @param requests The requests of the change set
+ * @param requests The requests of the change set.
  * @returns A change set for batch.
  */
 export declare function changeset<DeSerializersT extends DeSerializers>(

--- a/test-packages/test-services-odata-v2/multiple-schemas-service/BatchRequest.ts
+++ b/test-packages/test-services-odata-v2/multiple-schemas-service/BatchRequest.ts
@@ -18,7 +18,7 @@ import { MultiSchemaTestEntity } from './index';
 
 /**
  * Batch builder for operations supported on the Multiple Schemas Service.
- * @param requests The requests of the batch
+ * @param requests The requests of the batch.
  * @returns A request builder for batch.
  */
 export function batch<DeSerializersT extends DeSerializers>(
@@ -55,7 +55,7 @@ export function batch<DeSerializersT extends DeSerializers>(
 
 /**
  * Change set constructor consists of write operations supported on the Multiple Schemas Service.
- * @param requests The requests of the change set
+ * @param requests The requests of the change set.
  * @returns A change set for batch.
  */
 export function changeset<DeSerializersT extends DeSerializers>(

--- a/test-packages/test-services-odata-v2/multiple-schemas-service/MultiSchemaTestEntity.d.ts
+++ b/test-packages/test-services-odata-v2/multiple-schemas-service/MultiSchemaTestEntity.d.ts
@@ -28,7 +28,7 @@ export declare class MultiSchemaTestEntity<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the MultiSchemaTestEntity entity
+   * All key fields of the MultiSchemaTestEntity entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/multiple-schemas-service/MultiSchemaTestEntity.js
+++ b/test-packages/test-services-odata-v2/multiple-schemas-service/MultiSchemaTestEntity.js
@@ -25,7 +25,7 @@ MultiSchemaTestEntity._entityName = 'MultiSchemaTestEntity';
  */
 MultiSchemaTestEntity._defaultBasePath = '/';
 /**
- * All key fields of the MultiSchemaTestEntity entity
+ * All key fields of the MultiSchemaTestEntity entity.
  */
 MultiSchemaTestEntity._keys = ['KeyProperty'];
 //# sourceMappingURL=MultiSchemaTestEntity.js.map

--- a/test-packages/test-services-odata-v2/multiple-schemas-service/MultiSchemaTestEntity.ts
+++ b/test-packages/test-services-odata-v2/multiple-schemas-service/MultiSchemaTestEntity.ts
@@ -29,7 +29,7 @@ export class MultiSchemaTestEntity<
    */
   static override _defaultBasePath = '/';
   /**
-   * All key fields of the MultiSchemaTestEntity entity
+   * All key fields of the MultiSchemaTestEntity entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/BatchRequest.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/BatchRequest.d.ts
@@ -48,7 +48,7 @@ import {
 } from './index';
 /**
  * Batch builder for operations supported on the Test Service.
- * @param requests The requests of the batch
+ * @param requests The requests of the batch.
  * @returns A request builder for batch.
  */
 export declare function batch<DeSerializersT extends DeSerializers>(
@@ -65,7 +65,7 @@ export declare function batch<DeSerializersT extends DeSerializers>(
 ): ODataBatchRequestBuilder<DeSerializersT>;
 /**
  * Change set constructor consists of write operations supported on the Test Service.
- * @param requests The requests of the change set
+ * @param requests The requests of the change set.
  * @returns A change set for batch.
  */
 export declare function changeset<DeSerializersT extends DeSerializers>(

--- a/test-packages/test-services-odata-v2/test-service/BatchRequest.ts
+++ b/test-packages/test-services-odata-v2/test-service/BatchRequest.ts
@@ -50,7 +50,7 @@ import {
 
 /**
  * Batch builder for operations supported on the Test Service.
- * @param requests The requests of the batch
+ * @param requests The requests of the batch.
  * @returns A request builder for batch.
  */
 export function batch<DeSerializersT extends DeSerializers>(
@@ -87,7 +87,7 @@ export function batch<DeSerializersT extends DeSerializers>(
 
 /**
  * Change set constructor consists of write operations supported on the Test Service.
- * @param requests The requests of the change set
+ * @param requests The requests of the change set.
  * @returns A change set for batch.
  */
 export function changeset<DeSerializersT extends DeSerializers>(

--- a/test-packages/test-services-odata-v2/test-service/CaseTest.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/CaseTest.d.ts
@@ -26,7 +26,7 @@ export declare class CaseTest<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the CaseTest entity
+   * All key fields of the CaseTest entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/CaseTest.js
+++ b/test-packages/test-services-odata-v2/test-service/CaseTest.js
@@ -25,7 +25,7 @@ CaseTest._entityName = 'A_CaseTest';
  */
 CaseTest._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the CaseTest entity
+ * All key fields of the CaseTest entity.
  */
 CaseTest._keys = ['KeyPropertyString'];
 //# sourceMappingURL=CaseTest.js.map

--- a/test-packages/test-services-odata-v2/test-service/CaseTest.ts
+++ b/test-packages/test-services-odata-v2/test-service/CaseTest.ts
@@ -27,7 +27,7 @@ export class CaseTest<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the CaseTest entity
+   * All key fields of the CaseTest entity.
    */
   static _keys = ['KeyPropertyString'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/Casetest_1.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/Casetest_1.d.ts
@@ -26,7 +26,7 @@ export declare class Casetest_1<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the Casetest_1 entity
+   * All key fields of the Casetest_1 entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/Casetest_1.js
+++ b/test-packages/test-services-odata-v2/test-service/Casetest_1.js
@@ -25,7 +25,7 @@ Casetest_1._entityName = 'A_CASETEST';
  */
 Casetest_1._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the Casetest_1 entity
+ * All key fields of the Casetest_1 entity.
  */
 Casetest_1._keys = ['KeyPropertyString'];
 //# sourceMappingURL=Casetest_1.js.map

--- a/test-packages/test-services-odata-v2/test-service/Casetest_1.ts
+++ b/test-packages/test-services-odata-v2/test-service/Casetest_1.ts
@@ -27,7 +27,7 @@ export class Casetest_1<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the Casetest_1 entity
+   * All key fields of the Casetest_1 entity.
    */
   static _keys = ['KeyPropertyString'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntity.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntity.d.ts
@@ -39,7 +39,7 @@ export declare class TestEntity<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntity entity
+   * All key fields of the TestEntity entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntity.js
+++ b/test-packages/test-services-odata-v2/test-service/TestEntity.js
@@ -25,7 +25,7 @@ TestEntity._entityName = 'A_TestEntity';
  */
 TestEntity._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntity entity
+ * All key fields of the TestEntity entity.
  */
 TestEntity._keys = ['KeyPropertyGuid', 'KeyPropertyString'];
 //# sourceMappingURL=TestEntity.js.map

--- a/test-packages/test-services-odata-v2/test-service/TestEntity.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntity.ts
@@ -40,7 +40,7 @@ export class TestEntity<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntity entity
+   * All key fields of the TestEntity entity.
    */
   static _keys = ['KeyPropertyGuid', 'KeyPropertyString'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityCircularLinkChild.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityCircularLinkChild.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityCircularLinkChild<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityCircularLinkChild entity
+   * All key fields of the TestEntityCircularLinkChild entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityCircularLinkChild.js
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityCircularLinkChild.js
@@ -25,7 +25,7 @@ TestEntityCircularLinkChild._entityName = 'A_TestEntityCircularLinkChild';
  */
 TestEntityCircularLinkChild._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityCircularLinkChild entity
+ * All key fields of the TestEntityCircularLinkChild entity.
  */
 TestEntityCircularLinkChild._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityCircularLinkChild.js.map

--- a/test-packages/test-services-odata-v2/test-service/TestEntityCircularLinkChild.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityCircularLinkChild.ts
@@ -29,7 +29,7 @@ export class TestEntityCircularLinkChild<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityCircularLinkChild entity
+   * All key fields of the TestEntityCircularLinkChild entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityCircularLinkParent.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityCircularLinkParent.d.ts
@@ -32,7 +32,7 @@ export declare class TestEntityCircularLinkParent<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityCircularLinkParent entity
+   * All key fields of the TestEntityCircularLinkParent entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityCircularLinkParent.js
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityCircularLinkParent.js
@@ -25,7 +25,7 @@ TestEntityCircularLinkParent._entityName = 'A_TestEntityCircularLinkParent';
  */
 TestEntityCircularLinkParent._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityCircularLinkParent entity
+ * All key fields of the TestEntityCircularLinkParent entity.
  */
 TestEntityCircularLinkParent._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityCircularLinkParent.js.map

--- a/test-packages/test-services-odata-v2/test-service/TestEntityCircularLinkParent.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityCircularLinkParent.ts
@@ -33,7 +33,7 @@ export class TestEntityCircularLinkParent<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityCircularLinkParent entity
+   * All key fields of the TestEntityCircularLinkParent entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityEndsWith.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityEndsWith.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityEndsWith<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityEndsWith entity
+   * All key fields of the TestEntityEndsWith entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityEndsWith.js
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityEndsWith.js
@@ -25,7 +25,7 @@ TestEntityEndsWith._entityName = 'A_TestEntityEndsWithCollection';
  */
 TestEntityEndsWith._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityEndsWith entity
+ * All key fields of the TestEntityEndsWith entity.
  */
 TestEntityEndsWith._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityEndsWith.js.map

--- a/test-packages/test-services-odata-v2/test-service/TestEntityEndsWith.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityEndsWith.ts
@@ -27,7 +27,7 @@ export class TestEntityEndsWith<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityEndsWith entity
+   * All key fields of the TestEntityEndsWith entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityEndsWithSomethingElse.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityEndsWithSomethingElse.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityEndsWithSomethingElse<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityEndsWithSomethingElse entity
+   * All key fields of the TestEntityEndsWithSomethingElse entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityEndsWithSomethingElse.js
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityEndsWithSomethingElse.js
@@ -25,7 +25,7 @@ TestEntityEndsWithSomethingElse._entityName = 'A_TestEntityEndsWithSomethingElse
  */
 TestEntityEndsWithSomethingElse._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityEndsWithSomethingElse entity
+ * All key fields of the TestEntityEndsWithSomethingElse entity.
  */
 TestEntityEndsWithSomethingElse._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityEndsWithSomethingElse.js.map

--- a/test-packages/test-services-odata-v2/test-service/TestEntityEndsWithSomethingElse.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityEndsWithSomethingElse.ts
@@ -29,7 +29,7 @@ export class TestEntityEndsWithSomethingElse<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityEndsWithSomethingElse entity
+   * All key fields of the TestEntityEndsWithSomethingElse entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityLvl2MultiLink.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityLvl2MultiLink.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityLvl2MultiLink<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityLvl2MultiLink entity
+   * All key fields of the TestEntityLvl2MultiLink entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityLvl2MultiLink.js
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityLvl2MultiLink.js
@@ -25,7 +25,7 @@ TestEntityLvl2MultiLink._entityName = 'A_TestEntityLvl2MultiLink';
  */
 TestEntityLvl2MultiLink._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityLvl2MultiLink entity
+ * All key fields of the TestEntityLvl2MultiLink entity.
  */
 TestEntityLvl2MultiLink._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityLvl2MultiLink.js.map

--- a/test-packages/test-services-odata-v2/test-service/TestEntityLvl2MultiLink.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityLvl2MultiLink.ts
@@ -29,7 +29,7 @@ export class TestEntityLvl2MultiLink<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityLvl2MultiLink entity
+   * All key fields of the TestEntityLvl2MultiLink entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityLvl2SingleLink.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityLvl2SingleLink.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityLvl2SingleLink<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityLvl2SingleLink entity
+   * All key fields of the TestEntityLvl2SingleLink entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityLvl2SingleLink.js
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityLvl2SingleLink.js
@@ -25,7 +25,7 @@ TestEntityLvl2SingleLink._entityName = 'A_TestEntityLvl2SingleLink';
  */
 TestEntityLvl2SingleLink._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityLvl2SingleLink entity
+ * All key fields of the TestEntityLvl2SingleLink entity.
  */
 TestEntityLvl2SingleLink._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityLvl2SingleLink.js.map

--- a/test-packages/test-services-odata-v2/test-service/TestEntityLvl2SingleLink.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityLvl2SingleLink.ts
@@ -29,7 +29,7 @@ export class TestEntityLvl2SingleLink<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityLvl2SingleLink entity
+   * All key fields of the TestEntityLvl2SingleLink entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityMultiLink.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityMultiLink.d.ts
@@ -36,7 +36,7 @@ export declare class TestEntityMultiLink<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityMultiLink entity
+   * All key fields of the TestEntityMultiLink entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityMultiLink.js
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityMultiLink.js
@@ -25,7 +25,7 @@ TestEntityMultiLink._entityName = 'A_TestEntityMultiLink';
  */
 TestEntityMultiLink._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityMultiLink entity
+ * All key fields of the TestEntityMultiLink entity.
  */
 TestEntityMultiLink._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityMultiLink.js.map

--- a/test-packages/test-services-odata-v2/test-service/TestEntityMultiLink.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityMultiLink.ts
@@ -35,7 +35,7 @@ export class TestEntityMultiLink<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityMultiLink entity
+   * All key fields of the TestEntityMultiLink entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityOtherMultiLink.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityOtherMultiLink.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityOtherMultiLink<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityOtherMultiLink entity
+   * All key fields of the TestEntityOtherMultiLink entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityOtherMultiLink.js
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityOtherMultiLink.js
@@ -25,7 +25,7 @@ TestEntityOtherMultiLink._entityName = 'A_TestEntityOtherMultiLink';
  */
 TestEntityOtherMultiLink._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityOtherMultiLink entity
+ * All key fields of the TestEntityOtherMultiLink entity.
  */
 TestEntityOtherMultiLink._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityOtherMultiLink.js.map

--- a/test-packages/test-services-odata-v2/test-service/TestEntityOtherMultiLink.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityOtherMultiLink.ts
@@ -29,7 +29,7 @@ export class TestEntityOtherMultiLink<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityOtherMultiLink entity
+   * All key fields of the TestEntityOtherMultiLink entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntitySingleLink.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntitySingleLink.d.ts
@@ -36,7 +36,7 @@ export declare class TestEntitySingleLink<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntitySingleLink entity
+   * All key fields of the TestEntitySingleLink entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntitySingleLink.js
+++ b/test-packages/test-services-odata-v2/test-service/TestEntitySingleLink.js
@@ -25,7 +25,7 @@ TestEntitySingleLink._entityName = 'A_TestEntitySingleLink';
  */
 TestEntitySingleLink._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntitySingleLink entity
+ * All key fields of the TestEntitySingleLink entity.
  */
 TestEntitySingleLink._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntitySingleLink.js.map

--- a/test-packages/test-services-odata-v2/test-service/TestEntitySingleLink.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntitySingleLink.ts
@@ -37,7 +37,7 @@ export class TestEntitySingleLink<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntitySingleLink entity
+   * All key fields of the TestEntitySingleLink entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityWithSharedEntityType1.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityWithSharedEntityType1.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityWithSharedEntityType1<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityWithSharedEntityType1 entity
+   * All key fields of the TestEntityWithSharedEntityType1 entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityWithSharedEntityType1.js
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityWithSharedEntityType1.js
@@ -25,7 +25,7 @@ TestEntityWithSharedEntityType1._entityName = 'A_TestEntityWithSharedEntityType1
  */
 TestEntityWithSharedEntityType1._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityWithSharedEntityType1 entity
+ * All key fields of the TestEntityWithSharedEntityType1 entity.
  */
 TestEntityWithSharedEntityType1._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityWithSharedEntityType1.js.map

--- a/test-packages/test-services-odata-v2/test-service/TestEntityWithSharedEntityType1.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityWithSharedEntityType1.ts
@@ -29,7 +29,7 @@ export class TestEntityWithSharedEntityType1<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityWithSharedEntityType1 entity
+   * All key fields of the TestEntityWithSharedEntityType1 entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityWithSharedEntityType2.d.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityWithSharedEntityType2.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityWithSharedEntityType2<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityWithSharedEntityType2 entity
+   * All key fields of the TestEntityWithSharedEntityType2 entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v2/test-service/TestEntityWithSharedEntityType2.js
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityWithSharedEntityType2.js
@@ -25,7 +25,7 @@ TestEntityWithSharedEntityType2._entityName = 'A_TestEntityWithSharedEntityType2
  */
 TestEntityWithSharedEntityType2._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityWithSharedEntityType2 entity
+ * All key fields of the TestEntityWithSharedEntityType2 entity.
  */
 TestEntityWithSharedEntityType2._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityWithSharedEntityType2.js.map

--- a/test-packages/test-services-odata-v2/test-service/TestEntityWithSharedEntityType2.ts
+++ b/test-packages/test-services-odata-v2/test-service/TestEntityWithSharedEntityType2.ts
@@ -29,7 +29,7 @@ export class TestEntityWithSharedEntityType2<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityWithSharedEntityType2 entity
+   * All key fields of the TestEntityWithSharedEntityType2 entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/BatchRequest.d.ts
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/BatchRequest.d.ts
@@ -28,7 +28,7 @@ import {
 } from './index';
 /**
  * Batch builder for operations supported on the Multiple Schemas Service.
- * @param requests The requests of the batch
+ * @param requests The requests of the batch.
  * @returns A request builder for batch.
  */
 export declare function batch<DeSerializersT extends DeSerializers>(
@@ -45,7 +45,7 @@ export declare function batch<DeSerializersT extends DeSerializers>(
 ): ODataBatchRequestBuilder<DeSerializersT>;
 /**
  * Change set constructor consists of write operations supported on the Multiple Schemas Service.
- * @param requests The requests of the change set
+ * @param requests The requests of the change set.
  * @returns A change set for batch.
  */
 export declare function changeset<DeSerializersT extends DeSerializers>(

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/BatchRequest.ts
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/BatchRequest.ts
@@ -30,7 +30,7 @@ import {
 
 /**
  * Batch builder for operations supported on the Multiple Schemas Service.
- * @param requests The requests of the batch
+ * @param requests The requests of the batch.
  * @returns A request builder for batch.
  */
 export function batch<DeSerializersT extends DeSerializers>(
@@ -67,7 +67,7 @@ export function batch<DeSerializersT extends DeSerializers>(
 
 /**
  * Change set constructor consists of write operations supported on the Multiple Schemas Service.
- * @param requests The requests of the change set
+ * @param requests The requests of the change set.
  * @returns A change set for batch.
  */
 export function changeset<DeSerializersT extends DeSerializers>(

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity1.d.ts
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity1.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntity1<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntity1 entity
+   * All key fields of the TestEntity1 entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity1.js
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity1.js
@@ -25,7 +25,7 @@ TestEntity1._entityName = 'A_TestEntity1';
  */
 TestEntity1._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntity1 entity
+ * All key fields of the TestEntity1 entity.
  */
 TestEntity1._keys = ['KeyPropertyString'];
 //# sourceMappingURL=TestEntity1.js.map

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity1.ts
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity1.ts
@@ -29,7 +29,7 @@ export class TestEntity1<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntity1 entity
+   * All key fields of the TestEntity1 entity.
    */
   static _keys = ['KeyPropertyString'];
   /**

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity2.d.ts
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity2.d.ts
@@ -26,7 +26,7 @@ export declare class TestEntity2<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntity2 entity
+   * All key fields of the TestEntity2 entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity2.js
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity2.js
@@ -25,7 +25,7 @@ TestEntity2._entityName = 'A_TestEntity2';
  */
 TestEntity2._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntity2 entity
+ * All key fields of the TestEntity2 entity.
  */
 TestEntity2._keys = ['KeyPropertyString'];
 //# sourceMappingURL=TestEntity2.js.map

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity2.ts
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity2.ts
@@ -27,7 +27,7 @@ export class TestEntity2<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntity2 entity
+   * All key fields of the TestEntity2 entity.
    */
   static _keys = ['KeyPropertyString'];
   /**

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity3.d.ts
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity3.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntity3<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntity3 entity
+   * All key fields of the TestEntity3 entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity3.js
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity3.js
@@ -25,7 +25,7 @@ TestEntity3._entityName = 'A_TestEntity3';
  */
 TestEntity3._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntity3 entity
+ * All key fields of the TestEntity3 entity.
  */
 TestEntity3._keys = ['KeyPropertyString'];
 //# sourceMappingURL=TestEntity3.js.map

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity3.ts
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity3.ts
@@ -29,7 +29,7 @@ export class TestEntity3<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntity3 entity
+   * All key fields of the TestEntity3 entity.
    */
   static _keys = ['KeyPropertyString'];
   /**

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity4.d.ts
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity4.d.ts
@@ -26,7 +26,7 @@ export declare class TestEntity4<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntity4 entity
+   * All key fields of the TestEntity4 entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity4.js
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity4.js
@@ -25,7 +25,7 @@ TestEntity4._entityName = 'A_TestEntity4';
  */
 TestEntity4._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntity4 entity
+ * All key fields of the TestEntity4 entity.
  */
 TestEntity4._keys = ['KeyPropertyString'];
 //# sourceMappingURL=TestEntity4.js.map

--- a/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity4.ts
+++ b/test-packages/test-services-odata-v4/multiple-schemas-service/TestEntity4.ts
@@ -27,7 +27,7 @@ export class TestEntity4<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntity4 entity
+   * All key fields of the TestEntity4 entity.
    */
   static _keys = ['KeyPropertyString'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/BatchRequest.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/BatchRequest.d.ts
@@ -52,7 +52,7 @@ import {
 } from './index';
 /**
  * Batch builder for operations supported on the Test Service.
- * @param requests The requests of the batch
+ * @param requests The requests of the batch.
  * @returns A request builder for batch.
  */
 export declare function batch<DeSerializersT extends DeSerializers>(
@@ -69,7 +69,7 @@ export declare function batch<DeSerializersT extends DeSerializers>(
 ): ODataBatchRequestBuilder<DeSerializersT>;
 /**
  * Change set constructor consists of write operations supported on the Test Service.
- * @param requests The requests of the change set
+ * @param requests The requests of the change set.
  * @returns A change set for batch.
  */
 export declare function changeset<DeSerializersT extends DeSerializers>(

--- a/test-packages/test-services-odata-v4/test-service/BatchRequest.ts
+++ b/test-packages/test-services-odata-v4/test-service/BatchRequest.ts
@@ -54,7 +54,7 @@ import {
 
 /**
  * Batch builder for operations supported on the Test Service.
- * @param requests The requests of the batch
+ * @param requests The requests of the batch.
  * @returns A request builder for batch.
  */
 export function batch<DeSerializersT extends DeSerializers>(
@@ -91,7 +91,7 @@ export function batch<DeSerializersT extends DeSerializers>(
 
 /**
  * Change set constructor consists of write operations supported on the Test Service.
- * @param requests The requests of the change set
+ * @param requests The requests of the change set.
  * @returns A change set for batch.
  */
 export function changeset<DeSerializersT extends DeSerializers>(

--- a/test-packages/test-services-odata-v4/test-service/TestEntity.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntity.d.ts
@@ -39,7 +39,7 @@ export declare class TestEntity<T extends DeSerializers = DefaultDeSerializers>
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntity entity
+   * All key fields of the TestEntity entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntity.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntity.js
@@ -55,7 +55,7 @@ TestEntity._entityName = 'A_TestEntity';
  */
 TestEntity._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntity entity
+ * All key fields of the TestEntity entity.
  */
 TestEntity._keys = ['KeyPropertyGuid', 'KeyPropertyString', 'KeyDateProperty'];
 //# sourceMappingURL=TestEntity.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntity.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntity.ts
@@ -44,7 +44,7 @@ export class TestEntity<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntity entity
+   * All key fields of the TestEntity entity.
    */
   static _keys = ['KeyPropertyGuid', 'KeyPropertyString', 'KeyDateProperty'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityCircularLinkChild.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityCircularLinkChild.d.ts
@@ -32,7 +32,7 @@ export declare class TestEntityCircularLinkChild<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityCircularLinkChild entity
+   * All key fields of the TestEntityCircularLinkChild entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityCircularLinkChild.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityCircularLinkChild.js
@@ -25,7 +25,7 @@ TestEntityCircularLinkChild._entityName = 'A_TestEntityCircularLinkChild';
  */
 TestEntityCircularLinkChild._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityCircularLinkChild entity
+ * All key fields of the TestEntityCircularLinkChild entity.
  */
 TestEntityCircularLinkChild._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityCircularLinkChild.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityCircularLinkChild.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityCircularLinkChild.ts
@@ -33,7 +33,7 @@ export class TestEntityCircularLinkChild<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityCircularLinkChild entity
+   * All key fields of the TestEntityCircularLinkChild entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityCircularLinkParent.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityCircularLinkParent.d.ts
@@ -32,7 +32,7 @@ export declare class TestEntityCircularLinkParent<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityCircularLinkParent entity
+   * All key fields of the TestEntityCircularLinkParent entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityCircularLinkParent.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityCircularLinkParent.js
@@ -25,7 +25,7 @@ TestEntityCircularLinkParent._entityName = 'A_TestEntityCircularLinkParent';
  */
 TestEntityCircularLinkParent._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityCircularLinkParent entity
+ * All key fields of the TestEntityCircularLinkParent entity.
  */
 TestEntityCircularLinkParent._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityCircularLinkParent.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityCircularLinkParent.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityCircularLinkParent.ts
@@ -33,7 +33,7 @@ export class TestEntityCircularLinkParent<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityCircularLinkParent entity
+   * All key fields of the TestEntityCircularLinkParent entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityEndsWith.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityEndsWith.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityEndsWith<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityEndsWith entity
+   * All key fields of the TestEntityEndsWith entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityEndsWith.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityEndsWith.js
@@ -25,7 +25,7 @@ TestEntityEndsWith._entityName = 'A_TestEntityEndsWithCollection';
  */
 TestEntityEndsWith._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityEndsWith entity
+ * All key fields of the TestEntityEndsWith entity.
  */
 TestEntityEndsWith._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityEndsWith.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityEndsWith.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityEndsWith.ts
@@ -27,7 +27,7 @@ export class TestEntityEndsWith<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityEndsWith entity
+   * All key fields of the TestEntityEndsWith entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityEndsWithSomethingElse.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityEndsWithSomethingElse.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityEndsWithSomethingElse<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityEndsWithSomethingElse entity
+   * All key fields of the TestEntityEndsWithSomethingElse entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityEndsWithSomethingElse.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityEndsWithSomethingElse.js
@@ -25,7 +25,7 @@ TestEntityEndsWithSomethingElse._entityName = 'A_TestEntityEndsWithSomethingElse
  */
 TestEntityEndsWithSomethingElse._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityEndsWithSomethingElse entity
+ * All key fields of the TestEntityEndsWithSomethingElse entity.
  */
 TestEntityEndsWithSomethingElse._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityEndsWithSomethingElse.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityEndsWithSomethingElse.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityEndsWithSomethingElse.ts
@@ -29,7 +29,7 @@ export class TestEntityEndsWithSomethingElse<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityEndsWithSomethingElse entity
+   * All key fields of the TestEntityEndsWithSomethingElse entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityLvl2MultiLink.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityLvl2MultiLink.d.ts
@@ -32,7 +32,7 @@ export declare class TestEntityLvl2MultiLink<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityLvl2MultiLink entity
+   * All key fields of the TestEntityLvl2MultiLink entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityLvl2MultiLink.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityLvl2MultiLink.js
@@ -25,7 +25,7 @@ TestEntityLvl2MultiLink._entityName = 'A_TestEntityLvl2MultiLink';
  */
 TestEntityLvl2MultiLink._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityLvl2MultiLink entity
+ * All key fields of the TestEntityLvl2MultiLink entity.
  */
 TestEntityLvl2MultiLink._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityLvl2MultiLink.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityLvl2MultiLink.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityLvl2MultiLink.ts
@@ -33,7 +33,7 @@ export class TestEntityLvl2MultiLink<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityLvl2MultiLink entity
+   * All key fields of the TestEntityLvl2MultiLink entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityLvl2SingleLink.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityLvl2SingleLink.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityLvl2SingleLink<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityLvl2SingleLink entity
+   * All key fields of the TestEntityLvl2SingleLink entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityLvl2SingleLink.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityLvl2SingleLink.js
@@ -25,7 +25,7 @@ TestEntityLvl2SingleLink._entityName = 'A_TestEntityLvl2SingleLink';
  */
 TestEntityLvl2SingleLink._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityLvl2SingleLink entity
+ * All key fields of the TestEntityLvl2SingleLink entity.
  */
 TestEntityLvl2SingleLink._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityLvl2SingleLink.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityLvl2SingleLink.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityLvl2SingleLink.ts
@@ -29,7 +29,7 @@ export class TestEntityLvl2SingleLink<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityLvl2SingleLink entity
+   * All key fields of the TestEntityLvl2SingleLink entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityLvl3MultiLink.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityLvl3MultiLink.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityLvl3MultiLink<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityLvl3MultiLink entity
+   * All key fields of the TestEntityLvl3MultiLink entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityLvl3MultiLink.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityLvl3MultiLink.js
@@ -25,7 +25,7 @@ TestEntityLvl3MultiLink._entityName = 'A_TestEntityLvl3MultiLink';
  */
 TestEntityLvl3MultiLink._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityLvl3MultiLink entity
+ * All key fields of the TestEntityLvl3MultiLink entity.
  */
 TestEntityLvl3MultiLink._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityLvl3MultiLink.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityLvl3MultiLink.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityLvl3MultiLink.ts
@@ -29,7 +29,7 @@ export class TestEntityLvl3MultiLink<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityLvl3MultiLink entity
+   * All key fields of the TestEntityLvl3MultiLink entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityMultiLink.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityMultiLink.d.ts
@@ -36,7 +36,7 @@ export declare class TestEntityMultiLink<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityMultiLink entity
+   * All key fields of the TestEntityMultiLink entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityMultiLink.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityMultiLink.js
@@ -25,7 +25,7 @@ TestEntityMultiLink._entityName = 'A_TestEntityMultiLink';
  */
 TestEntityMultiLink._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityMultiLink entity
+ * All key fields of the TestEntityMultiLink entity.
  */
 TestEntityMultiLink._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityMultiLink.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityMultiLink.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityMultiLink.ts
@@ -35,7 +35,7 @@ export class TestEntityMultiLink<T extends DeSerializers = DefaultDeSerializers>
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityMultiLink entity
+   * All key fields of the TestEntityMultiLink entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityOtherMultiLink.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityOtherMultiLink.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityOtherMultiLink<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityOtherMultiLink entity
+   * All key fields of the TestEntityOtherMultiLink entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityOtherMultiLink.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityOtherMultiLink.js
@@ -25,7 +25,7 @@ TestEntityOtherMultiLink._entityName = 'A_TestEntityOtherMultiLink';
  */
 TestEntityOtherMultiLink._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityOtherMultiLink entity
+ * All key fields of the TestEntityOtherMultiLink entity.
  */
 TestEntityOtherMultiLink._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityOtherMultiLink.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityOtherMultiLink.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityOtherMultiLink.ts
@@ -29,7 +29,7 @@ export class TestEntityOtherMultiLink<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityOtherMultiLink entity
+   * All key fields of the TestEntityOtherMultiLink entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntitySingleLink.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntitySingleLink.d.ts
@@ -36,7 +36,7 @@ export declare class TestEntitySingleLink<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntitySingleLink entity
+   * All key fields of the TestEntitySingleLink entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntitySingleLink.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntitySingleLink.js
@@ -25,7 +25,7 @@ TestEntitySingleLink._entityName = 'A_TestEntitySingleLink';
  */
 TestEntitySingleLink._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntitySingleLink entity
+ * All key fields of the TestEntitySingleLink entity.
  */
 TestEntitySingleLink._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntitySingleLink.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntitySingleLink.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntitySingleLink.ts
@@ -37,7 +37,7 @@ export class TestEntitySingleLink<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntitySingleLink entity
+   * All key fields of the TestEntitySingleLink entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityWithEnumKey.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityWithEnumKey.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityWithEnumKey<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityWithEnumKey entity
+   * All key fields of the TestEntityWithEnumKey entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityWithEnumKey.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityWithEnumKey.js
@@ -25,7 +25,7 @@ TestEntityWithEnumKey._entityName = 'A_TestEntityWithEnumKey';
  */
 TestEntityWithEnumKey._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityWithEnumKey entity
+ * All key fields of the TestEntityWithEnumKey entity.
  */
 TestEntityWithEnumKey._keys = ['KeyPropertyEnum1'];
 //# sourceMappingURL=TestEntityWithEnumKey.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityWithEnumKey.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityWithEnumKey.ts
@@ -30,7 +30,7 @@ export class TestEntityWithEnumKey<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityWithEnumKey entity
+   * All key fields of the TestEntityWithEnumKey entity.
    */
   static _keys = ['KeyPropertyEnum1'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityWithNoKeys.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityWithNoKeys.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityWithNoKeys<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityWithNoKeys entity
+   * All key fields of the TestEntityWithNoKeys entity.
    */
   static _keys: never[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityWithNoKeys.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityWithNoKeys.js
@@ -25,7 +25,7 @@ TestEntityWithNoKeys._entityName = 'A_TestEntityWithNoKeys';
  */
 TestEntityWithNoKeys._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityWithNoKeys entity
+ * All key fields of the TestEntityWithNoKeys entity.
  */
 TestEntityWithNoKeys._keys = [];
 //# sourceMappingURL=TestEntityWithNoKeys.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityWithNoKeys.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityWithNoKeys.ts
@@ -29,7 +29,7 @@ export class TestEntityWithNoKeys<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityWithNoKeys entity
+   * All key fields of the TestEntityWithNoKeys entity.
    */
   static _keys = [];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityWithSharedEntityType1.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityWithSharedEntityType1.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityWithSharedEntityType1<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityWithSharedEntityType1 entity
+   * All key fields of the TestEntityWithSharedEntityType1 entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityWithSharedEntityType1.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityWithSharedEntityType1.js
@@ -25,7 +25,7 @@ TestEntityWithSharedEntityType1._entityName = 'A_TestEntityWithSharedEntityType1
  */
 TestEntityWithSharedEntityType1._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityWithSharedEntityType1 entity
+ * All key fields of the TestEntityWithSharedEntityType1 entity.
  */
 TestEntityWithSharedEntityType1._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityWithSharedEntityType1.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityWithSharedEntityType1.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityWithSharedEntityType1.ts
@@ -29,7 +29,7 @@ export class TestEntityWithSharedEntityType1<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityWithSharedEntityType1 entity
+   * All key fields of the TestEntityWithSharedEntityType1 entity.
    */
   static _keys = ['KeyProperty'];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityWithSharedEntityType2.d.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityWithSharedEntityType2.d.ts
@@ -28,7 +28,7 @@ export declare class TestEntityWithSharedEntityType2<
    */
   static _defaultBasePath: string;
   /**
-   * All key fields of the TestEntityWithSharedEntityType2 entity
+   * All key fields of the TestEntityWithSharedEntityType2 entity.
    */
   static _keys: string[];
   /**

--- a/test-packages/test-services-odata-v4/test-service/TestEntityWithSharedEntityType2.js
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityWithSharedEntityType2.js
@@ -25,7 +25,7 @@ TestEntityWithSharedEntityType2._entityName = 'A_TestEntityWithSharedEntityType2
  */
 TestEntityWithSharedEntityType2._defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
 /**
- * All key fields of the TestEntityWithSharedEntityType2 entity
+ * All key fields of the TestEntityWithSharedEntityType2 entity.
  */
 TestEntityWithSharedEntityType2._keys = ['KeyProperty'];
 //# sourceMappingURL=TestEntityWithSharedEntityType2.js.map

--- a/test-packages/test-services-odata-v4/test-service/TestEntityWithSharedEntityType2.ts
+++ b/test-packages/test-services-odata-v4/test-service/TestEntityWithSharedEntityType2.ts
@@ -29,7 +29,7 @@ export class TestEntityWithSharedEntityType2<
    */
   static override _defaultBasePath = '/sap/opu/odata/sap/API_TEST_SRV';
   /**
-   * All key fields of the TestEntityWithSharedEntityType2 entity
+   * All key fields of the TestEntityWithSharedEntityType2 entity.
    */
   static _keys = ['KeyProperty'];
   /**


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Some of the generated comments in the clients dont follow jsdoc complete sentence rule. Adjusted those. Also removed prettier recommended config from the new config, as it seems unnecessary.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
