### PR TITLE
fix: Fix reading correct tenant for destination caching

### DIFF
--- a/.changeset/calm-candles-lie.md
+++ b/.changeset/calm-candles-lie.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+---
+
+[Fixed Issue] Throw an error if a JWT for caching was provided, but doesn't contain tenant information.

--- a/.changeset/selfish-cougars-shout.md
+++ b/.changeset/selfish-cougars-shout.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+---
+
+[Fixed Issue] Derive tenant information for destination caching also for IAS tokens.

--- a/packages/connectivity/src/scp-cf/destination/__snapshots__/destination-from-registration.spec.ts.snap
+++ b/packages/connectivity/src/scp-cf/destination/__snapshots__/destination-from-registration.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`register-destination without XSUAA binding throws an error if there is a JWT, but no tenant ID could be identified 1`] = `"Could not determine tenant from JWT nor XSUAA, identity or destination service binding. Destination is registered without tenant information."`;

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
@@ -252,7 +252,9 @@ describe('register-destination', () => {
     it('throws an error if there is a JWT, but no tenant ID could be identified', async () => {
       const dummyTenantId = 'provider-tenant';
 
-      expect(registerDestination(testDestination, { jwt: signedJwt({}) })).rejects.toThrowErrorMatchingSnapshot();
+      expect(
+        registerDestination(testDestination, { jwt: signedJwt({}) })
+      ).rejects.toThrowErrorMatchingSnapshot();
       const registeredDestination = await registerDestinationCache.destination
         .getCacheInstance()
         .get(`${dummyTenantId}::${testDestination.name}`);

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import { decodeJwt, decodeOrMakeJwt, defaultTenantId } from '../jwt';
+import { decodeJwt, decodeOrMakeJwt, defaultTenantId, getTenantId } from '../jwt';
 import { DestinationFetchOptions } from './destination-accessor-types';
 import {
   IsolationStrategy,
@@ -58,7 +58,7 @@ export async function registerDestination(
 
 function getJwtForCaching(options: RegisterDestinationOptions | undefined) {
   const jwt = decodeOrMakeJwt(options?.jwt);
-  if (!jwt?.zid) {
+  if (!getTenantId(jwt?.zid)) {
     if (options?.jwt) {
       logger.error(
         'Could not determine tenant from JWT nor XSUAA, identity or destination service binding. Destination is registered without tenant information.'

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
@@ -63,7 +63,7 @@ export async function registerDestination(
 
 function getJwtForCaching(options: RegisterDestinationOptions | undefined) {
   const jwt = decodeOrMakeJwt(options?.jwt);
-  if (!getTenantId(jwt?.zid)) {
+  if (!getTenantId(jwt)) {
     if (options?.jwt) {
       logger.error(
         'Could not determine tenant from JWT nor XSUAA, identity or destination service binding. Destination is registered without tenant information.'

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
@@ -1,5 +1,10 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import { decodeJwt, decodeOrMakeJwt, defaultTenantId, getTenantId } from '../jwt';
+import {
+  decodeJwt,
+  decodeOrMakeJwt,
+  defaultTenantId,
+  getTenantId
+} from '../jwt';
 import { DestinationFetchOptions } from './destination-accessor-types';
 import {
   IsolationStrategy,

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
@@ -65,7 +65,7 @@ function getJwtForCaching(options: RegisterDestinationOptions | undefined) {
   const jwt = decodeOrMakeJwt(options?.jwt);
   if (!getTenantId(jwt)) {
     if (options?.jwt) {
-      logger.error(
+      throw Error(
         'Could not determine tenant from JWT nor XSUAA, identity or destination service binding. Destination is registered without tenant information.'
       );
     } else {


### PR DESCRIPTION
Currently, for IAS tokens we do not read the correct key for the tenant, when registering destinations.