### PR TITLE
fix: Fix import of jsonwebtoken types

### DIFF
--- a/.changeset/chatty-parrots-dream.md
+++ b/.changeset/chatty-parrots-dream.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+---
+
+[Fixed Issue] Fix the JwtPayload import.

--- a/packages/connectivity/src/scp-cf/connectivity-service.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.ts
@@ -1,5 +1,5 @@
 import { createLogger, ErrorWithCause } from '@sap-cloud-sdk/util';
-import { JwtPayload } from 'jsonwebtoken';
+import { JwtPayload } from './jsonwebtoken-type';
 import { Protocol } from './protocol';
 import {
   ProxyConfiguration,

--- a/packages/connectivity/src/scp-cf/destination/get-subscriber-token.ts
+++ b/packages/connectivity/src/scp-cf/destination/get-subscriber-token.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import { JwtPayload } from 'jsonwebtoken';
+import { JwtPayload } from './jsonwebtoken-type';
 import {
   decodeJwt,
   getJwtPair,

--- a/packages/connectivity/src/scp-cf/destination/get-subscriber-token.ts
+++ b/packages/connectivity/src/scp-cf/destination/get-subscriber-token.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import { JwtPayload } from './jsonwebtoken-type';
+import { JwtPayload } from '../jsonwebtoken-type';
 import {
   decodeJwt,
   getJwtPair,


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Remove imports from '@types/jsonwebtoken'

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
