### PR TITLE
fix: fix token exchange

### DIFF
--- a/.changeset/afraid-parrots-run.md
+++ b/.changeset/afraid-parrots-run.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+---
+
+[Fixed Issue] Fix IAS to XSUAA token exchange to have less strict verification.

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor.ts
@@ -129,8 +129,8 @@ export async function getAllDestinationsFromDestinationService(
   logger.debug(
     'Attempting to retrieve all destinations from destination service.'
   );
-  if (shouldExchangeToken(options)) {
-    options.jwt = await exchangeToken(options);
+  if (shouldExchangeToken(options) && options.jwt) {
+    options.jwt = await exchangeToken(options.jwt);
   }
 
   const token =

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -93,8 +93,8 @@ export class DestinationFromServiceRetriever {
     // TODO: This is currently always skipped for tokens issued by XSUAA
     // in the XSUAA case no exchange takes place, but instead the JWT is verified
     // in the future we should just let it verify here, but skip it later (get-subscriber-token)
-    if (shouldExchangeToken(options)) {
-      options.jwt = await exchangeToken(options);
+    if (shouldExchangeToken(options) && options.jwt) {
+      options.jwt = await exchangeToken(options.jwt);
     }
 
     const subscriberToken = await getSubscriberToken(options);

--- a/packages/connectivity/src/scp-cf/identity-service.ts
+++ b/packages/connectivity/src/scp-cf/identity-service.ts
@@ -1,7 +1,6 @@
-import { createSecurityContext } from '@sap/xssec';
 import { DestinationOptions } from './destination';
-import { getXsuaaService } from './environment-accessor';
 import { decodeJwt, isXsuaaToken } from './jwt';
+import { jwtBearerToken } from './token-accessor';
 
 /**
  * @internal
@@ -9,16 +8,8 @@ import { decodeJwt, isXsuaaToken } from './jwt';
  * @param options - Configuration for how to retrieve destinations from the destination service.
  * @returns Exchanged token.
  */
-export async function exchangeToken(
-  options: DestinationOptions
-): Promise<string> {
-  const xsuaaService = getXsuaaService({
-    disableCache: !options.cacheVerificationKeys
-  });
-  const { token } = await createSecurityContext(xsuaaService, {
-    jwt: options.jwt
-  });
-  return token.getTokenValue();
+export async function exchangeToken(jwt: string): Promise<string> {
+  return jwtBearerToken(jwt, 'xsuaa');
 }
 
 /**

--- a/packages/connectivity/src/scp-cf/token-accessor.ts
+++ b/packages/connectivity/src/scp-cf/token-accessor.ts
@@ -72,13 +72,13 @@ export async function serviceToken(
 }
 
 /**
- * Returns a jwt bearer token that can be used to call the given service.
+ * Returns a JWT bearer token that can be used to call the given service.
  * The token is fetched via a JWT bearer token grant using the user token + client credentials.
  *
  * Throws an error if there is no instance of the given service type or the XSUAA service, or if the request to the XSUAA service fails.
  * @param jwt - The JWT of the user for whom the access token should be fetched.
  * @param service - The type of the service or an instance of {@link Service}.
- * @returns A jwt bearer token.
+ * @returns A JWT bearer token.
  */
 export async function jwtBearerToken(
   jwt: string,


### PR DESCRIPTION
The token exchange was looking at the token's audiences before and basically did a token verification for XSUAA in the case of IAS tokens. This is incorrect, the token should be merely exchanged.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
