### PR TITLE
feat: initial implementation for discriminator

### DIFF
--- a/packages/openapi-generator/src/file-serializer/schema.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/schema.spec.ts
@@ -206,6 +206,34 @@ describe('serializeSchema for xOf schemas', () => {
     ).toEqual('XOr1 | XOr2');
   });
 
+  it('serializes array schema for oneOf with discriminator', () => {
+    const oneOf = [
+      {
+        $ref: '#/components/schemas/XOr1',
+        schemaName: 'XOr1',
+        fileName: 'x-or-1'
+      },
+      {
+        $ref: '#/components/schemas/XOr2',
+        schemaName: 'XOr2',
+        fileName: 'x-or-2'
+      }
+    ];
+
+    expect(
+      serializeSchema({
+        oneOf,
+        discriminator: {
+          propertyName: 'discr',
+          mapping: {
+            a: oneOf[0],
+            b: oneOf[1]
+          }
+        }
+      })
+    ).toEqual("({ discr: 'a' } & XOr1) | ({ discr: 'b' } & XOr2)");
+  });
+
   it('serializes array schema for anyOf', () => {
     expect(
       serializeSchema({
@@ -223,6 +251,36 @@ describe('serializeSchema for xOf schemas', () => {
         ]
       })
     ).toEqual('InclusiveOr1 | InclusiveOr2');
+  });
+
+  it('serializes array schema for anyOfOf with discriminator', () => {
+    const anyOf = [
+      {
+        $ref: '#/components/schemas/InclusiveOr1',
+        schemaName: 'InclusiveOr1',
+        fileName: 'inclusive-or-1'
+      },
+      {
+        $ref: '#/components/schemas/InclusiveOr2',
+        schemaName: 'InclusiveOr2',
+        fileName: 'inclusive-or-2'
+      }
+    ];
+
+    expect(
+      serializeSchema({
+        anyOf,
+        discriminator: {
+          propertyName: 'discr',
+          mapping: {
+            a: anyOf[0],
+            b: anyOf[1]
+          }
+        }
+      })
+    ).toEqual(
+      "({ discr: 'a' } & InclusiveOr1) | ({ discr: 'b' } & InclusiveOr2)"
+    );
   });
 
   it('serializes array schema for allOf', () => {

--- a/packages/openapi-generator/src/file-serializer/schema.ts
+++ b/packages/openapi-generator/src/file-serializer/schema.ts
@@ -2,7 +2,9 @@ import { codeBlock, documentationBlock, unixEOL } from '@sap-cloud-sdk/util';
 import {
   OpenApiSchema,
   OpenApiObjectSchema,
-  OpenApiObjectSchemaProperty
+  OpenApiObjectSchemaProperty,
+  OpenApiOneOfSchema,
+  OpenApiAnyOfSchema
 } from '../openapi-types';
 import { getType } from '../parser/type-mapping';
 import {
@@ -48,6 +50,10 @@ export function serializeSchema(schema: OpenApiSchema): string {
   }
 
   if (isOneOfSchema(schema)) {
+    if (schema.discriminator) {
+      return serializeXOfSchemaWithDiscriminator(schema);
+    }
+
     return schema.oneOf.map(type => serializeSchema(type)).join(' | ');
   }
 
@@ -56,6 +62,9 @@ export function serializeSchema(schema: OpenApiSchema): string {
   }
 
   if (isAnyOfSchema(schema)) {
+    if (schema.discriminator) {
+      return serializeXOfSchemaWithDiscriminator(schema);
+    }
     return schema.anyOf.map(type => serializeSchema(type)).join(' | ');
   }
 
@@ -137,4 +146,23 @@ export function schemaPropertyDocumentation(
   signature.push(...getSchemaPropertiesDocumentation(schema.schemaProperties));
 
   return documentationBlock`${signature.join(unixEOL)}`;
+}
+
+function serializeXOfSchemaWithDiscriminator(
+  schema: OpenApiOneOfSchema | OpenApiAnyOfSchema
+) {
+  const { discriminator } = schema;
+
+  if (!discriminator) {
+    throw new Error(
+      'Could not serialize discriminator schema without discriminator.'
+    );
+  }
+
+  return Object.entries(discriminator.mapping)
+    .map(
+      ([propertyValue, mappedSchema]) =>
+        `({ ${discriminator.propertyName}: '${propertyValue}' } & ${serializeSchema(mappedSchema)})`
+    )
+    .join(' | ');
 }

--- a/packages/openapi-generator/src/openapi-types.ts
+++ b/packages/openapi-generator/src/openapi-types.ts
@@ -290,6 +290,17 @@ export interface OpenApiObjectSchema {
 }
 
 /**
+ * TODO: document.
+ */
+export type OpenApiDiscriminator = Omit<
+  OpenAPIV3.DiscriminatorObject,
+  'mapping'
+> & {
+  // originalRef: string;
+  mapping: Record<string, OpenApiReferenceSchema>;
+};
+
+/**
  * Represents a type where one of the given schemas can be chosen exclusively.
  * @internal
  */
@@ -298,6 +309,10 @@ export interface OpenApiOneOfSchema {
    * Represents the schemas to chose from.
    */
   oneOf: OpenApiSchema[];
+  /**
+   * TODO: document.
+   */
+  discriminator?: OpenApiDiscriminator;
 }
 
 /**
@@ -320,6 +335,10 @@ export interface OpenApiAnyOfSchema {
    * Represents the schemas to chose from.
    */
   anyOf: OpenApiSchema[];
+  /**
+   * TODO: document.
+   */
+  discriminator?: OpenApiDiscriminator;
 }
 
 /**

--- a/packages/openapi-generator/src/parser/schema.spec.ts
+++ b/packages/openapi-generator/src/parser/schema.spec.ts
@@ -4,122 +4,128 @@ import { createTestRefs, emptyObjectSchema } from '../../test/test-util';
 import { OpenApiObjectSchema } from '../openapi-types';
 import { parseSchema, parseSchemaProperties } from './schema';
 
-describe('parseSchema', () => {
-  const defaultOptions = { strictNaming: true, schemaPrefix: '' };
+describe('schema parser', () => {
+  describe('parseSchema()', () => {
+    const defaultOptions = { strictNaming: true, schemaPrefix: '' };
 
-  it('parses reference schema', async () => {
-    const schema = { $ref: '#/components/schemas/test' };
-    expect(
-      parseSchema(
-        schema,
-        await createTestRefs({ schemas: { test: { type: 'string' } } }),
-        defaultOptions
-      )
-    ).toEqual({
-      ...schema,
-      schemaName: 'Test',
-      fileName: 'test'
+    it('parses reference schema', async () => {
+      const schema = { $ref: '#/components/schemas/test' };
+      expect(
+        parseSchema(
+          schema,
+          await createTestRefs({ schemas: { test: { type: 'string' } } }),
+          defaultOptions
+        )
+      ).toEqual({
+        ...schema,
+        schemaName: 'Test',
+        fileName: 'test'
+      });
     });
-  });
 
-  it('parses simple schema', async () => {
-    const schema: OpenAPIV3.SchemaObject = { type: 'string' };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      schema
-    );
-  });
+    it('parses simple schema', async () => {
+      const schema: OpenAPIV3.SchemaObject = { type: 'string' };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual(schema);
+    });
 
-  it('parses simple schema with description', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      type: 'object',
-      properties: { prop1: { description: 'My Description', type: 'string' } }
-    };
-    expect(
-      (
-        parseSchema(
-          schema,
-          await createTestRefs(),
-          defaultOptions
-        ) as OpenApiObjectSchema
-      ).properties[0].description
-    ).toBe('My Description');
-  });
+    it('parses simple schema with description', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: 'object',
+        properties: { prop1: { description: 'My Description', type: 'string' } }
+      };
+      expect(
+        (
+          parseSchema(
+            schema,
+            await createTestRefs(),
+            defaultOptions
+          ) as OpenApiObjectSchema
+        ).properties[0].description
+      ).toBe('My Description');
+    });
 
-  it('parses simple schema with nullable property', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      type: 'object',
-      properties: {
-        prop1: { description: 'My Description', type: 'string', nullable: true }
-      }
-    };
-    expect(
-      (
-        parseSchema(
-          schema,
-          await createTestRefs(),
-          defaultOptions
-        ) as OpenApiObjectSchema
-      ).properties[0].nullable
-    ).toBe(true);
-  });
-
-  it('parses array schema', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      type: 'array',
-      items: { type: 'string' }
-    };
-
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
-        items: { type: 'string' }
-      }
-    );
-  });
-
-  it('parses array schema with unique items', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      type: 'array',
-      uniqueItems: true,
-      items: { type: 'string' }
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
-        uniqueItems: true,
-        items: { type: 'string' }
-      }
-    );
-  });
-
-  it('parses array schema with nested object schema', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      type: 'array',
-      uniqueItems: true,
-      items: { type: 'object' }
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
-        uniqueItems: true,
-        items: emptyObjectSchema
-      }
-    );
-  });
-
-  it('parses object schema with nested object schema with additional properties', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      required: ['simpleProperty'],
-      properties: {
-        simpleProperty: {
-          type: 'string'
-        },
-        nestedObjectProperty: {
-          additionalProperties: {
-            properties: { simpleProperty: { type: 'string' } }
+    it('parses simple schema with nullable property', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: 'object',
+        properties: {
+          prop1: {
+            description: 'My Description',
+            type: 'string',
+            nullable: true
           }
         }
-      }
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
+      };
+      expect(
+        (
+          parseSchema(
+            schema,
+            await createTestRefs(),
+            defaultOptions
+          ) as OpenApiObjectSchema
+        ).properties[0].nullable
+      ).toBe(true);
+    });
+
+    it('parses array schema', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: 'array',
+        items: { type: 'string' }
+      };
+
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
+        items: { type: 'string' }
+      });
+    });
+
+    it('parses array schema with unique items', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: 'array',
+        uniqueItems: true,
+        items: { type: 'string' }
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
+        uniqueItems: true,
+        items: { type: 'string' }
+      });
+    });
+
+    it('parses array schema with nested object schema', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: 'array',
+        uniqueItems: true,
+        items: { type: 'object' }
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
+        uniqueItems: true,
+        items: emptyObjectSchema
+      });
+    });
+
+    it('parses object schema with nested object schema with additional properties', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        required: ['simpleProperty'],
+        properties: {
+          simpleProperty: {
+            type: 'string'
+          },
+          nestedObjectProperty: {
+            additionalProperties: {
+              properties: { simpleProperty: { type: 'string' } }
+            }
+          }
+        }
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
         properties: [
           {
             name: 'simpleProperty',
@@ -158,26 +164,26 @@ describe('parseSchema', () => {
           }
         ],
         additionalProperties: { type: 'any' }
-      }
-    );
-  });
+      });
+    });
 
-  it('parses object schema with schema properties', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      required: ['simpleProperty'],
-      properties: {
-        simpleProperty: {
-          type: 'string',
-          deprecated: true,
-          example: 'test',
-          maxLength: 10,
-          default: 'testString',
-          nullable: false
+    it('parses object schema with schema properties', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        required: ['simpleProperty'],
+        properties: {
+          simpleProperty: {
+            type: 'string',
+            deprecated: true,
+            example: 'test',
+            maxLength: 10,
+            default: 'testString',
+            nullable: false
+          }
         }
-      }
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
         properties: [
           {
             name: 'simpleProperty',
@@ -196,213 +202,213 @@ describe('parseSchema', () => {
           }
         ],
         additionalProperties: { type: 'any' }
-      }
-    );
-  });
-
-  it('parses object schema with referenced property description as undefined', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      description: 'Object Description',
-      type: 'object',
-      properties: {
-        prop: {
-          $ref: '#/components/schemas/PropertySchema'
-        }
-      }
-    };
-    expect(
-      (
-        parseSchema(
-          schema,
-          await createTestRefs({
-            schemas: { PropertySchema: { type: 'string' } }
-          }),
-          defaultOptions
-        ) as OpenApiObjectSchema
-      ).properties[0].description
-    ).toBeUndefined();
-  });
-
-  it('parses object schema with inline property description', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      description: 'Object Description',
-      type: 'object',
-      properties: {
-        prop: {
-          description: 'Property Description',
-          type: 'string'
-        }
-      }
-    };
-
-    expect(
-      (
-        parseSchema(
-          schema,
-          await createTestRefs({
-            schemas: { PropertySchema: { type: 'string' } }
-          }),
-          defaultOptions
-        ) as OpenApiObjectSchema
-      ).properties[0].description
-    ).toEqual('Property Description');
-  });
-
-  it('parses schema properties and ignores unknown and undefined properties', () => {
-    const schemaProperties = {
-      deprecated: true,
-      example: 100,
-      minimum: 10,
-      maximum: 1000,
-      default: 10,
-      maxLength: undefined,
-      minLength: undefined,
-      format: undefined,
-      unknownProperty: undefined
-    };
-    expect(parseSchemaProperties(schemaProperties)).toEqual({
-      deprecated: true,
-      example: 100,
-      minimum: 10,
-      maximum: 1000,
-      default: 10
+      });
     });
-  });
 
-  it('throws an error if there are neither properties nor additional properties', async () => {
-    const refs = await createTestRefs();
-    expect(() =>
-      parseSchema(
-        {
-          type: 'object',
-          additionalProperties: false,
-          properties: {}
-        },
-        refs,
-        defaultOptions
-      )
-    ).toThrowErrorMatchingInlineSnapshot(
-      '"Could not parse object schema without neither properties nor additional properties."'
-    );
-  });
+    it('parses object schema with referenced property description as undefined', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        description: 'Object Description',
+        type: 'object',
+        properties: {
+          prop: {
+            $ref: '#/components/schemas/PropertySchema'
+          }
+        }
+      };
+      expect(
+        (
+          parseSchema(
+            schema,
+            await createTestRefs({
+              schemas: { PropertySchema: { type: 'string' } }
+            }),
+            defaultOptions
+          ) as OpenApiObjectSchema
+        ).properties[0].description
+      ).toBeUndefined();
+    });
 
-  it('parses enum schema', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      enum: ['1', '2', '3'],
-      type: 'number'
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      schema
-    );
-  });
+    it('parses object schema with inline property description', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        description: 'Object Description',
+        type: 'object',
+        properties: {
+          prop: {
+            description: 'Property Description',
+            type: 'string'
+          }
+        }
+      };
 
-  it('parses string enum schema', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      enum: ['one', 'two', 'three'],
-      type: 'string'
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
+      expect(
+        (
+          parseSchema(
+            schema,
+            await createTestRefs({
+              schemas: { PropertySchema: { type: 'string' } }
+            }),
+            defaultOptions
+          ) as OpenApiObjectSchema
+        ).properties[0].description
+      ).toEqual('Property Description');
+    });
+
+    it('parses schema properties and ignores unknown and undefined properties', () => {
+      const schemaProperties = {
+        deprecated: true,
+        example: 100,
+        minimum: 10,
+        maximum: 1000,
+        default: 10,
+        maxLength: undefined,
+        minLength: undefined,
+        format: undefined,
+        unknownProperty: undefined
+      };
+      expect(parseSchemaProperties(schemaProperties)).toEqual({
+        deprecated: true,
+        example: 100,
+        minimum: 10,
+        maximum: 1000,
+        default: 10
+      });
+    });
+
+    it('throws an error if there are neither properties nor additional properties', async () => {
+      const refs = await createTestRefs();
+      expect(() =>
+        parseSchema(
+          {
+            type: 'object',
+            additionalProperties: false,
+            properties: {}
+          },
+          refs,
+          defaultOptions
+        )
+      ).toThrowErrorMatchingInlineSnapshot(
+        '"Could not parse object schema without neither properties nor additional properties."'
+      );
+    });
+
+    it('parses enum schema', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        enum: ['1', '2', '3'],
+        type: 'number'
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual(schema);
+    });
+
+    it('parses string enum schema', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        enum: ['one', 'two', 'three'],
+        type: 'string'
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
         type: 'string',
         enum: ["'one'", "'two'", "'three'"]
-      }
-    );
-  });
+      });
+    });
 
-  it('parses string enum schema with integers', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      enum: [1, 2, 3],
-      type: 'string'
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
+    it('parses string enum schema with integers', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        enum: [1, 2, 3],
+        type: 'string'
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
         type: 'string',
         enum: ["'1'", "'2'", "'3'"]
-      }
-    );
-  });
+      });
+    });
 
-  it('parses string enum schema with a null value and nullable set to true', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      enum: [1, 2, 3, null],
-      type: 'string',
-      nullable: true
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
+    it('parses string enum schema with a null value and nullable set to true', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        enum: [1, 2, 3, null],
+        type: 'string',
+        nullable: true
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
         type: 'string',
         enum: ["'1'", "'2'", "'3'", null]
-      }
-    );
-  });
-
-  it('parses string enum schema with a null value, no nullable set, and skipValidation set to false', async () => {
-    const logger = createLogger('openapi-generator');
-    jest.spyOn(logger, 'warn');
-    const schema: OpenAPIV3.SchemaObject = {
-      enum: [1, 2, 3, null],
-      type: 'string'
-    };
-    parseSchema(schema, await createTestRefs(), {
-      strictNaming: false,
-      schemaPrefix: ''
+      });
     });
-    expect(logger.warn).toHaveBeenCalledWith(
-      'null was used as a parameter in an enum, although the schema was not declared as nullable'
-    );
-  });
 
-  it('parses string enum schema with a null value and no nullable set and strictNaming set to true', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      enum: [1, 2, 3, null],
-      type: 'string'
-    };
-    expect(async () => {
-      parseSchema(schema, await createTestRefs(), defaultOptions);
-    }).rejects.toThrowErrorMatchingInlineSnapshot(
-      '"null was used as a parameter in an enum, although the schema was not declared as nullable"'
-    );
-  });
+    it('parses string enum schema with a null value, no nullable set, and skipValidation set to false', async () => {
+      const logger = createLogger('openapi-generator');
+      jest.spyOn(logger, 'warn');
+      const schema: OpenAPIV3.SchemaObject = {
+        enum: [1, 2, 3, null],
+        type: 'string'
+      };
+      parseSchema(schema, await createTestRefs(), {
+        strictNaming: false,
+        schemaPrefix: ''
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        'null was used as a parameter in an enum, although the schema was not declared as nullable'
+      );
+    });
 
-  it('parses string enum schema with escaping', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      enum: ["valueWith'Quot'es"],
-      type: 'string'
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
+    it('parses string enum schema with a null value and no nullable set and strictNaming set to true', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        enum: [1, 2, 3, null],
+        type: 'string'
+      };
+      expect(async () => {
+        parseSchema(schema, await createTestRefs(), defaultOptions);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(
+        '"null was used as a parameter in an enum, although the schema was not declared as nullable"'
+      );
+    });
+
+    it('parses string enum schema with escaping', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        enum: ["valueWith'Quot'es"],
+        type: 'string'
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
         type: 'string',
         enum: ["'valueWith\\'Quot\\'es'"]
-      }
-    );
-  });
+      });
+    });
 
-  it("parses enum schema with 'string' as default", async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      enum: ['one', 'two', 'three']
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
+    it("parses enum schema with 'string' as default", async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        enum: ['one', 'two', 'three']
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
         type: 'string',
         enum: ["'one'", "'two'", "'three'"]
-      }
-    );
-  });
+      });
+    });
 
-  it('parses oneOf, anyOf, allOf schemas', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      oneOf: [
-        { type: 'object' },
-        {
-          anyOf: [
-            { type: 'object' },
-            { allOf: [{ type: 'object' }, { type: 'string' }] }
-          ]
-        }
-      ]
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
+    it('parses oneOf, anyOf, allOf schemas', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        oneOf: [
+          { type: 'object' },
+          {
+            anyOf: [
+              { type: 'object' },
+              { allOf: [{ type: 'object' }, { type: 'string' }] }
+            ]
+          }
+        ]
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
         oneOf: [
           emptyObjectSchema,
           {
@@ -412,25 +418,25 @@ describe('parseSchema', () => {
             ]
           }
         ]
-      }
-    );
-  });
+      });
+    });
 
-  it('parses xOf schema ignoring type:object at same level', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      type: 'object',
-      oneOf: [
-        { type: 'object' },
-        {
-          anyOf: [
-            { type: 'object' },
-            { allOf: [{ type: 'object' }, { type: 'string' }] }
-          ]
-        }
-      ]
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
+    it('parses xOf schema ignoring type:object at same level', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: 'object',
+        oneOf: [
+          { type: 'object' },
+          {
+            anyOf: [
+              { type: 'object' },
+              { allOf: [{ type: 'object' }, { type: 'string' }] }
+            ]
+          }
+        ]
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
         oneOf: [
           emptyObjectSchema,
           {
@@ -440,23 +446,23 @@ describe('parseSchema', () => {
             ]
           }
         ]
-      }
-    );
-  });
+      });
+    });
 
-  it('normalizes xOf schemas with properties at same level', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      type: 'object',
-      properties: { prop1: { type: 'string' } },
-      oneOf: [
-        { type: 'object' },
-        {
-          allOf: [{ type: 'object' }, { type: 'string' }]
-        }
-      ]
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
+    it('normalizes xOf schemas with properties at same level', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: 'object',
+        properties: { prop1: { type: 'string' } },
+        oneOf: [
+          { type: 'object' },
+          {
+            allOf: [{ type: 'object' }, { type: 'string' }]
+          }
+        ]
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
         oneOf: [
           emptyObjectSchema,
           { allOf: [emptyObjectSchema, { type: 'string' }] },
@@ -476,25 +482,25 @@ describe('parseSchema', () => {
             ]
           }
         ]
-      }
-    );
-  });
+      });
+    });
 
-  it('parses xOf schemas with required', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      oneOf: [
-        { type: 'object' },
-        {
-          allOf: [
-            { type: 'object', properties: { prop1: { type: 'string' } } },
-            { type: 'string' }
-          ],
-          required: ['prop1']
-        }
-      ]
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
+    it('parses xOf schemas with required', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        oneOf: [
+          { type: 'object' },
+          {
+            allOf: [
+              { type: 'object', properties: { prop1: { type: 'string' } } },
+              { type: 'string' }
+            ],
+            required: ['prop1']
+          }
+        ]
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
         oneOf: [
           emptyObjectSchema,
           {
@@ -518,18 +524,141 @@ describe('parseSchema', () => {
             ]
           }
         ]
-      }
-    );
-  });
+      });
+    });
 
-  it('parses not schema', async () => {
-    const schema: OpenAPIV3.SchemaObject = {
-      not: { type: 'object' }
-    };
-    expect(parseSchema(schema, await createTestRefs(), defaultOptions)).toEqual(
-      {
+    it('parses not schema', async () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        not: { type: 'object' }
+      };
+      expect(
+        parseSchema(schema, await createTestRefs(), defaultOptions)
+      ).toEqual({
         not: emptyObjectSchema
-      }
-    );
+      });
+    });
+
+    it('adds discriminator when discriminator has mapping', async () => {
+      const discriminator = {
+        propertyName: 'discriminatingProperty',
+        mapping: {
+          a: '#/components/schemas/SchemaA',
+          b: '#/components/schemas/SchemaB'
+        }
+      };
+      expect(
+        parseSchema(
+          {
+            oneOf: [
+              { $ref: '#/components/schemas/SchemaA' },
+              { $ref: '#/components/schemas/SchemaB' }
+            ],
+            discriminator
+          },
+          await createTestRefs({
+            schemas: {
+              SchemaA: { properties: { c: { type: 'string' } } },
+              SchemaB: { properties: { c: { type: 'integer' } } }
+            }
+          }),
+          defaultOptions
+        )
+      ).toEqual(
+        expect.objectContaining({
+          discriminator: {
+            propertyName: discriminator.propertyName,
+            mapping: {
+              a: {
+                $ref: '#/components/schemas/SchemaA',
+                schemaName: 'SchemaA',
+                fileName: 'schema-a'
+              },
+              b: {
+                $ref: '#/components/schemas/SchemaB',
+                schemaName: 'SchemaB',
+                fileName: 'schema-b'
+              }
+            }
+          }
+        })
+      );
+    });
+
+    it('adds discriminator mapping when discriminator has no mapping', async () => {
+      const discriminator = {
+        propertyName: 'discriminatingProperty',
+        mapping: {
+          SchemaA: '#/components/schemas/SchemaA',
+          SchemaB: '#/components/schemas/SchemaB'
+        }
+      };
+      expect(
+        parseSchema(
+          {
+            oneOf: [
+              { $ref: '#/components/schemas/SchemaA' },
+              { $ref: '#/components/schemas/SchemaB' }
+            ],
+            discriminator: {
+              propertyName: discriminator.propertyName
+            }
+          },
+          await createTestRefs({
+            schemas: {
+              SchemaA: { properties: { c: { type: 'string' } } },
+              SchemaB: { properties: { c: { type: 'integer' } } }
+            }
+          }),
+          defaultOptions
+        )
+      ).toEqual(
+        expect.objectContaining({
+          discriminator: {
+            propertyName: discriminator.propertyName,
+            mapping: {
+              SchemaA: {
+                $ref: '#/components/schemas/SchemaA',
+                schemaName: 'SchemaA',
+                fileName: 'schema-a'
+              },
+              SchemaB: {
+                $ref: '#/components/schemas/SchemaB',
+                schemaName: 'SchemaB',
+                fileName: 'schema-b'
+              }
+            }
+          }
+        })
+      );
+    });
+
+    it('parses as oneOf if there is a discriminator', async () => {
+      const discriminator = {
+        propertyName: 'discriminatingProperty',
+        mapping: {
+          a: '#/components/schemas/SchemaA',
+          b: '#/components/schemas/SchemaB'
+        }
+      };
+      expect(
+        parseSchema(
+          {
+            type: 'object',
+            discriminator
+          },
+          await createTestRefs({
+            schemas: {
+              SchemaA: { properties: { c: { type: 'string' } } },
+              SchemaB: { properties: { c: { type: 'integer' } } }
+            }
+          }),
+          defaultOptions
+        )
+      ).toEqual(
+        expect.objectContaining({
+          oneOf: []
+        })
+      );
+    });
   });
 });


### PR DESCRIPTION
This provides an initial implementation for the discriminating properties of OpenAPI specs: https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/

According to the documentation this can only happen on `oneOf` and `anyOf` schemas and there can either be an explicit mapping or it is implicitly derived from the referenced schema names.

Of course, the Azure OpenAPI spec does not use `oneOf` but `type: object`. 

This PR got all the above covered. There is however, one more thing:

The Azure OpenAPI spec has a circular reference like:
```yml
- SchemaA:
  discriminator:
    propertyName: discriminatorProp
    mapping:
      value1: => SchemaB
      value2: => SchemaC
- SchemaB:
  allOf:
    - SchemaA // this references back to the original type
    - ...
```

This would result in something like this: 
```ts
type SchemaA = { discriminatorProp: 'value1'} & SchemaB;
type SchemaB = SchemaA & ... // <-- ERROR
```

Currently, the solution that I have in mind is to clean this up before even really parsing the schemas by removing such references.