### PR TITLE
fix: Make generation slightly more resilient

### DIFF
--- a/.changeset/famous-donuts-act.md
+++ b/.changeset/famous-donuts-act.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/openapi-generator': patch
+---
+
+[Improvement] Make generation of `oneOf`, `allOf`, `anyOf` and `not` generation of schemas with type object. In cases where both types are assigned type object is ignored.

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -42,18 +42,6 @@ export function parseSchema(
     return parseArraySchema(schema, refs, options);
   }
 
-  if (
-    schema.type === 'object' ||
-    schema.properties ||
-    'additionalProperties' in schema
-  ) {
-    return parseObjectSchema(schema, refs, options);
-  }
-
-  if (schema.enum?.length) {
-    return parseEnumSchema(schema, options);
-  }
-
   if (schema.oneOf?.length) {
     return parseXOfSchema(schema, refs, 'oneOf', options);
   }
@@ -70,6 +58,18 @@ export function parseSchema(
     return {
       not: parseSchema(schema.not, refs, options)
     };
+  }
+
+  if (
+    schema.type === 'object' ||
+    schema.properties ||
+    'additionalProperties' in schema
+  ) {
+    return parseObjectSchema(schema, refs, options);
+  }
+
+  if (schema.enum?.length) {
+    return parseEnumSchema(schema, options);
   }
 
   return {


### PR DESCRIPTION
I accidentally found that `oneOf` does not get generated correctly in some cases and the order matters. I think what we are doing is not a mistake but now we allow slightly incorrect specs as well.