### PR TITLE
fix: Fix OpenAPI client's generated typedoc

### DIFF
--- a/.changeset/clever-hairs-flow.md
+++ b/.changeset/clever-hairs-flow.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/openapi-generator': patch
+---
+
+[Fixed Issue] Properly format generated typedoc if existing documentation doesn't align with our ESLint config.

--- a/packages/openapi-generator/src/file-serializer/schema-file.ts
+++ b/packages/openapi-generator/src/file-serializer/schema-file.ts
@@ -48,9 +48,13 @@ function getImports(
  * @internal
  */
 export function schemaDocumentation(schema: OpenApiPersistedSchema): string {
+  const schemaDescription = schema.description
+    ? schema.description.endsWith('.')
+      ? schema.description
+      : schema.description + '.'
+    : `Representation of the '${schema.schemaName}' schema.`;
   const lines = [
-    schema.description ||
-      `Representation of the '${schema.schemaName}' schema.`,
+    schemaDescription,
     ...getSchemaPropertiesDocumentation(schema.schemaProperties)
   ];
   return documentationBlock`${lines.join(unixEOL)}`;


### PR DESCRIPTION
With this PR, we check if the existing type doc is properly formated, and if not, do it ourselves.