### PR TITLE
fix: Ignore charset parameter in media-types

### DIFF
--- a/.changeset/plenty-vans-mix.md
+++ b/.changeset/plenty-vans-mix.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/openapi-generator': minor
+---
+
+[Fixed Issue] Ignore charset parameter in media-types given in OpenApi specification.

--- a/.changeset/plenty-vans-mix.md
+++ b/.changeset/plenty-vans-mix.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/openapi-generator': minor
 ---
 
-[Fixed Issue] Ignore charset parameter in media-types given in OpenApi specification.
+[Fixed Issue] Ignore charset parameter in media types given in OpenAPI specification.

--- a/packages/openapi-generator/src/parser/media-type.spec.ts
+++ b/packages/openapi-generator/src/parser/media-type.spec.ts
@@ -19,7 +19,7 @@ describe('parseTopLevelMediaType', () => {
     expect(
       parseTopLevelMediaType(
         {
-          content: { 'application/json': { schema: { type: 'object' } } }
+          content: { 'application/json;charset=utf-8': { schema: { type: 'object' } } }
         },
         await createTestRefs(),
         defaultOptions

--- a/packages/openapi-generator/src/parser/media-type.spec.ts
+++ b/packages/openapi-generator/src/parser/media-type.spec.ts
@@ -19,7 +19,9 @@ describe('parseTopLevelMediaType', () => {
     expect(
       parseTopLevelMediaType(
         {
-          content: { 'application/json;charset=utf-8': { schema: { type: 'object' } } }
+          content: {
+            'application/json;charset=utf-8': { schema: { type: 'object' } }
+          }
         },
         await createTestRefs(),
         defaultOptions

--- a/packages/openapi-generator/src/parser/media-type.ts
+++ b/packages/openapi-generator/src/parser/media-type.ts
@@ -104,7 +104,7 @@ function getMediaTypeObject(
 ): OpenAPIV3.MediaTypeObject | undefined {
   if (bodyOrResponseObject?.content) {
     return Object.entries(bodyOrResponseObject.content).find(([key]) =>
-      contentType.includes(key)
+      contentType.includes(key.split(';')[0])
     )?.[1];
   }
   return undefined;


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-js#4969.

As we currently do not support handling charset, the changes in this PR simply ignores the provided charset in the spec and only considers the base media-type. So `application/json;charset=utf-8` would be read as `application/json` and underlying schema is parsed accordingly. Currently it is up to the user to provide any `Accept` and `Content-Type` headers as required by the individual API.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
