### PR TITLE
chore: Add schemaprefix option

### DIFF
--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -264,7 +264,10 @@ async function generateService(
   const parsedOpenApiDocument = await parseOpenApiDocument(
     openApiDocument,
     serviceOptions,
-    { strictNaming: !options.skipValidation }
+    {
+      strictNaming: !options.skipValidation,
+      schemaPrefix: options.schemaPrefix
+    }
   );
 
   const serviceDir = resolve(options.outputDir, serviceOptions.directoryName);

--- a/packages/openapi-generator/src/options/generator-options.spec.ts
+++ b/packages/openapi-generator/src/options/generator-options.spec.ts
@@ -37,7 +37,8 @@ describe('parseGeneratorOptions', () => {
     verbose: false,
     overwrite: false,
     config: undefined,
-    generateESM: false
+    generateESM: false,
+    schemaPrefix: ''
   };
 
   it('gets default options', () => {

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -19,7 +19,7 @@ export interface OpenAPIGeneratorOptions {
    * Whether to generate ECMAScript modules instead of CommonJS modules.
    */
   generateESM?: boolean;
-    /**
+  /**
    * Prefix all schema names with a value.
    * @experimental
    */

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -19,6 +19,11 @@ export interface OpenAPIGeneratorOptions {
    * Whether to generate ECMAScript modules instead of CommonJS modules.
    */
   generateESM?: boolean;
+    /**
+   * Prefix all schema names with a value.
+   * @experimental
+   */
+  schemaPrefix?: string;
 }
 
 /**
@@ -37,5 +42,12 @@ export const cliOptions = {
       'When enabled, all generated files follow the ECMAScript module syntax.',
     type: 'boolean',
     default: false
+  },
+  schemaPrefix: {
+    describe:
+      'Prefix all schema names with a value. This is useful to avoid naming conflicts when multiple services are generated.',
+    type: 'string',
+    default: '',
+    hidden: true
   }
 } as const satisfies Options<GeneratorOptions>;

--- a/packages/openapi-generator/src/parser/api.spec.ts
+++ b/packages/openapi-generator/src/parser/api.spec.ts
@@ -4,7 +4,7 @@ import { apiNameExtension } from '../extensions';
 import { parseApis } from './api';
 import { createRefs } from './refs';
 
-const options = { strictNaming: true };
+const options = { strictNaming: true, schemaPrefix: '' };
 describe('parseApis', () => {
   it('throws an error if there are APIs without paths', async () => {
     const refs = await createTestRefs();

--- a/packages/openapi-generator/src/parser/document.spec.ts
+++ b/packages/openapi-generator/src/parser/document.spec.ts
@@ -54,9 +54,7 @@ describe('parseOpenApiDocument', () => {
         packageName: '@sap/cloud-sdk-openapi-test-service',
         directoryName: 'test-service'
       },
-      { strictNaming: false,
-         schemaPrefix: ''
-       }
+      { strictNaming: false, schemaPrefix: '' }
     );
 
     expect(parsedDocument.schemas).toEqual([
@@ -123,9 +121,7 @@ describe('parseOpenApiDocument', () => {
         packageName: '@sap/cloud-sdk-openapi-test-service',
         directoryName: 'test-service'
       },
-      { strictNaming: false,
-         schemaPrefix: ''
-       }
+      { strictNaming: false, schemaPrefix: '' }
     );
 
     expect(parsedDocument.schemas).toEqual([

--- a/packages/openapi-generator/src/parser/document.spec.ts
+++ b/packages/openapi-generator/src/parser/document.spec.ts
@@ -4,7 +4,7 @@ import { emptyDocument } from '../../test/test-util';
 import { parseOpenApiDocument } from './document';
 import * as api from './api';
 
-const options = { strictNaming: true };
+const options = { strictNaming: true, schemaPrefix: '' };
 describe('parseOpenApiDocument', () => {
   it('does not modify input service specification', () => {
     const input: OpenAPIV3.Document = {
@@ -54,7 +54,9 @@ describe('parseOpenApiDocument', () => {
         packageName: '@sap/cloud-sdk-openapi-test-service',
         directoryName: 'test-service'
       },
-      { strictNaming: false }
+      { strictNaming: false,
+         schemaPrefix: ''
+       }
     );
 
     expect(parsedDocument.schemas).toEqual([
@@ -121,7 +123,9 @@ describe('parseOpenApiDocument', () => {
         packageName: '@sap/cloud-sdk-openapi-test-service',
         directoryName: 'test-service'
       },
-      { strictNaming: false }
+      { strictNaming: false,
+         schemaPrefix: ''
+       }
     );
 
     expect(parsedDocument.schemas).toEqual([

--- a/packages/openapi-generator/src/parser/media-type.spec.ts
+++ b/packages/openapi-generator/src/parser/media-type.spec.ts
@@ -1,7 +1,7 @@
 import { createTestRefs, emptyObjectSchema } from '../../test/test-util';
 import { parseTopLevelMediaType, parseMediaType } from './media-type';
 
-const defaultOptions = { strictNaming: true };
+const defaultOptions = { strictNaming: true, schemaPrefix: '' };
 describe('parseTopLevelMediaType', () => {
   it('returns undefined if the media type is not supported', async () => {
     expect(

--- a/packages/openapi-generator/src/parser/operation.spec.ts
+++ b/packages/openapi-generator/src/parser/operation.spec.ts
@@ -8,7 +8,7 @@ import {
   parsePathPattern
 } from './operation';
 
-const defaultOptions = { strictNaming: true };
+const defaultOptions = { strictNaming: true,  schemaPrefix: '' };
 describe('getRelevantParameters', () => {
   it('ignores cookie parameters', async () => {
     expect(
@@ -110,7 +110,7 @@ describe('parsePathParameters', () => {
   it('returns empty arrays if there are no parameters', async () => {
     expect(
       parsePathParameters([], await createTestRefs(), {
-        strictNaming: false
+        strictNaming: false,  schemaPrefix: ''
       })
     ).toEqual([]);
   });
@@ -129,7 +129,7 @@ describe('parsePathParameters', () => {
     };
     expect(
       parsePathParameters([pathParam1, pathParam2], refs, {
-        strictNaming: false
+        strictNaming: false,  schemaPrefix: ''
       })
     ).toEqual([
       { ...pathParam1, originalName: 'param1', schemaProperties: {} },

--- a/packages/openapi-generator/src/parser/operation.spec.ts
+++ b/packages/openapi-generator/src/parser/operation.spec.ts
@@ -8,7 +8,7 @@ import {
   parsePathPattern
 } from './operation';
 
-const defaultOptions = { strictNaming: true,  schemaPrefix: '' };
+const defaultOptions = { strictNaming: true, schemaPrefix: '' };
 describe('getRelevantParameters', () => {
   it('ignores cookie parameters', async () => {
     expect(
@@ -110,7 +110,8 @@ describe('parsePathParameters', () => {
   it('returns empty arrays if there are no parameters', async () => {
     expect(
       parsePathParameters([], await createTestRefs(), {
-        strictNaming: false,  schemaPrefix: ''
+        strictNaming: false,
+        schemaPrefix: ''
       })
     ).toEqual([]);
   });
@@ -129,7 +130,8 @@ describe('parsePathParameters', () => {
     };
     expect(
       parsePathParameters([pathParam1, pathParam2], refs, {
-        strictNaming: false,  schemaPrefix: ''
+        strictNaming: false,
+        schemaPrefix: ''
       })
     ).toEqual([
       { ...pathParam1, originalName: 'param1', schemaProperties: {} },

--- a/packages/openapi-generator/src/parser/options.ts
+++ b/packages/openapi-generator/src/parser/options.ts
@@ -7,8 +7,8 @@ export interface ParserOptions {
    * Fail parsing on conflicting names.
    */
   strictNaming: boolean;
-   /**
+  /**
    * Add prefix to schema names.
    */
-   schemaPrefix: string;
+  schemaPrefix: string;
 }

--- a/packages/openapi-generator/src/parser/options.ts
+++ b/packages/openapi-generator/src/parser/options.ts
@@ -7,4 +7,8 @@ export interface ParserOptions {
    * Fail parsing on conflicting names.
    */
   strictNaming: boolean;
+   /**
+   * Add prefix to schema names.
+   */
+   schemaPrefix: string;
 }

--- a/packages/openapi-generator/src/parser/refs.spec.ts
+++ b/packages/openapi-generator/src/parser/refs.spec.ts
@@ -10,7 +10,7 @@ describe('OpenApiDocumentRefs', () => {
         ...emptyDocument,
         components: { schemas: { typeName } }
       },
-      { strictNaming: true,  schemaPrefix: '' }
+      { strictNaming: true, schemaPrefix: '' }
     );
   });
 
@@ -85,7 +85,7 @@ describe('OpenApiDocumentRefs', () => {
           ...emptyDocument,
           components: { schemas: { '123456': {}, 'something.Else%': {} } }
         },
-        { strictNaming: false,  schemaPrefix: '' }
+        { strictNaming: false, schemaPrefix: '' }
       );
       expect(refs.getSchemaNaming('#/components/schemas/123456')).toEqual({
         fileName: 'schema-123456',
@@ -108,7 +108,7 @@ describe('OpenApiDocumentRefs', () => {
             schemas: { '123456': {}, schema123456: {}, schema12345_6: {} }
           }
         },
-        { strictNaming: false,  schemaPrefix: '' }
+        { strictNaming: false, schemaPrefix: '' }
       );
       expect(refs.getSchemaNaming('#/components/schemas/123456')).toEqual({
         fileName: 'schema-123456',
@@ -138,7 +138,7 @@ describe('OpenApiDocumentRefs', () => {
             ...emptyDocument,
             components: { schemas: { '123456': {} } }
           },
-          { strictNaming: true,  schemaPrefix: '' }
+          { strictNaming: true, schemaPrefix: '' }
         )
       ).rejects.toThrowError(
         'The service specification contains invalid schema names.'
@@ -151,7 +151,7 @@ describe('OpenApiDocumentRefs', () => {
           ...emptyDocument,
           components: { schemas: { name: {}, Name: {} } }
         },
-        { strictNaming: false,  schemaPrefix: '' }
+        { strictNaming: false, schemaPrefix: '' }
       );
       expect(refs.getSchemaNaming('#/components/schemas/name')).toEqual({
         fileName: 'name-1',
@@ -170,7 +170,7 @@ describe('OpenApiDocumentRefs', () => {
           ...emptyDocument,
           components: { schemas: { name400: {}, Name400: {} } }
         },
-        { strictNaming: false,  schemaPrefix: '' }
+        { strictNaming: false, schemaPrefix: '' }
       );
       expect(refs.getSchemaNaming('#/components/schemas/name400')).toEqual({
         fileName: 'name-400-1',

--- a/packages/openapi-generator/src/parser/refs.spec.ts
+++ b/packages/openapi-generator/src/parser/refs.spec.ts
@@ -10,7 +10,7 @@ describe('OpenApiDocumentRefs', () => {
         ...emptyDocument,
         components: { schemas: { typeName } }
       },
-      { strictNaming: true }
+      { strictNaming: true,  schemaPrefix: '' }
     );
   });
 
@@ -60,13 +60,32 @@ describe('OpenApiDocumentRefs', () => {
       );
     });
 
+    it('gets the schema naming for reference object with a prefix', async () => {
+      refs = await createRefs(
+        {
+          ...emptyDocument,
+          components: { schemas: { typeName } }
+        },
+        { strictNaming: true, schemaPrefix: 'xyz' }
+      );
+
+      expect(
+        refs.getSchemaNaming({
+          $ref: '#/components/schemas/typeName'
+        })
+      ).toEqual({
+        schemaName: 'XyzTypeName',
+        fileName: 'type-name'
+      });
+    });
+
     it('renames a schema if needed due to illegal names', async () => {
       refs = await createRefs(
         {
           ...emptyDocument,
           components: { schemas: { '123456': {}, 'something.Else%': {} } }
         },
-        { strictNaming: false }
+        { strictNaming: false,  schemaPrefix: '' }
       );
       expect(refs.getSchemaNaming('#/components/schemas/123456')).toEqual({
         fileName: 'schema-123456',
@@ -89,7 +108,7 @@ describe('OpenApiDocumentRefs', () => {
             schemas: { '123456': {}, schema123456: {}, schema12345_6: {} }
           }
         },
-        { strictNaming: false }
+        { strictNaming: false,  schemaPrefix: '' }
       );
       expect(refs.getSchemaNaming('#/components/schemas/123456')).toEqual({
         fileName: 'schema-123456',
@@ -119,7 +138,7 @@ describe('OpenApiDocumentRefs', () => {
             ...emptyDocument,
             components: { schemas: { '123456': {} } }
           },
-          { strictNaming: true }
+          { strictNaming: true,  schemaPrefix: '' }
         )
       ).rejects.toThrowError(
         'The service specification contains invalid schema names.'
@@ -132,7 +151,7 @@ describe('OpenApiDocumentRefs', () => {
           ...emptyDocument,
           components: { schemas: { name: {}, Name: {} } }
         },
-        { strictNaming: false }
+        { strictNaming: false,  schemaPrefix: '' }
       );
       expect(refs.getSchemaNaming('#/components/schemas/name')).toEqual({
         fileName: 'name-1',
@@ -151,7 +170,7 @@ describe('OpenApiDocumentRefs', () => {
           ...emptyDocument,
           components: { schemas: { name400: {}, Name400: {} } }
         },
-        { strictNaming: false }
+        { strictNaming: false,  schemaPrefix: '' }
       );
       expect(refs.getSchemaNaming('#/components/schemas/name400')).toEqual({
         fileName: 'name-400-1',

--- a/packages/openapi-generator/src/parser/refs.ts
+++ b/packages/openapi-generator/src/parser/refs.ts
@@ -72,7 +72,7 @@ export class OpenApiDocumentRefs {
       (mapping, originalName, i) => ({
         ...mapping,
         [`#/components/schemas/${originalName}`]: {
-          schemaName: schemaNames[i],
+          schemaName: pascalCase(options.schemaPrefix ?? '') + schemaNames[i],
           fileName: fileNames[i]
         }
       }),

--- a/packages/openapi-generator/src/parser/refs.ts
+++ b/packages/openapi-generator/src/parser/refs.ts
@@ -72,7 +72,7 @@ export class OpenApiDocumentRefs {
       (mapping, originalName, i) => ({
         ...mapping,
         [`#/components/schemas/${originalName}`]: {
-          schemaName: pascalCase(options.schemaPrefix ?? '') + schemaNames[i],
+          schemaName: pascalCase(options.schemaPrefix) + schemaNames[i],
           fileName: fileNames[i]
         }
       }),

--- a/packages/openapi-generator/src/parser/request-body.spec.ts
+++ b/packages/openapi-generator/src/parser/request-body.spec.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@sap-cloud-sdk/util';
 import { createTestRefs } from '../../test/test-util';
 import { parseRequestBody } from './request-body';
 
-const defaultOptions = { strictNaming: true };
+const defaultOptions = { strictNaming: true,  schemaPrefix: '' };
 describe('getRequestBody', () => {
   it('returns undefined for undefined', async () => {
     const logger = createLogger('openapi-generator');

--- a/packages/openapi-generator/src/parser/request-body.spec.ts
+++ b/packages/openapi-generator/src/parser/request-body.spec.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@sap-cloud-sdk/util';
 import { createTestRefs } from '../../test/test-util';
 import { parseRequestBody } from './request-body';
 
-const defaultOptions = { strictNaming: true,  schemaPrefix: '' };
+const defaultOptions = { strictNaming: true, schemaPrefix: '' };
 describe('getRequestBody', () => {
   it('returns undefined for undefined', async () => {
     const logger = createLogger('openapi-generator');

--- a/packages/openapi-generator/src/parser/responses.spec.ts
+++ b/packages/openapi-generator/src/parser/responses.spec.ts
@@ -1,7 +1,7 @@
 import { createTestRefs } from '../../test/test-util';
 import { parseResponses } from './responses';
 
-const defaultOptions = { strictNaming: true,  schemaPrefix: '' };
+const defaultOptions = { strictNaming: true, schemaPrefix: '' };
 describe('parseResponses', () => {
   it('parses response schema without content', async () => {
     expect(

--- a/packages/openapi-generator/src/parser/responses.spec.ts
+++ b/packages/openapi-generator/src/parser/responses.spec.ts
@@ -1,7 +1,7 @@
 import { createTestRefs } from '../../test/test-util';
 import { parseResponses } from './responses';
 
-const defaultOptions = { strictNaming: true };
+const defaultOptions = { strictNaming: true,  schemaPrefix: '' };
 describe('parseResponses', () => {
   it('parses response schema without content', async () => {
     expect(

--- a/packages/openapi-generator/src/parser/schema-naming.spec.ts
+++ b/packages/openapi-generator/src/parser/schema-naming.spec.ts
@@ -3,20 +3,20 @@ import { ensureValidSchemaNames } from './schema-naming';
 describe('schema-naming', () => {
   it('adds prefix if schema starts with integer', () => {
     expect(
-      ensureValidSchemaNames(['1234ABC'], { strictNaming: false })
+      ensureValidSchemaNames(['1234ABC'], { strictNaming: false,  schemaPrefix: '' })
     ).toEqual(['schema1234ABC']);
   });
 
   it('removes special character', () => {
     expect(
-      ensureValidSchemaNames(['#som%eth.ing'], { strictNaming: false })
+      ensureValidSchemaNames(['#som%eth.ing'], { strictNaming: false,  schemaPrefix: '' })
     ).toEqual(['something']);
   });
 
   it('throws if the strict naming is on', () => {
     expect(() =>
       ensureValidSchemaNames(['1234ABC', '#som%eth.ing'], {
-        strictNaming: true
+        strictNaming: true,  schemaPrefix: ''
       })
     ).toThrowErrorMatchingInlineSnapshot(`
       "The service specification contains invalid schema names. Adjust the definition file or enable automatic name adjustment with \`skipValidation\`.

--- a/packages/openapi-generator/src/parser/schema-naming.spec.ts
+++ b/packages/openapi-generator/src/parser/schema-naming.spec.ts
@@ -3,20 +3,27 @@ import { ensureValidSchemaNames } from './schema-naming';
 describe('schema-naming', () => {
   it('adds prefix if schema starts with integer', () => {
     expect(
-      ensureValidSchemaNames(['1234ABC'], { strictNaming: false,  schemaPrefix: '' })
+      ensureValidSchemaNames(['1234ABC'], {
+        strictNaming: false,
+        schemaPrefix: ''
+      })
     ).toEqual(['schema1234ABC']);
   });
 
   it('removes special character', () => {
     expect(
-      ensureValidSchemaNames(['#som%eth.ing'], { strictNaming: false,  schemaPrefix: '' })
+      ensureValidSchemaNames(['#som%eth.ing'], {
+        strictNaming: false,
+        schemaPrefix: ''
+      })
     ).toEqual(['something']);
   });
 
   it('throws if the strict naming is on', () => {
     expect(() =>
       ensureValidSchemaNames(['1234ABC', '#som%eth.ing'], {
-        strictNaming: true,  schemaPrefix: ''
+        strictNaming: true,
+        schemaPrefix: ''
       })
     ).toThrowErrorMatchingInlineSnapshot(`
       "The service specification contains invalid schema names. Adjust the definition file or enable automatic name adjustment with \`skipValidation\`.

--- a/packages/openapi-generator/src/parser/schema.spec.ts
+++ b/packages/openapi-generator/src/parser/schema.spec.ts
@@ -5,7 +5,7 @@ import { OpenApiObjectSchema } from '../openapi-types';
 import { parseSchema, parseSchemaProperties } from './schema';
 
 describe('parseSchema', () => {
-  const defaultOptions = { strictNaming: true };
+  const defaultOptions = { strictNaming: true, schemaPrefix: '' };
 
   it('parses reference schema', async () => {
     const schema = { $ref: '#/components/schemas/test' };
@@ -320,7 +320,7 @@ describe('parseSchema', () => {
       enum: [1, 2, 3, null],
       type: 'string'
     };
-    parseSchema(schema, await createTestRefs(), { strictNaming: false });
+    parseSchema(schema, await createTestRefs(), { strictNaming: false, schemaPrefix: '' });
     expect(logger.warn).toHaveBeenCalledWith(
       'null was used as a parameter in an enum, although the schema was not declared as nullable'
     );

--- a/packages/openapi-generator/src/parser/schema.spec.ts
+++ b/packages/openapi-generator/src/parser/schema.spec.ts
@@ -320,7 +320,10 @@ describe('parseSchema', () => {
       enum: [1, 2, 3, null],
       type: 'string'
     };
-    parseSchema(schema, await createTestRefs(), { strictNaming: false, schemaPrefix: '' });
+    parseSchema(schema, await createTestRefs(), {
+      strictNaming: false,
+      schemaPrefix: ''
+    });
     expect(logger.warn).toHaveBeenCalledWith(
       'null was used as a parameter in an enum, although the schema was not declared as nullable'
     );

--- a/packages/openapi-generator/src/parser/unique-naming.spec.ts
+++ b/packages/openapi-generator/src/parser/unique-naming.spec.ts
@@ -3,7 +3,7 @@ import { ensureUniqueNames } from './unique-naming';
 
 describe('ensureUniqueNames', () => {
   describe('with strictNaming enabled', () => {
-    const options = { strictNaming: true };
+    const options = { strictNaming: true,  schemaPrefix: '' };
     it('does not throw for empty list of names', () => {
       expect(() => ensureUniqueNames([], options)).not.toThrow();
     });
@@ -67,7 +67,7 @@ describe('ensureUniqueNames', () => {
   });
 
   describe('with strictNaming disabled', () => {
-    const options = { strictNaming: false };
+    const options = { strictNaming: false, schemaPrefix: '' };
 
     it('replaces duplicate names using defaults', () => {
       expect(ensureUniqueNames(['duplicate', 'duplicate'], options)).toEqual([

--- a/packages/openapi-generator/src/parser/unique-naming.spec.ts
+++ b/packages/openapi-generator/src/parser/unique-naming.spec.ts
@@ -3,7 +3,7 @@ import { ensureUniqueNames } from './unique-naming';
 
 describe('ensureUniqueNames', () => {
   describe('with strictNaming enabled', () => {
-    const options = { strictNaming: true,  schemaPrefix: '' };
+    const options = { strictNaming: true, schemaPrefix: '' };
     it('does not throw for empty list of names', () => {
       expect(() => ensureUniqueNames([], options)).not.toThrow();
     });

--- a/packages/openapi-generator/test/test-util.ts
+++ b/packages/openapi-generator/test/test-util.ts
@@ -11,7 +11,10 @@ export const emptyDocument = {
 export function createTestRefs(
   components: OpenAPIV3.ComponentsObject = {}
 ): Promise<OpenApiDocumentRefs> {
-  return createRefs({ ...emptyDocument, components }, { strictNaming: true,  schemaPrefix: '' });
+  return createRefs(
+    { ...emptyDocument, components },
+    { strictNaming: true, schemaPrefix: '' }
+  );
 }
 
 export const emptyObjectSchema = {

--- a/packages/openapi-generator/test/test-util.ts
+++ b/packages/openapi-generator/test/test-util.ts
@@ -11,7 +11,7 @@ export const emptyDocument = {
 export function createTestRefs(
   components: OpenAPIV3.ComponentsObject = {}
 ): Promise<OpenApiDocumentRefs> {
-  return createRefs({ ...emptyDocument, components }, { strictNaming: true });
+  return createRefs({ ...emptyDocument, components }, { strictNaming: true,  schemaPrefix: '' });
 }
 
 export const emptyObjectSchema = {


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

This PR adds new option `schemaPrefix` for openapi generator. Its primarily for internal usage by us for the ai sdk

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
