### PR TITLE
chore: Remove dup concurrency flag in windows workflow

### DIFF
--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: 18
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
-      - run: yarn test:unit --concurrency=1
+      - run: yarn test:unit
       - run: yarn test:integration
         if: always()
       - run: yarn test:self


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Fix windows workflow error.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
