### PR TITLE
chore: Turn off concurrency for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "postinstall": "yarn compile",
     "compile": "turbo run compile",
-    "test": "turbo run test",
+    "test": "turbo run test --concurrency 1",
     "test:unit": "turbo run test --filter=./packages/*",
     "test:build-packages": "turbo run test --filter=./build-packages/*",
     "test:integration": "turbo run test --filter=@sap-cloud-sdk/integration-tests",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
   "scripts": {
     "postinstall": "yarn compile",
     "compile": "turbo run compile",
-    "test": "turbo run test --concurrency=1",
-    "test:unit": "turbo run test --filter=./packages/*",
+    "test": "turbo run test",
+    "test:unit": "turbo run test --filter=./packages/* --concurrency=1",
     "test:build-packages": "turbo run test --filter=./build-packages/*",
     "test:integration": "turbo run test --filter=@sap-cloud-sdk/integration-tests",
     "test:type": "turbo run test --filter=@sap-cloud-sdk/type-tests",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "postinstall": "yarn compile",
     "compile": "turbo run compile",
     "test": "turbo run test",
-    "test:unit": "turbo run test --filter=./packages/* --concurrency=1",
+    "test:unit": "turbo run test --filter=./packages/* --parallel",
     "test:build-packages": "turbo run test --filter=./build-packages/*",
     "test:integration": "turbo run test --filter=@sap-cloud-sdk/integration-tests",
     "test:type": "turbo run test --filter=@sap-cloud-sdk/type-tests",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "postinstall": "yarn compile",
     "compile": "turbo run compile",
-    "test": "turbo run test --concurrency 1",
+    "test": "turbo run test --concurrency=1",
     "test:unit": "turbo run test --filter=./packages/*",
     "test:build-packages": "turbo run test --filter=./build-packages/*",
     "test:integration": "turbo run test --filter=@sap-cloud-sdk/integration-tests",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "postinstall": "yarn compile",
     "compile": "turbo run compile",
     "test": "turbo run test",
-    "test:unit": "turbo run test --filter=./packages/* --parallel",
+    "test:unit": "turbo run test --filter=./packages/* --concurrency=1",
     "test:build-packages": "turbo run test --filter=./build-packages/*",
     "test:integration": "turbo run test --filter=@sap-cloud-sdk/integration-tests",
     "test:type": "turbo run test --filter=@sap-cloud-sdk/type-tests",


### PR DESCRIPTION
Our unit tests are flaky. The reason is most likely that we mock the file system and the tests run concurrently. 