### PR TITLE
chore: add import/order rule groups

### DIFF
--- a/packages/connectivity/src/http-agent/http-agent.spec.ts
+++ b/packages/connectivity/src/http-agent/http-agent.spec.ts
@@ -1,11 +1,11 @@
 import { X509Certificate } from 'node:crypto';
 import mock from 'mock-fs';
 import { createLogger } from '@sap-cloud-sdk/util';
-import type { DestinationCertificate } from '../scp-cf';
-import type { HttpDestination } from '../scp-cf/destination';
 import { registerDestinationCache } from '../scp-cf/destination/register-destination-cache';
 import { certAsString } from '../../../../test-resources/test/test-util/test-certificate';
 import { getAgentConfigAsync } from './http-agent';
+import type { HttpDestination } from '../scp-cf/destination';
+import type { DestinationCertificate } from '../scp-cf';
 
 describe('createAgent', () => {
   const baseDestination: HttpDestination = {

--- a/packages/connectivity/src/http-agent/http-agent.ts
+++ b/packages/connectivity/src/http-agent/http-agent.ts
@@ -2,12 +2,6 @@ import { readFile } from 'fs/promises';
 import http from 'http';
 import https from 'https';
 import { createLogger, last } from '@sap-cloud-sdk/util';
-import type {
-  BasicProxyConfiguration,
-  Destination,
-  DestinationCertificate,
-  HttpDestination
-} from '../scp-cf';
 /* Careful the proxy imports cause circular dependencies if imported from scp directly */
 // eslint-disable-next-line import/no-internal-modules
 import { getProtocolOrDefault } from '../scp-cf/get-protocol';
@@ -19,6 +13,12 @@ import {
 } from '../scp-cf/destination/http-proxy-util';
 // eslint-disable-next-line import/no-internal-modules
 import { registerDestinationCache } from '../scp-cf/destination/register-destination-cache';
+import type {
+  BasicProxyConfiguration,
+  Destination,
+  DestinationCertificate,
+  HttpDestination
+} from '../scp-cf';
 import type { HttpAgentConfig, HttpsAgentConfig } from './agent-config';
 
 const logger = createLogger({

--- a/packages/connectivity/src/scp-cf/async-cache.ts
+++ b/packages/connectivity/src/scp-cf/async-cache.ts
@@ -1,5 +1,5 @@
-import type { CacheEntry } from './cache';
 import { Cache } from './cache';
+import type { CacheEntry } from './cache';
 
 /**
  * Generic async cache interface.

--- a/packages/connectivity/src/scp-cf/authorization-header.ts
+++ b/packages/connectivity/src/scp-cf/authorization-header.ts
@@ -5,13 +5,13 @@ import {
   encodeBase64,
   pickValueIgnoreCase
 } from '@sap-cloud-sdk/util';
+// eslint-disable-next-line import/no-internal-modules
+import { sanitizeDestination } from './destination/destination';
 import type {
   AuthenticationType,
   Destination,
   DestinationAuthToken
 } from './destination';
-// eslint-disable-next-line import/no-internal-modules
-import { sanitizeDestination } from './destination/destination';
 
 const logger = createLogger({
   package: 'connectivity',

--- a/packages/connectivity/src/scp-cf/cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/cache.spec.ts
@@ -1,7 +1,7 @@
 import { Cache } from './cache';
 import { clientCredentialsTokenCache } from './client-credentials-token-cache';
-import type { AuthenticationType, Destination } from './destination';
 import { destinationCache } from './destination';
+import type { AuthenticationType, Destination } from './destination';
 import type { ClientCredentialsResponse } from './xsuaa-service-types';
 
 const destinationOne: Destination = {

--- a/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
@@ -16,9 +16,9 @@ import {
   addProxyConfigurationOnPrem,
   httpProxyHostAndPort
 } from './connectivity-service';
-import type { Destination } from './destination';
 import { getRequiredSubscriberToken } from './destination';
 import { getJwtPair } from './jwt';
+import type { Destination } from './destination';
 
 describe('connectivity-service', () => {
   afterEach(() => {

--- a/packages/connectivity/src/scp-cf/connectivity-service.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.ts
@@ -1,4 +1,6 @@
 import { createLogger, ErrorWithCause } from '@sap-cloud-sdk/util';
+import { getServiceBindings } from './environment-accessor';
+import { serviceToken } from './token-accessor';
 import type { JwtPayload } from './jsonwebtoken-type';
 import type { Protocol } from './protocol';
 import type {
@@ -10,9 +12,7 @@ import type {
   Destination,
   SubscriberToken
 } from './destination';
-import { getServiceBindings } from './environment-accessor';
 import type { Service } from './environment-accessor';
-import { serviceToken } from './token-accessor';
 
 const logger = createLogger({
   package: 'connectivity',

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-jwks.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-jwks.spec.ts
@@ -7,9 +7,9 @@ import {
   oauthMultipleResponse,
   providerServiceToken
 } from '../../../../../test-resources/test/test-util';
-import type { DestinationFetchOptions } from './destination-accessor-types';
 import { alwaysProvider } from './destination-selection-strategies';
 import { getDestination } from './destination-accessor';
+import type { DestinationFetchOptions } from './destination-accessor-types';
 import type { DestinationConfiguration } from './destination';
 
 describe('custom JWTs', () => {

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-loading-precendence.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-loading-precendence.spec.ts
@@ -1,9 +1,9 @@
-import type { MockServiceBindings } from '../../../../../test-resources/test/test-util';
 import { mockServiceBindings } from '../../../../../test-resources/test/test-util';
 import { getDestination, useOrFetchDestination } from './destination-accessor';
-import type { DestinationWithName } from './destination-from-registration';
 import { registerDestination } from './destination-from-registration';
 import { registerDestinationCache } from './register-destination-cache';
+import type { DestinationWithName } from './destination-from-registration';
+import type { MockServiceBindings } from '../../../../../test-resources/test/test-util';
 
 function mockEnvDestinations() {
   process.env['destinations'] = JSON.stringify([

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
@@ -1,6 +1,4 @@
-import type { ErrorWithCause } from '@sap-cloud-sdk/util';
 import { createLogger } from '@sap-cloud-sdk/util';
-import type { AxiosError } from 'axios';
 import nock from 'nock';
 import {
   mockFetchDestinationCalls,
@@ -28,23 +26,25 @@ import {
 } from '../../../../../test-resources/test/test-util/mocked-access-tokens';
 import { mockServiceToken } from '../../../../../test-resources/test/test-util/token-accessor-mocks';
 import * as identityService from '../identity-service';
-import type { DestinationConfiguration } from './destination';
 import { parseDestination } from './destination';
 import {
   getAllDestinationsFromDestinationService,
   getDestination
 } from './destination-accessor';
-import type {
-  DestinationFetchOptions,
-  DestinationWithoutToken
-} from './destination-accessor-types';
 import { getDestinationFromDestinationService } from './destination-from-service';
-import type { DestinationSelectionStrategy } from './destination-selection-strategies';
 import {
   alwaysProvider,
   alwaysSubscriber,
   subscriberFirst
 } from './destination-selection-strategies';
+import type {
+  DestinationFetchOptions,
+  DestinationWithoutToken
+} from './destination-accessor-types';
+import type { DestinationSelectionStrategy } from './destination-selection-strategies';
+import type { DestinationConfiguration } from './destination';
+import type { AxiosError } from 'axios';
+import type { ErrorWithCause } from '@sap-cloud-sdk/util';
 import type { Destination } from './destination-service-types';
 
 const destName = 'DESTINATION';

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
@@ -27,9 +27,9 @@ import {
 import { getDestination } from './destination-accessor';
 import * as ProxyUtil from './http-proxy-util';
 import { alwaysProvider } from './destination-selection-strategies';
-import type { Destination } from './destination-service-types';
 import { destinationCache } from './destination-cache';
 import { destinationServiceCache } from './destination-service-cache';
+import type { Destination } from './destination-service-types';
 
 describe('proxy configuration', () => {
   beforeEach(() => {

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor.ts
@@ -2,23 +2,23 @@ import { createLogger, ErrorWithCause } from '@sap-cloud-sdk/util';
 import { exchangeToken, shouldExchangeToken } from '../identity-service';
 import { getDestinationServiceCredentials } from '../environment-accessor';
 import { getSubdomain } from '../jwt';
-import type { DestinationOrFetchOptions } from './destination';
 import { sanitizeDestination, toDestinationNameUrl } from './destination';
-import type { Destination } from './destination-service-types';
 import { searchEnvVariablesForDestination } from './destination-from-env';
-import type { DestinationForServiceBindingOptions } from './destination-from-vcap';
 import { searchServiceBindingForDestination } from './destination-from-vcap';
 import { getDestinationFromDestinationService } from './destination-from-service';
-import type {
-  DestinationFetchOptions,
-  AllDestinationOptions,
-  DestinationWithoutToken
-} from './destination-accessor-types';
 import { isDestinationFetchOptions } from './destination-accessor-types';
 import { searchRegisteredDestination } from './destination-from-registration';
 import { getSubscriberToken } from './get-subscriber-token';
 import { getProviderServiceToken } from './get-provider-token';
 import { fetchDestinations } from './destination-service';
+import type {
+  DestinationFetchOptions,
+  AllDestinationOptions,
+  DestinationWithoutToken
+} from './destination-accessor-types';
+import type { DestinationForServiceBindingOptions } from './destination-from-vcap';
+import type { Destination } from './destination-service-types';
+import type { DestinationOrFetchOptions } from './destination';
 
 const logger = createLogger({
   package: 'connectivity',

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
@@ -31,11 +31,6 @@ import {
   mockJwtBearerToken,
   mockServiceToken
 } from '../../../../../test-resources/test/test-util/token-accessor-mocks';
-import type {
-  AuthenticationType,
-  Destination,
-  DestinationAuthToken
-} from './destination-service-types';
 import { destinationServiceCache } from './destination-service-cache';
 import {
   alwaysProvider,
@@ -43,7 +38,6 @@ import {
   subscriberFirst
 } from './destination-selection-strategies';
 import { getDestinationFromDestinationService } from './destination-from-service';
-import type { IsolationStrategy } from './destination-cache';
 import {
   destinationCache,
   getDestinationCacheKey,
@@ -51,6 +45,12 @@ import {
 } from './destination-cache';
 import { getDestination } from './destination-accessor';
 import { parseDestination } from './destination';
+import type { IsolationStrategy } from './destination-cache';
+import type {
+  AuthenticationType,
+  Destination,
+  DestinationAuthToken
+} from './destination-service-types';
 
 const destinationOne: Destination = {
   url: 'https://destination1.example',

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.ts
@@ -1,8 +1,8 @@
 import { createLogger, first } from '@sap-cloud-sdk/util';
 import { getTenantId, userId } from '../jwt';
+import { AsyncCache } from '../async-cache';
 import type { JwtPayload } from '../jsonwebtoken-type';
 import type { AsyncCacheInterface } from '../async-cache';
-import { AsyncCache } from '../async-cache';
 import type { Destination } from './destination-service-types';
 import type { DestinationsByType } from './destination-accessor-types';
 import type { SubscriberToken } from './get-subscriber-token';

--- a/packages/connectivity/src/scp-cf/destination/destination-from-env.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-env.spec.ts
@@ -5,7 +5,6 @@ import {
   unmockDestinationsEnv
 } from '../../../../../test-resources/test/test-util/request-mocker';
 import { signedJwt } from '../../../../../test-resources/test/test-util';
-import type { Destination } from './destination-service-types';
 import {
   getDestinationFromEnvByName,
   getDestinationsFromEnv,
@@ -13,6 +12,7 @@ import {
 } from './destination-from-env';
 import { getDestination, useOrFetchDestination } from './destination-accessor';
 import { sanitizeDestination } from './destination';
+import type { Destination } from './destination-service-types';
 
 const environmentDestination = {
   name: 'FINAL-DESTINATION',

--- a/packages/connectivity/src/scp-cf/destination/destination-from-env.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-env.ts
@@ -4,14 +4,14 @@ import {
   isDestinationConfiguration,
   parseDestination
 } from './destination';
-import type { DestinationFetchOptions } from './destination-accessor-types';
-import type { Destination } from './destination-service-types';
 import {
   addProxyConfigurationInternet,
   proxyStrategy
 } from './http-proxy-util';
 import { isHttpDestination } from './destination-service-types';
 import { setForwardedAuthTokenIfNeeded } from './forward-auth-token';
+import type { Destination } from './destination-service-types';
+import type { DestinationFetchOptions } from './destination-accessor-types';
 
 const logger = createLogger({
   package: 'connectivity',

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
@@ -11,12 +11,12 @@ import {
   xsuaaBindingMock
 } from '../../../../../test-resources/test/test-util';
 import { certAsString } from '../../../../../test-resources/test/test-util/test-certificate';
-import type { DestinationWithName } from './destination-from-registration';
 import {
   registerDestination,
   searchRegisteredDestination
 } from './destination-from-registration';
 import { registerDestinationCache } from './register-destination-cache';
+import type { DestinationWithName } from './destination-from-registration';
 
 const testDestination: DestinationWithName = {
   name: 'RegisteredDestination',

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.ts
@@ -5,10 +5,7 @@ import {
   defaultTenantId,
   getTenantId
 } from '../jwt';
-import type { DestinationFetchOptions } from './destination-accessor-types';
-import type { IsolationStrategy } from './destination-cache';
 import { getDefaultIsolationStrategy } from './destination-cache';
-import type { Destination } from './destination-service-types';
 import { isHttpDestination } from './destination-service-types';
 import {
   addProxyConfigurationInternet,
@@ -16,6 +13,9 @@ import {
 } from './http-proxy-util';
 import { registerDestinationCache } from './register-destination-cache';
 import { setForwardedAuthTokenIfNeeded } from './forward-auth-token';
+import type { Destination } from './destination-service-types';
+import type { IsolationStrategy } from './destination-cache';
+import type { DestinationFetchOptions } from './destination-accessor-types';
 
 const logger = createLogger({
   package: 'connectivity',

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -1,19 +1,13 @@
 import { createLogger } from '@sap-cloud-sdk/util';
 import { addProxyConfigurationOnPrem } from '../connectivity-service';
-import type { Service } from '../environment-accessor';
 import {
   getDestinationServiceCredentials,
   getServiceBinding
 } from '../environment-accessor';
 import { exchangeToken, shouldExchangeToken } from '../identity-service';
-import type { JwtPair } from '../jwt';
 import { getSubdomain, isXsuaaToken } from '../jwt';
 import { isIdenticalTenant } from '../tenant';
 import { jwtBearerToken } from '../token-accessor';
-import type {
-  DestinationFetchOptions,
-  DestinationsByType
-} from './destination-accessor-types';
 import {
   destinationCache,
   getDefaultIsolationStrategy
@@ -23,16 +17,13 @@ import {
   alwaysSubscriber,
   subscriberFirst
 } from './destination-selection-strategies';
-import type { AuthAndExchangeTokens } from './destination-service';
 import {
   fetchCertificate,
   fetchDestinationWithTokenRetrieval,
   fetchDestinationWithoutTokenRetrieval
 } from './destination-service';
-import type { Destination } from './destination-service-types';
 import { assertHttpDestination } from './destination-service-types';
 import { getProviderServiceToken } from './get-provider-token';
-import type { SubscriberToken } from './get-subscriber-token';
 import {
   getRequiredSubscriberToken,
   getSubscriberToken,
@@ -43,6 +34,15 @@ import {
   proxyStrategy
 } from './http-proxy-util';
 import { setForwardedAuthTokenIfNeeded } from './forward-auth-token';
+import type { SubscriberToken } from './get-subscriber-token';
+import type { Destination } from './destination-service-types';
+import type { AuthAndExchangeTokens } from './destination-service';
+import type {
+  DestinationFetchOptions,
+  DestinationsByType
+} from './destination-accessor-types';
+import type { JwtPair } from '../jwt';
+import type { Service } from '../environment-accessor';
 
 type DestinationOrigin = 'subscriber' | 'provider';
 

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
@@ -7,12 +7,12 @@ import {
   testTenants
 } from '../../../../../test-resources/test/test-util';
 import * as tokenAccessor from '../token-accessor';
-import type { Service } from '../environment-accessor/environment-accessor-types';
 import { decodeJwt } from '../jwt';
 import { getDestination } from './destination-accessor';
 import { getDestinationFromServiceBinding } from './destination-from-vcap';
 import { destinationCache } from './destination-cache';
 import SpyInstance = jest.SpyInstance;
+import type { Service } from '../environment-accessor';
 
 describe('vcap-service-destination', () => {
   const serviceTokenSpy = jest.spyOn(tokenAccessor, 'serviceToken');

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
@@ -1,19 +1,19 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import type { JwtPayload } from '../jsonwebtoken-type';
 import { decodeJwt, decodeOrMakeJwt } from '../jwt';
-import type { Service } from '../environment-accessor';
 import { getServiceBindingByInstanceName } from '../environment-accessor';
-import type { CachingOptions } from '../cache';
 import {
   addProxyConfigurationInternet,
   proxyStrategy
 } from './http-proxy-util';
-import type { Destination } from './destination-service-types';
 import { isHttpDestination } from './destination-service-types';
-import type { DestinationFetchOptions } from './destination-accessor-types';
 import { destinationCache } from './destination-cache';
 import { serviceToDestinationTransformers } from './service-binding-to-destination';
 import { setForwardedAuthTokenIfNeeded } from './forward-auth-token';
+import type { DestinationFetchOptions } from './destination-accessor-types';
+import type { Destination } from './destination-service-types';
+import type { CachingOptions } from '../cache';
+import type { Service } from '../environment-accessor';
+import type { JwtPayload } from '../jsonwebtoken-type';
 
 const logger = createLogger({
   package: 'connectivity',

--- a/packages/connectivity/src/scp-cf/destination/destination-selection-strategies.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-selection-strategies.spec.ts
@@ -1,10 +1,10 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import type { AllDestinations } from './destination-accessor-types';
 import {
   alwaysProvider,
   alwaysSubscriber,
   subscriberFirst
 } from './destination-selection-strategies';
+import type { AllDestinations } from './destination-accessor-types';
 
 const target = {
   name: 'testination',

--- a/packages/connectivity/src/scp-cf/destination/destination-service-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-cache.spec.ts
@@ -11,9 +11,9 @@ import {
   mockVerifyJwt
 } from '../../../../../test-resources/test/test-util/destination-service-mocks';
 import { decodeJwt } from '../jwt';
-import type { Destination } from './destination-service-types';
 import { destinationServiceCache } from './destination-service-cache';
 import { fetchDestinations } from './destination-service';
+import type { Destination } from './destination-service-types';
 
 const destinationServiceUrl = 'https://myDestination.service.url';
 

--- a/packages/connectivity/src/scp-cf/destination/destination-service-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service-cache.ts
@@ -1,7 +1,7 @@
-import type { JwtPayload } from '../jsonwebtoken-type';
 import { Cache } from '../cache';
-import type { Destination } from './destination-service-types';
 import { getDestinationCacheKey } from './destination-cache';
+import type { JwtPayload } from '../jsonwebtoken-type';
+import type { Destination } from './destination-service-types';
 
 const DestinationServiceCache = (cache: Cache<Destination[]>) => ({
   retrieveDestinationsFromCache: (

--- a/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.spec.ts
@@ -4,12 +4,10 @@ import nock from 'nock';
 import * as resilienceMethods from '@sap-cloud-sdk/resilience/internal';
 import { circuitBreakers } from '@sap-cloud-sdk/resilience/internal';
 // eslint-disable-next-line import/named
-import type { RawAxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import { mockCertificateCall } from '../../../../../test-resources/test/test-util';
 import { destinationServiceUri } from '../../../../../test-resources/test/test-util/environment-mocks';
 import { privateKey } from '../../../../../test-resources/test/test-util/keys';
-import type { DestinationConfiguration } from './destination';
 import { parseDestination } from './destination';
 import {
   fetchCertificate,
@@ -17,6 +15,8 @@ import {
   fetchDestinationWithoutTokenRetrieval,
   fetchDestinations
 } from './destination-service';
+import type { DestinationConfiguration } from './destination';
+import type { RawAxiosRequestConfig } from 'axios';
 import type { Destination } from './destination-service-types';
 
 const jwt = jwt123.sign(

--- a/packages/connectivity/src/scp-cf/destination/destination-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-service.ts
@@ -5,22 +5,22 @@ import {
   removeTrailingSlashes
 } from '@sap-cloud-sdk/util';
 // eslint-disable-next-line import/named
-import type { RawAxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
 import axios from 'axios';
 import { executeWithMiddleware } from '@sap-cloud-sdk/resilience/internal';
-import type { Middleware, MiddlewareContext } from '@sap-cloud-sdk/resilience';
 import { resilience } from '@sap-cloud-sdk/resilience';
 import * as asyncRetry from 'async-retry';
 import { decodeJwt, getTenantId, wrapJwtInHeader } from '../jwt';
 import { urlAndAgent } from '../../http-agent';
 import { buildAuthorizationHeaders } from '../authorization-header';
-import type { DestinationConfiguration, DestinationJson } from './destination';
 import { parseCertificate, parseDestination } from './destination';
+import { destinationServiceCache } from './destination-service-cache';
+import type { DestinationConfiguration, DestinationJson } from './destination';
 import type {
   DestinationFetchOptions,
   DestinationsByType
 } from './destination-accessor-types';
-import { destinationServiceCache } from './destination-service-cache';
+import type { Middleware, MiddlewareContext } from '@sap-cloud-sdk/resilience';
+import type { RawAxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
 import type {
   Destination,
   DestinationCertificate

--- a/packages/connectivity/src/scp-cf/destination/destination.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination.spec.ts
@@ -3,8 +3,8 @@ import {
   certificateMultipleResponse,
   certificateSingleResponse
 } from '../../../../../test-resources/test/test-util/example-destination-service-responses';
-import type { DestinationConfiguration } from './destination';
 import { parseDestination, sanitizeDestination } from './destination';
+import type { DestinationConfiguration } from './destination';
 import type { Destination } from './destination-service-types';
 
 describe('parseDestination', () => {

--- a/packages/connectivity/src/scp-cf/destination/destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination.ts
@@ -1,6 +1,6 @@
+import { isDestinationFetchOptions } from './destination-accessor-types';
 import type { Xor } from '@sap-cloud-sdk/util';
 import type { DestinationFetchOptions } from './destination-accessor-types';
-import { isDestinationFetchOptions } from './destination-accessor-types';
 import type { DestinationForServiceBindingOptions } from './destination-from-vcap';
 import type {
   AuthenticationType,

--- a/packages/connectivity/src/scp-cf/destination/get-provider-token.ts
+++ b/packages/connectivity/src/scp-cf/destination/get-provider-token.ts
@@ -1,6 +1,6 @@
-import type { JwtPair } from '../jwt';
 import { decodeJwt } from '../jwt';
 import { serviceToken } from '../token-accessor';
+import type { JwtPair } from '../jwt';
 import type { DestinationOptions } from './destination-accessor-types';
 
 /**

--- a/packages/connectivity/src/scp-cf/destination/get-subscriber-token.ts
+++ b/packages/connectivity/src/scp-cf/destination/get-subscriber-token.ts
@@ -1,9 +1,9 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import type { JwtPayload } from '../jsonwebtoken-type';
-import type { JwtPair } from '../jwt';
 import { decodeJwt, getJwtPair, isXsuaaToken, verifyJwt } from '../jwt';
 import { serviceToken } from '../token-accessor';
 import { getIssuerSubdomain } from '../subdomain-replacer';
+import type { JwtPair } from '../jwt';
+import type { JwtPayload } from '../jsonwebtoken-type';
 import type { DestinationOptions } from './destination-accessor-types';
 
 const logger = createLogger({

--- a/packages/connectivity/src/scp-cf/destination/http-proxy-util.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/http-proxy-util.spec.ts
@@ -1,12 +1,12 @@
 import { createLogger } from '@sap-cloud-sdk/util';
 import { basicHeader } from '../authorization-header';
-import type { BasicProxyConfiguration } from '../connectivity-service-types';
 import {
   addProxyConfigurationInternet,
   getProxyConfig,
   parseProxyEnv,
   proxyStrategy
 } from './http-proxy-util';
+import type { BasicProxyConfiguration } from '../connectivity-service-types';
 import type { HttpDestination } from './destination-service-types';
 
 describe('proxy-util', () => {

--- a/packages/connectivity/src/scp-cf/destination/http-proxy-util.ts
+++ b/packages/connectivity/src/scp-cf/destination/http-proxy-util.ts
@@ -1,15 +1,15 @@
 import { URL } from 'node:url';
 import { createLogger, sanitizeRecord } from '@sap-cloud-sdk/util';
-import type { Protocol } from '../protocol';
 import { getProtocol } from '../protocol';
+import { basicHeader } from '../authorization-header';
+import { getProtocolOrDefault } from '../get-protocol';
+import { isHttpDestination } from './destination-service-types';
+import type { Destination, HttpDestination } from './destination-service-types';
 import type {
   BasicProxyConfiguration,
   ProxyConfiguration
 } from '../connectivity-service-types';
-import { basicHeader } from '../authorization-header';
-import { getProtocolOrDefault } from '../get-protocol';
-import type { Destination, HttpDestination } from './destination-service-types';
-import { isHttpDestination } from './destination-service-types';
+import type { Protocol } from '../protocol';
 
 const logger = createLogger({
   package: 'connectivity',

--- a/packages/connectivity/src/scp-cf/destination/register-destination-cache.ts
+++ b/packages/connectivity/src/scp-cf/destination/register-destination-cache.ts
@@ -1,11 +1,11 @@
 import { readFile } from 'fs/promises';
 import { X509Certificate } from 'crypto';
 import { createLogger } from '@sap-cloud-sdk/util';
+import { AsyncCache } from '../async-cache';
+import { DefaultDestinationCache, DestinationCache } from './destination-cache';
 import type { MtlsOptions } from '../../http-agent';
 import type { AsyncCacheInterface } from '../async-cache';
-import { AsyncCache } from '../async-cache';
 import type { DestinationCacheType } from './destination-cache';
-import { DefaultDestinationCache, DestinationCache } from './destination-cache';
 
 const logger = createLogger('register-destination-cache');
 

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
@@ -1,6 +1,6 @@
-import type { Service } from '../environment-accessor';
 import { serviceToken } from '../token-accessor';
 import { decodeJwt } from '../jwt';
+import type { Service } from '../environment-accessor';
 import type {
   ServiceBindingTransformFunction,
   ServiceBindingTransformOptions

--- a/packages/connectivity/src/scp-cf/environment-accessor/destination.ts
+++ b/packages/connectivity/src/scp-cf/environment-accessor/destination.ts
@@ -1,5 +1,5 @@
-import type { DestinationServiceCredentials } from './environment-accessor-types';
 import { getServiceCredentials } from './service-credentials';
+import type { DestinationServiceCredentials } from './environment-accessor-types';
 
 /**
  * Utility function to get destination service credentials, including error handling.

--- a/packages/connectivity/src/scp-cf/environment-accessor/service-credentials.ts
+++ b/packages/connectivity/src/scp-cf/environment-accessor/service-credentials.ts
@@ -1,9 +1,9 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import type { JwtPayload } from '../jsonwebtoken-type';
 // eslint-disable-next-line import/no-internal-modules
 import { audiences, decodeJwt } from '../jwt/jwt';
-import type { ServiceCredentials } from './environment-accessor-types';
 import { getServiceBindings } from './service-bindings';
+import type { JwtPayload } from '../jsonwebtoken-type';
+import type { ServiceCredentials } from './environment-accessor-types';
 
 const logger = createLogger({
   package: 'connectivity',

--- a/packages/connectivity/src/scp-cf/environment-accessor/xsuaa.ts
+++ b/packages/connectivity/src/scp-cf/environment-accessor/xsuaa.ts
@@ -1,10 +1,10 @@
 import { XsuaaService } from '@sap/xssec';
+import { getServiceCredentials } from './service-credentials';
 import type { JwtPayload } from '../jsonwebtoken-type';
 import type {
   ServiceCredentials,
   XsuaaServiceCredentials
 } from './environment-accessor-types';
-import { getServiceCredentials } from './service-credentials';
 
 /**
  * @internal

--- a/packages/connectivity/src/scp-cf/get-protocol.ts
+++ b/packages/connectivity/src/scp-cf/get-protocol.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@sap-cloud-sdk/util';
+import { getProtocol } from './protocol';
 import type { HttpDestination } from './destination';
 import type { Protocol } from './protocol';
-import { getProtocol } from './protocol';
 
 const logger = createLogger({
   package: 'connectivity',

--- a/packages/connectivity/src/scp-cf/identity-service.ts
+++ b/packages/connectivity/src/scp-cf/identity-service.ts
@@ -1,6 +1,6 @@
-import type { DestinationOptions } from './destination';
 import { decodeJwt, isXsuaaToken } from './jwt';
 import { jwtBearerToken } from './token-accessor';
+import type { DestinationOptions } from './destination';
 
 /**
  * @internal

--- a/packages/connectivity/src/scp-cf/jwt/binding.ts
+++ b/packages/connectivity/src/scp-cf/jwt/binding.ts
@@ -1,6 +1,6 @@
 import { getServiceCredentials } from '../environment-accessor';
-import type { JwtPayload } from '../jsonwebtoken-type';
 import { decodeJwt, getTenantId } from './jwt';
+import type { JwtPayload } from '../jsonwebtoken-type';
 
 /**
  * This method either decodes the given JWT or tries to retrieve the tenant from a service binding (XSUAA, IAS or destination) as `zid`.

--- a/packages/connectivity/src/scp-cf/jwt/jwt.ts
+++ b/packages/connectivity/src/scp-cf/jwt/jwt.ts
@@ -1,14 +1,14 @@
-import type { IncomingMessage } from 'http';
 import { createLogger, pickValueIgnoreCase } from '@sap-cloud-sdk/util';
 import { decode } from 'jsonwebtoken';
 import { Cache } from '../cache';
+import { getIssuerSubdomain } from '../subdomain-replacer';
 import type {
   Jwt,
   JwtPayload,
   JwtWithPayloadObject
 } from '../jsonwebtoken-type';
 import type { TokenKey } from '../xsuaa-service-types';
-import { getIssuerSubdomain } from '../subdomain-replacer';
+import type { IncomingMessage } from 'http';
 
 const logger = createLogger({
   package: 'connectivity',

--- a/packages/connectivity/src/scp-cf/tenant.ts
+++ b/packages/connectivity/src/scp-cf/tenant.ts
@@ -1,5 +1,5 @@
-import type { JwtPayload } from './jsonwebtoken-type';
 import { getTenantId } from './jwt';
+import type { JwtPayload } from './jsonwebtoken-type';
 
 /**
  * Compare two decoded JWTs based on their `tenantId`s.

--- a/packages/connectivity/src/scp-cf/token-accessor.spec.ts
+++ b/packages/connectivity/src/scp-cf/token-accessor.spec.ts
@@ -29,8 +29,8 @@ import {
 } from '../../../../test-resources/test/test-util/xsuaa-service-mocks';
 import { clientCredentialsTokenCache } from './client-credentials-token-cache';
 import { jwtBearerToken, serviceToken } from './token-accessor';
-import type { ClientCredentialsResponse } from './xsuaa-service-types';
 import { clearXsuaaServices } from './environment-accessor';
+import type { ClientCredentialsResponse } from './xsuaa-service-types';
 
 describe('token accessor', () => {
   describe('serviceToken()', () => {

--- a/packages/connectivity/src/scp-cf/token-accessor.ts
+++ b/packages/connectivity/src/scp-cf/token-accessor.ts
@@ -1,16 +1,16 @@
 import { ErrorWithCause } from '@sap-cloud-sdk/util';
-import type { JwtPayload } from './jsonwebtoken-type';
 import {
   getDefaultTenantId,
   getSubdomain,
   getTenantId,
   getTenantIdFromBinding
 } from './jwt';
-import type { CachingOptions } from './cache';
 import { clientCredentialsTokenCache } from './client-credentials-token-cache';
 import { resolveServiceBinding } from './environment-accessor';
-import type { Service, XsuaaServiceCredentials } from './environment-accessor';
 import { getClientCredentialsToken, getUserToken } from './xsuaa-service';
+import type { Service, XsuaaServiceCredentials } from './environment-accessor';
+import type { CachingOptions } from './cache';
+import type { JwtPayload } from './jsonwebtoken-type';
 
 /**
  * Returns an access token that can be used to call the given service. The token is fetched via a client credentials grant with the credentials of the given service.

--- a/packages/connectivity/src/scp-cf/xsuaa-service.ts
+++ b/packages/connectivity/src/scp-cf/xsuaa-service.ts
@@ -1,11 +1,11 @@
 import { executeWithMiddleware } from '@sap-cloud-sdk/resilience/internal';
-import type { MiddlewareContext } from '@sap-cloud-sdk/resilience';
 import { resilience } from '@sap-cloud-sdk/resilience';
+import { getXsuaaService, resolveServiceBinding } from './environment-accessor';
+import { decodeJwt, getSubdomain, getTenantId } from './jwt';
+import type { MiddlewareContext } from '@sap-cloud-sdk/resilience';
 import type { JwtPayload } from './jsonwebtoken-type';
 import type { Service, ServiceCredentials } from './environment-accessor';
 import type { ClientCredentialsResponse } from './xsuaa-service-types';
-import { getXsuaaService, resolveServiceBinding } from './environment-accessor';
-import { decodeJwt, getSubdomain, getTenantId } from './jwt';
 
 interface XsuaaParameters {
   subdomain?: string;

--- a/packages/eslint-config/flat-config.js
+++ b/packages/eslint-config/flat-config.js
@@ -162,7 +162,21 @@ const flatConfig = [
         }
       ],
       'import/export': 'error',
-      'import/order': 'error',
+      'import/order': [
+        'error',
+        {
+          groups: [
+            'builtin',
+            'external',
+            'internal',
+            'parent',
+            'sibling',
+            'index',
+            'object',
+            'type'
+          ]
+        }
+      ],
       'import/no-duplicates': 'error',
       'unused-imports/no-unused-imports': 'error',
       'arrow-body-style': 'error',

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -167,7 +167,21 @@ module.exports = {
       }
     ],
     'import/export': 'error',
-    'import/order': 'error',
+    'import/order': [
+      'error',
+      {
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+          'object',
+          'type'
+        ]
+      }
+    ],
     'import/no-duplicates': 'error',
     'unused-imports/no-unused-imports': 'error',
     'arrow-body-style': 'error',

--- a/packages/generator-common/src/cli-parser.ts
+++ b/packages/generator-common/src/cli-parser.ts
@@ -1,6 +1,6 @@
 import yargs from 'yargs';
-import type { Option } from './options-parser';
 import { getOptionsWithoutDefaults } from './options-parser';
+import type { Option } from './options-parser';
 
 /**
  * @internal

--- a/packages/generator-common/src/compiler.spec.ts
+++ b/packages/generator-common/src/compiler.spec.ts
@@ -2,7 +2,6 @@ import { promises } from 'fs';
 import { resolve, join } from 'path';
 import { EOL } from 'os';
 import mock from 'mock-fs';
-import type { CompilerOptions } from 'typescript';
 import { ModuleKind, ModuleResolutionKind, ScriptTarget } from 'typescript';
 import { globSync } from 'glob';
 import {
@@ -10,8 +9,9 @@ import {
   readIncludeExcludeWithDefaults,
   transpileDirectory
 } from './compiler';
-import type { CreateFileOptions } from './file-writer';
 import { defaultPrettierConfig } from './file-writer';
+import type { CreateFileOptions } from './file-writer';
+import type { CompilerOptions } from 'typescript';
 
 const { readFile, readdir } = promises;
 

--- a/packages/generator-common/src/compiler.ts
+++ b/packages/generator-common/src/compiler.ts
@@ -2,13 +2,6 @@ import { parse, resolve } from 'path';
 import { existsSync, promises } from 'fs';
 import { EOL } from 'os';
 import { createLogger } from '@sap-cloud-sdk/util';
-import type {
-  CompilerOptions,
-  Diagnostic,
-  NodeArray,
-  Statement,
-  WriteFileCallback
-} from 'typescript';
 import {
   createProgram,
   getPreEmitDiagnostics,
@@ -17,8 +10,15 @@ import {
   ScriptTarget
 } from 'typescript';
 import { glob } from 'glob';
-import type { CreateFileOptions } from './file-writer';
 import { createFile, getFileExtension } from './file-writer';
+import type { CreateFileOptions } from './file-writer';
+import type {
+  CompilerOptions,
+  Diagnostic,
+  NodeArray,
+  Statement,
+  WriteFileCallback
+} from 'typescript';
 
 const logger = createLogger('compiler');
 const { mkdir } = promises;

--- a/packages/generator-common/src/file-writer/create-file.spec.ts
+++ b/packages/generator-common/src/file-writer/create-file.spec.ts
@@ -2,12 +2,12 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import mock from 'mock-fs';
 import { createLogger, unixEOL } from '@sap-cloud-sdk/util';
-import type { CreateFileOptions } from './create-file';
 import {
   createFile,
   defaultPrettierConfig,
   readPrettierConfig
 } from './create-file';
+import type { CreateFileOptions } from './create-file';
 
 describe('createFile', () => {
   const pathRootNodeModules = resolve(__dirname, '../../../../node_modules');

--- a/packages/generator-common/src/file-writer/create-file.ts
+++ b/packages/generator-common/src/file-writer/create-file.ts
@@ -6,9 +6,9 @@ import {
   ErrorWithCause,
   unixEOL
 } from '@sap-cloud-sdk/util';
-import type { BuiltInParserName, Options as PrettierOptions } from 'prettier';
 import { format } from 'prettier';
 import { getCopyrightHeader } from '../util';
+import type { BuiltInParserName, Options as PrettierOptions } from 'prettier';
 
 const { writeFile, readFile } = promises;
 const logger = createLogger('create-file');

--- a/packages/generator-common/src/options-parser.ts
+++ b/packages/generator-common/src/options-parser.ts
@@ -1,9 +1,9 @@
 import { dirname, extname, join, posix, resolve, sep } from 'path';
 import { existsSync, lstatSync } from 'fs';
 import { createLogger } from '@sap-cloud-sdk/util';
+import { globSync, hasMagic } from 'glob';
 import type { InferredOptionType, Options as YargsOption } from 'yargs';
 const logger = createLogger('generator-options');
-import { globSync, hasMagic } from 'glob';
 
 /**
  * @internal

--- a/packages/generator-common/src/options-per-service.spec.ts
+++ b/packages/generator-common/src/options-per-service.spec.ts
@@ -10,12 +10,12 @@ jest.mock('path', () => {
 });
 
 import mock from 'mock-fs';
-import type { OptionsPerService } from './options-per-service';
 import {
   getOptionsPerService,
   getOriginalOptionsPerService,
   getServiceOptions
 } from './options-per-service';
+import type { OptionsPerService } from './options-per-service';
 
 describe('getOriginalOptionsPerService', () => {
   const config: OptionsPerService = {

--- a/packages/generator-common/src/options.ts
+++ b/packages/generator-common/src/options.ts
@@ -1,4 +1,3 @@
-import type { ServiceType } from './options-parser';
 import {
   buildResolveInputGlob,
   resolveGlob,
@@ -6,6 +5,7 @@ import {
   resolvePath,
   resolveRequiredPath
 } from './options-parser';
+import type { ServiceType } from './options-parser';
 
 function getReadmeText(serviceType: ServiceType): string {
   return serviceType === 'OData'

--- a/packages/generator/src/batch/file.ts
+++ b/packages/generator/src/batch/file.ts
@@ -1,9 +1,9 @@
-import type { SourceFileStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
-import type { VdmServiceMetadata } from '../vdm-types';
 import { batchFunction, changesetFunction } from './function';
 import { importBatchDeclarations } from './imports';
 import { readRequestType, writeRequestType } from './type';
+import type { VdmServiceMetadata } from '../vdm-types';
+import type { SourceFileStructure } from 'ts-morph';
 
 /**
  * @internal

--- a/packages/generator/src/batch/function.ts
+++ b/packages/generator/src/batch/function.ts
@@ -1,9 +1,9 @@
+import { StructureKind } from 'ts-morph';
+import { addLeadingNewline, getFunctionDoc } from '../typedoc';
 import type {
   FunctionDeclarationOverloadStructure,
   FunctionDeclarationStructure
 } from 'ts-morph';
-import { StructureKind } from 'ts-morph';
-import { addLeadingNewline, getFunctionDoc } from '../typedoc';
 import type { VdmServiceMetadata } from '../vdm-types';
 
 /**

--- a/packages/generator/src/batch/imports.ts
+++ b/packages/generator/src/batch/imports.ts
@@ -1,7 +1,7 @@
-import type { ImportDeclarationStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
 import { unique } from '@sap-cloud-sdk/util';
 import { odataImportDeclarationTsMorph } from '../imports';
+import type { ImportDeclarationStructure } from 'ts-morph';
 import type { VdmServiceMetadata } from '../vdm-types';
 
 /**

--- a/packages/generator/src/batch/type.ts
+++ b/packages/generator/src/batch/type.ts
@@ -1,7 +1,7 @@
-import type { TypeAliasDeclarationStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
-import type { VdmServiceMetadata } from '../vdm-types';
 import { operationReturnType } from '../operations';
+import type { TypeAliasDeclarationStructure } from 'ts-morph';
+import type { VdmServiceMetadata } from '../vdm-types';
 
 /**
  * @internal

--- a/packages/generator/src/cli-parser.ts
+++ b/packages/generator/src/cli-parser.ts
@@ -1,6 +1,6 @@
 import { parseCmdArgsBuilder } from '@sap-cloud-sdk/generator-common/internal';
-import type { GeneratorOptions } from './options';
 import { cliOptions } from './options';
+import type { GeneratorOptions } from './options';
 
 const commandText =
   'OData Client Code Generator for OData v2 and v4. Generates typed clients from EDMX and XML files for usage with the SAP Cloud SDK for JavaScript.';

--- a/packages/generator/src/complex-type/field-type-class.ts
+++ b/packages/generator/src/complex-type/field-type-class.ts
@@ -1,14 +1,14 @@
 import { unixEOL } from '@sap-cloud-sdk/util';
-import type {
-  ClassDeclarationStructure,
-  PropertyDeclarationStructure
-} from 'ts-morph';
 import { Scope, StructureKind } from 'ts-morph';
 import { getGenericParameters } from '../generator-utils';
 import {
   getComplexTypeFieldDescription,
   getComplexTypePropertyDescription
 } from '../typedoc';
+import type {
+  ClassDeclarationStructure,
+  PropertyDeclarationStructure
+} from 'ts-morph';
 import type { VdmComplexType, VdmProperty } from '../vdm-types';
 
 /**

--- a/packages/generator/src/complex-type/file.ts
+++ b/packages/generator/src/complex-type/file.ts
@@ -1,11 +1,11 @@
-import type { SourceFileStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
-import type { ODataVersion } from '@sap-cloud-sdk/util';
-import type { VdmComplexType } from '../vdm-types';
 import { fieldTypeClass } from './field-type-class';
 import { importDeclarations } from './imports';
 import { complexTypeInterface } from './interface';
 import { complexTypeNamespace } from './namespace';
+import type { VdmComplexType } from '../vdm-types';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
+import type { SourceFileStructure } from 'ts-morph';
 
 /**
  * @internal

--- a/packages/generator/src/complex-type/imports.spec.ts
+++ b/packages/generator/src/complex-type/imports.spec.ts
@@ -3,8 +3,8 @@ import {
   complexMeal,
   complexMealWithDesert
 } from '../../test/test-util/data-model';
-import type { VdmComplexType } from '../vdm-types';
 import { importDeclarations } from './imports';
+import type { VdmComplexType } from '../vdm-types';
 
 describe('complex type imports', () => {
   it('importDeclarations', () => {

--- a/packages/generator/src/complex-type/imports.ts
+++ b/packages/generator/src/complex-type/imports.ts
@@ -1,10 +1,10 @@
-import type { ImportDeclarationStructure } from 'ts-morph';
-import type { ODataVersion } from '@sap-cloud-sdk/util';
 import {
   complexTypeImportDeclarations,
   odataImportDeclarationTsMorph,
   enumTypeImportDeclarations
 } from '../imports';
+import type { ImportDeclarationStructure } from 'ts-morph';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
 import type { VdmComplexType } from '../vdm-types';
 
 /**

--- a/packages/generator/src/complex-type/interface.ts
+++ b/packages/generator/src/complex-type/interface.ts
@@ -1,9 +1,9 @@
+import { StructureKind } from 'ts-morph';
+import { getPropertyDescription, addLeadingNewline } from '../typedoc';
 import type {
   InterfaceDeclarationStructure,
   PropertySignatureStructure
 } from 'ts-morph';
-import { StructureKind } from 'ts-morph';
-import { getPropertyDescription, addLeadingNewline } from '../typedoc';
 import type { VdmComplexType, VdmProperty } from '../vdm-types';
 
 /**

--- a/packages/generator/src/complex-type/namespace.ts
+++ b/packages/generator/src/complex-type/namespace.ts
@@ -1,9 +1,9 @@
 import { unixEOL } from '@sap-cloud-sdk/util';
+import { StructureKind, VariableDeclarationKind } from 'ts-morph';
 import type {
   ModuleDeclarationStructure,
   VariableStatementStructure
 } from 'ts-morph';
-import { StructureKind, VariableDeclarationKind } from 'ts-morph';
 import type { VdmComplexType } from '../vdm-types';
 
 /**

--- a/packages/generator/src/edmx-parser/edmx-file-reader.ts
+++ b/packages/generator/src/edmx-parser/edmx-file-reader.ts
@@ -1,13 +1,13 @@
-import type { PathLike } from 'fs';
 import { readdirSync, readFileSync } from 'fs';
 import path, { basename, join, parse } from 'path';
 import { XMLParser } from 'fast-xml-parser';
-import type { ODataVersion } from '@sap-cloud-sdk/util';
 import { removeFileExtension } from '@sap-cloud-sdk/util';
 import { forceArray } from '../generator-utils';
-import type { SwaggerMetadata } from '../swagger-parser';
 import { readSwaggerFile } from '../swagger-parser';
 import { getMergedPropertyWithNamespace } from './common';
+import type { SwaggerMetadata } from '../swagger-parser';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
+import type { PathLike } from 'fs';
 /**
  * @internal
  */

--- a/packages/generator/src/edmx-parser/v2/edmx-parser.ts
+++ b/packages/generator/src/edmx-parser/v2/edmx-parser.ts
@@ -5,8 +5,8 @@ import {
   parseEntitySetsBase,
   parseEntityTypesBase
 } from '../common';
-import type { EdmxComplexTypeBase, EdmxEntitySetBase } from '../common';
 import { forceArray } from '../../generator-utils';
+import type { EdmxComplexTypeBase, EdmxEntitySetBase } from '../common';
 import type {
   EdmxAssociation,
   EdmxAssociationSet,

--- a/packages/generator/src/edmx-to-vdm/common/complex-type.ts
+++ b/packages/generator/src/edmx-to-vdm/common/complex-type.ts
@@ -4,12 +4,6 @@ import {
   getFallbackEdmTypeIfNeeded,
   isNullableProperty
 } from '../../generator-utils';
-import type { ServiceNameFormatter } from '../../service-name-formatter';
-import type {
-  VdmComplexType,
-  VdmMappedEdmType,
-  VdmEnumType
-} from '../../vdm-types';
 import { propertyDescription } from '../description-util';
 import {
   checkCollectionKind,
@@ -23,8 +17,14 @@ import {
   typesForCollection,
   enumTypeForName
 } from '../edmx-to-vdm-util';
-import type { EdmxComplexTypeBase } from '../../edmx-parser';
 import { applyPrefixOnJsConflictParam } from '../../name-formatting-strategies';
+import type { ServiceNameFormatter } from '../../service-name-formatter';
+import type {
+  VdmComplexType,
+  VdmMappedEdmType,
+  VdmEnumType
+} from '../../vdm-types';
+import type { EdmxComplexTypeBase } from '../../edmx-parser';
 
 /**
  * @internal

--- a/packages/generator/src/edmx-to-vdm/common/entity.ts
+++ b/packages/generator/src/edmx-to-vdm/common/entity.ts
@@ -1,9 +1,3 @@
-import type {
-  EdmxEntitySetBase,
-  EdmxEntityTypeBase,
-  EdmxNamed,
-  JoinedEntityMetadata
-} from '../../edmx-parser';
 import {
   edmToFieldType,
   edmToTsType,
@@ -14,16 +8,6 @@ import {
   isUpdatable
 } from '../../generator-utils';
 import { applyPrefixOnJsConflictParam } from '../../name-formatting-strategies';
-import type { ServiceNameFormatter } from '../../service-name-formatter';
-import type { SwaggerMetadata } from '../../swagger-parser';
-import type {
-  VdmComplexType,
-  VdmEntity,
-  VdmEnumType,
-  VdmMappedEdmType,
-  VdmNavigationProperty,
-  VdmProperty
-} from '../../vdm-types';
 import { entityDescription, propertyDescription } from '../description-util';
 import {
   checkCollectionKind,
@@ -37,6 +21,22 @@ import {
   parseCollectionTypeName,
   typesForCollection
 } from '../edmx-to-vdm-util';
+import type {
+  EdmxEntitySetBase,
+  EdmxEntityTypeBase,
+  EdmxNamed,
+  JoinedEntityMetadata
+} from '../../edmx-parser';
+import type { ServiceNameFormatter } from '../../service-name-formatter';
+import type { SwaggerMetadata } from '../../swagger-parser';
+import type {
+  VdmComplexType,
+  VdmEntity,
+  VdmEnumType,
+  VdmMappedEdmType,
+  VdmNavigationProperty,
+  VdmProperty
+} from '../../vdm-types';
 
 /**
  * @internal

--- a/packages/generator/src/edmx-to-vdm/common/operation-parameter.ts
+++ b/packages/generator/src/edmx-to-vdm/common/operation-parameter.ts
@@ -1,10 +1,10 @@
-import type { VdmParameter } from '../../vdm-types';
 import { isNullableProperty } from '../../generator-utils';
 import { parameterDescription } from '../description-util';
+import { getTypeMappingActionFunction } from '../edmx-to-vdm-util';
+import type { VdmParameter } from '../../vdm-types';
 import type { EdmxParameter, EdmxFunctionImportV2 } from '../../edmx-parser';
 import type { SwaggerPath } from '../../swagger-parser';
 import type { ServiceNameFormatter } from '../../service-name-formatter';
-import { getTypeMappingActionFunction } from '../edmx-to-vdm-util';
 import type { EdmxJoinedOperation } from '../v4';
 
 /**

--- a/packages/generator/src/edmx-to-vdm/common/operation-return-type.ts
+++ b/packages/generator/src/edmx-to-vdm/common/operation-return-type.ts
@@ -1,19 +1,19 @@
 import { first } from '@sap-cloud-sdk/util';
 import voca from 'voca';
-import type { EdmxReturnType } from '../../edmx-parser';
 import { isNullableProperty } from '../../generator-utils';
 // eslint-disable-next-line import/no-internal-modules
 import { getApiName } from '../../generator-without-ts-morph/service';
-import type {
-  VdmComplexType,
-  VdmPartialEntity,
-  VdmOperationReturnType
-} from '../../vdm-types';
 import {
   getTypeMappingActionFunction,
   isCollectionType,
   parseTypeName
 } from '../edmx-to-vdm-util';
+import type {
+  VdmComplexType,
+  VdmPartialEntity,
+  VdmOperationReturnType
+} from '../../vdm-types';
+import type { EdmxReturnType } from '../../edmx-parser';
 
 /**
  * @internal

--- a/packages/generator/src/edmx-to-vdm/common/operation.ts
+++ b/packages/generator/src/edmx-to-vdm/common/operation.ts
@@ -1,11 +1,11 @@
 import { pascalCase } from '@sap-cloud-sdk/util';
+import { functionImportDescription } from '../description-util';
+import { getOperationParameters } from './operation-parameter';
 import type { EdmxParameter, EdmxFunctionImportV2 } from '../../edmx-parser';
 import type { ServiceNameFormatter } from '../../service-name-formatter';
 import type { SwaggerPath } from '../../swagger-parser';
 import type { VdmOperationBase } from '../../vdm-types';
-import { functionImportDescription } from '../description-util';
 import type { EdmxJoinedOperation } from '../v4';
-import { getOperationParameters } from './operation-parameter';
 
 /**
  * @internal

--- a/packages/generator/src/edmx-to-vdm/edmx-to-vdm-util.ts
+++ b/packages/generator/src/edmx-to-vdm/edmx-to-vdm-util.ts
@@ -1,14 +1,14 @@
 import { createLogger, last } from '@sap-cloud-sdk/util';
-import type {
-  EdmxProperty,
-  EdmxMetadata,
-  EdmxFunctionImportV2
-} from '../edmx-parser';
 import {
   edmToFieldType,
   edmToTsType,
   getFallbackEdmTypeIfNeeded
 } from '../generator-utils';
+import type {
+  EdmxProperty,
+  EdmxMetadata,
+  EdmxFunctionImportV2
+} from '../edmx-parser';
 import type {
   VdmComplexType,
   VdmEnumType,

--- a/packages/generator/src/edmx-to-vdm/v2/complex-type.ts
+++ b/packages/generator/src/edmx-to-vdm/v2/complex-type.ts
@@ -1,7 +1,7 @@
 import { transformComplexTypesBase } from '../common';
+import { parseComplexTypesV2 } from '../../edmx-parser';
 import type { ServiceNameFormatter } from '../../service-name-formatter';
 import type { VdmComplexType } from '../../vdm-types';
-import { parseComplexTypesV2 } from '../../edmx-parser';
 import type { ServiceMetadata } from '../../edmx-parser';
 
 /**

--- a/packages/generator/src/edmx-to-vdm/v2/entity.ts
+++ b/packages/generator/src/edmx-to-vdm/v2/entity.ts
@@ -4,6 +4,13 @@ import {
   navigationPropertyBase,
   transformEntityBase
 } from '../common';
+import {
+  parseAssociation,
+  parseAssociationSets,
+  parseEntitySetsV2,
+  parseEntityTypes
+} from '../../edmx-parser';
+import { stripNamespace } from '../edmx-to-vdm-util';
 import type {
   VdmComplexType,
   VdmEntity,
@@ -20,13 +27,6 @@ import type {
   JoinedAssociationMetadata,
   ServiceMetadata
 } from '../../edmx-parser';
-import {
-  parseAssociation,
-  parseAssociationSets,
-  parseEntitySetsV2,
-  parseEntityTypes
-} from '../../edmx-parser';
-import { stripNamespace } from '../edmx-to-vdm-util';
 
 /**
  * @internal

--- a/packages/generator/src/edmx-to-vdm/v2/function-import.ts
+++ b/packages/generator/src/edmx-to-vdm/v2/function-import.ts
@@ -1,10 +1,10 @@
-import type { ServiceNameFormatter } from '../../service-name-formatter';
 import { transformOperationBase, parseOperationReturnType } from '../common';
-import type { VdmComplexType, VdmEntity, VdmOperation } from '../../vdm-types';
 import { getSwaggerDefinitionForOperation } from '../../swagger-parser';
 import { parseFunctionImportsV2 } from '../../edmx-parser';
-import type { ServiceMetadata } from '../../edmx-parser';
 import { hasUnsupportedParameterTypes } from '../edmx-to-vdm-util';
+import type { ServiceMetadata } from '../../edmx-parser';
+import type { VdmComplexType, VdmEntity, VdmOperation } from '../../vdm-types';
+import type { ServiceNameFormatter } from '../../service-name-formatter';
 
 const extractResponse = (functionName: string) => (response: string) =>
   `${response}.${functionName}`;

--- a/packages/generator/src/edmx-to-vdm/v2/service-entities.ts
+++ b/packages/generator/src/edmx-to-vdm/v2/service-entities.ts
@@ -1,9 +1,9 @@
-import type { ServiceMetadata } from '../../edmx-parser';
-import type { VdmServiceEntities } from '../../vdm-types';
 import { ServiceNameFormatter } from '../../service-name-formatter';
 import { generateFunctionImportsV2 } from './function-import';
 import { generateComplexTypesV2 } from './complex-type';
 import { generateEntitiesV2 } from './entity';
+import type { VdmServiceEntities } from '../../vdm-types';
+import type { ServiceMetadata } from '../../edmx-parser';
 
 /**
  * @internal

--- a/packages/generator/src/edmx-to-vdm/v4/complex-type.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/complex-type.ts
@@ -1,7 +1,7 @@
 import { transformComplexTypesBase } from '../common';
+import { parseComplexTypesV4 } from '../../edmx-parser';
 import type { ServiceNameFormatter } from '../../service-name-formatter';
 import type { VdmComplexType, VdmEnumType } from '../../vdm-types';
-import { parseComplexTypesV4 } from '../../edmx-parser';
 import type { ServiceMetadata } from '../../edmx-parser';
 
 /**

--- a/packages/generator/src/edmx-to-vdm/v4/entity.spec.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/entity.spec.ts
@@ -1,3 +1,6 @@
+import { ServiceNameFormatter } from '../../service-name-formatter';
+import { generateComplexTypesV4 } from './complex-type';
+import { generateEntitiesV4 } from './entity';
 import type { ServiceMetadata } from '../../edmx-parser';
 import type { EdmxProperty } from '../../edmx-parser/common';
 import type {
@@ -6,9 +9,6 @@ import type {
   EdmxEntityTypeV4,
   EdmxOperation
 } from '../../edmx-parser/v4';
-import { ServiceNameFormatter } from '../../service-name-formatter';
-import { generateComplexTypesV4 } from './complex-type';
-import { generateEntitiesV4 } from './entity';
 
 describe('entity', () => {
   it('transforms collection type properties for primitive types', () => {

--- a/packages/generator/src/edmx-to-vdm/v4/entity.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/entity.ts
@@ -1,17 +1,4 @@
-import type {
-  ServiceMetadata,
-  EdmxEntitySet,
-  EdmxEntityTypeV4
-} from '../../edmx-parser';
 import { parseEntitySetsV4, parseEntityType } from '../../edmx-parser';
-import type { ServiceNameFormatter } from '../../service-name-formatter';
-import type {
-  VdmComplexType,
-  VdmEntity,
-  VdmPartialEntity,
-  VdmEnumType,
-  VdmNavigationProperty
-} from '../../vdm-types';
 import {
   createEntityClassNames,
   joinEntityMetadata,
@@ -20,6 +7,19 @@ import {
 } from '../common';
 import { isCollectionType } from '../edmx-to-vdm-util';
 import { generateBoundOperations } from './operation';
+import type {
+  VdmComplexType,
+  VdmEntity,
+  VdmPartialEntity,
+  VdmEnumType,
+  VdmNavigationProperty
+} from '../../vdm-types';
+import type { ServiceNameFormatter } from '../../service-name-formatter';
+import type {
+  ServiceMetadata,
+  EdmxEntitySet,
+  EdmxEntityTypeV4
+} from '../../edmx-parser';
 
 /**
  * @internal

--- a/packages/generator/src/edmx-to-vdm/v4/enum-type.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/enum-type.ts
@@ -1,8 +1,8 @@
-import type { ServiceNameFormatter } from '../../service-name-formatter';
 import { parseEnumTypes } from '../../edmx-parser';
+import { transformEnumTypesBase } from '../common';
+import type { ServiceNameFormatter } from '../../service-name-formatter';
 import type { ServiceMetadata } from '../../edmx-parser';
 import type { VdmEnumType } from '../../vdm-types';
-import { transformEnumTypesBase } from '../common';
 
 /**
  * @internal

--- a/packages/generator/src/edmx-to-vdm/v4/operation-util.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/operation-util.ts
@@ -1,5 +1,5 @@
-import type { EdmxOperation } from '../../edmx-parser';
 import { stripNamespace } from '../edmx-to-vdm-util';
+import type { EdmxOperation } from '../../edmx-parser';
 
 /**
  * @internal

--- a/packages/generator/src/edmx-to-vdm/v4/operation.spec.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/operation.spec.ts
@@ -1,13 +1,4 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import type { EdmxParameter, EdmxProperty } from '../../edmx-parser/common';
-import type {
-  EdmxComplexType,
-  EdmxEntitySet,
-  EdmxEntityTypeV4,
-  EdmxOperation,
-  EdmxOperationImport
-} from '../../edmx-parser/v4';
-import type { ServiceMetadata } from '../../edmx-parser';
 import { generateEntitiesV4 } from './entity';
 import {
   filterAndTransformOperations,
@@ -15,6 +6,15 @@ import {
 } from './operation';
 import { generateComplexTypesV4 } from './complex-type';
 import { createEntityType, getComplexType, getFormatter } from './entity.spec';
+import type { ServiceMetadata } from '../../edmx-parser';
+import type {
+  EdmxComplexType,
+  EdmxEntitySet,
+  EdmxEntityTypeV4,
+  EdmxOperation,
+  EdmxOperationImport
+} from '../../edmx-parser/v4';
+import type { EdmxParameter, EdmxProperty } from '../../edmx-parser/common';
 
 describe('action-import', () => {
   beforeEach(() => {

--- a/packages/generator/src/edmx-to-vdm/v4/operation.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/operation.ts
@@ -1,4 +1,15 @@
 import { createLogger } from '@sap-cloud-sdk/util';
+import { parseOperationImports, parseOperations } from '../../edmx-parser';
+import { getSwaggerDefinitionForOperation } from '../../swagger-parser';
+import { transformOperationBase, parseOperationReturnType } from '../common';
+import { hasUnsupportedParameterTypes } from '../edmx-to-vdm-util';
+import { findOperationByImportName } from './operation-util';
+import type {
+  VdmComplexType,
+  VdmOperation,
+  VdmPartialEntity
+} from '../../vdm-types';
+import type { ServiceNameFormatter } from '../../service-name-formatter';
 import type {
   EdmxParameter,
   ServiceMetadata,
@@ -6,17 +17,6 @@ import type {
   EdmxOperationImport,
   EdmxReturnType
 } from '../../edmx-parser';
-import { parseOperationImports, parseOperations } from '../../edmx-parser';
-import type { ServiceNameFormatter } from '../../service-name-formatter';
-import { getSwaggerDefinitionForOperation } from '../../swagger-parser';
-import type {
-  VdmComplexType,
-  VdmOperation,
-  VdmPartialEntity
-} from '../../vdm-types';
-import { transformOperationBase, parseOperationReturnType } from '../common';
-import { hasUnsupportedParameterTypes } from '../edmx-to-vdm-util';
-import { findOperationByImportName } from './operation-util';
 
 const logger = createLogger({
   package: 'generator',

--- a/packages/generator/src/edmx-to-vdm/v4/service-entities.ts
+++ b/packages/generator/src/edmx-to-vdm/v4/service-entities.ts
@@ -1,10 +1,10 @@
-import type { ServiceMetadata } from '../../edmx-parser';
 import { ServiceNameFormatter } from '../../service-name-formatter';
-import type { VdmServiceEntities } from '../../vdm-types';
 import { generateUnboundOperations } from './operation';
 import { generateComplexTypesV4 } from './complex-type';
 import { generateEntitiesV4 } from './entity';
 import { generateEnumTypesV4 } from './enum-type';
+import type { VdmServiceEntities } from '../../vdm-types';
+import type { ServiceMetadata } from '../../edmx-parser';
 
 /**
  * @internal

--- a/packages/generator/src/entity/class.ts
+++ b/packages/generator/src/entity/class.ts
@@ -1,8 +1,3 @@
-import type {
-  ClassDeclarationStructure,
-  MethodDeclarationStructure,
-  PropertyDeclarationStructure
-} from 'ts-morph';
 import { StructureKind } from 'ts-morph';
 import { prependPrefix } from '../internal-prefix';
 import { operationFunctionBase } from '../operations';
@@ -12,6 +7,11 @@ import {
   getNavPropertyDescription,
   getPropertyDescription
 } from '../typedoc';
+import type {
+  ClassDeclarationStructure,
+  MethodDeclarationStructure,
+  PropertyDeclarationStructure
+} from 'ts-morph';
 import type {
   VdmEntity,
   VdmNavigationProperty,

--- a/packages/generator/src/entity/file.ts
+++ b/packages/generator/src/entity/file.ts
@@ -1,10 +1,10 @@
-import type { SourceFileStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
 import { parametersInterface } from '../operations';
-import type { VdmEntity, VdmServiceMetadata } from '../vdm-types';
 import { entityClass } from './class';
 import { entityImportDeclarations, otherEntityImports } from './imports';
 import { entityTypeInterface } from './interface';
+import type { VdmEntity, VdmServiceMetadata } from '../vdm-types';
+import type { SourceFileStructure } from 'ts-morph';
 
 /**
  * @internal

--- a/packages/generator/src/entity/imports.ts
+++ b/packages/generator/src/entity/imports.ts
@@ -1,5 +1,3 @@
-import type { ODataVersion } from '@sap-cloud-sdk/util';
-import type { ImportDeclarationStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
 import {
   complexTypeImportDeclarations,
@@ -8,6 +6,8 @@ import {
   odataImportDeclarationTsMorph
 } from '../imports';
 import { operationDeclarations } from '../operations';
+import type { ImportDeclarationStructure } from 'ts-morph';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
 import type { VdmEntity, VdmServiceMetadata } from '../vdm-types';
 
 /**

--- a/packages/generator/src/entity/interface.ts
+++ b/packages/generator/src/entity/interface.ts
@@ -1,15 +1,15 @@
+import { StructureKind } from 'ts-morph';
+import { getPropertyType } from './class';
 import type {
   InterfaceDeclarationStructure,
   PropertySignatureStructure
 } from 'ts-morph';
-import { StructureKind } from 'ts-morph';
 import type {
   VdmEntity,
   VdmNavigationProperty,
   VdmProperty,
   VdmServiceMetadata
 } from '../vdm-types';
-import { getPropertyType } from './class';
 
 /**
  * @internal

--- a/packages/generator/src/entity/namespace.spec.ts
+++ b/packages/generator/src/entity/namespace.spec.ts
@@ -1,4 +1,3 @@
-import type { VariableStatementStructure } from 'ts-morph';
 import {
   breakfastEntity,
   breakfastTime,
@@ -8,6 +7,7 @@ import {
   toBrunch
 } from '../../test/test-util/data-model';
 import { entityNamespace } from './namespace';
+import type { VariableStatementStructure } from 'ts-morph';
 
 describe('entity namespace', () => {
   it('creates namespace', () => {

--- a/packages/generator/src/entity/namespace.ts
+++ b/packages/generator/src/entity/namespace.ts
@@ -1,10 +1,4 @@
 import { unixEOL, unique } from '@sap-cloud-sdk/util';
-import type {
-  ModuleDeclarationStructure,
-  VariableStatementStructure,
-  OptionalKind,
-  VariableDeclarationStructure
-} from 'ts-morph';
 import { StructureKind, VariableDeclarationKind } from 'ts-morph';
 import { isOrderableEdmType } from '@sap-cloud-sdk/odata-common';
 import { getGenericParameters, linkClass } from '../generator-utils';
@@ -14,6 +8,12 @@ import {
   getStaticPropertyDescription,
   addLeadingNewline
 } from '../typedoc';
+import type {
+  ModuleDeclarationStructure,
+  VariableStatementStructure,
+  OptionalKind,
+  VariableDeclarationStructure
+} from 'ts-morph';
 import type {
   VdmEntity,
   VdmNavigationProperty,

--- a/packages/generator/src/enum-type/enum.ts
+++ b/packages/generator/src/enum-type/enum.ts
@@ -1,7 +1,7 @@
-import type { EnumDeclarationStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
-import type { VdmEnumType } from '../vdm-types';
 import { addLeadingNewline, enumDocs } from '../typedoc';
+import type { EnumDeclarationStructure } from 'ts-morph';
+import type { VdmEnumType } from '../vdm-types';
 
 /**
  * @internal

--- a/packages/generator/src/enum-type/file.ts
+++ b/packages/generator/src/enum-type/file.ts
@@ -1,7 +1,7 @@
-import type { SourceFileStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
-import type { VdmEnumType } from '../vdm-types';
 import { enumTypeClass } from './enum';
+import type { SourceFileStructure } from 'ts-morph';
+import type { VdmEnumType } from '../vdm-types';
 
 /**
  * @internal

--- a/packages/generator/src/file-generator.ts
+++ b/packages/generator/src/file-generator.ts
@@ -1,7 +1,7 @@
 import { parse } from 'path';
+import { createFile } from '@sap-cloud-sdk/generator-common/internal';
 import type { Directory, SourceFile, SourceFileStructure } from 'ts-morph';
 import type { CreateFileOptions } from '@sap-cloud-sdk/generator-common/internal';
-import { createFile } from '@sap-cloud-sdk/generator-common/internal';
 
 /**
  * @internal

--- a/packages/generator/src/generator-utils.ts
+++ b/packages/generator/src/generator-utils.ts
@@ -1,5 +1,5 @@
-import type { ODataVersion } from '@sap-cloud-sdk/util';
 import { createLogger } from '@sap-cloud-sdk/util';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
 import type {
   VdmNavigationProperty,
   VdmProperty,

--- a/packages/generator/src/generator-without-ts-morph/entity-api/class.ts
+++ b/packages/generator/src/generator-without-ts-morph/entity-api/class.ts
@@ -1,11 +1,11 @@
 import { codeBlock, documentationBlock } from '@sap-cloud-sdk/util';
-import type { VdmEntity, VdmServiceMetadata } from '../../vdm-types';
 import {
   addNavigationPropertyFieldsFunction,
   navigationPropertyFieldsVariable
 } from './navigation-properties';
 import { getSchema } from './schema';
 import { getSchemaType } from './schema-type';
+import type { VdmEntity, VdmServiceMetadata } from '../../vdm-types';
 
 /**
  * @internal

--- a/packages/generator/src/generator-without-ts-morph/entity-api/file.ts
+++ b/packages/generator/src/generator-without-ts-morph/entity-api/file.ts
@@ -1,7 +1,5 @@
 import { unixEOL } from '@sap-cloud-sdk/util';
-import type { Import } from '@sap-cloud-sdk/generator-common/internal';
 import { serializeImports } from '@sap-cloud-sdk/generator-common/internal';
-import type { VdmEntity, VdmServiceMetadata } from '../../vdm-types';
 import {
   navPropertyFieldTypeImportNames,
   propertyFieldTypeImportNames,
@@ -9,6 +7,8 @@ import {
 } from '../../imports';
 import { odataImport, complexTypeImports, enumTypeImports } from './imports';
 import { classContent } from './class';
+import type { VdmEntity, VdmServiceMetadata } from '../../vdm-types';
+import type { Import } from '@sap-cloud-sdk/generator-common/internal';
 
 /**
  * @internal

--- a/packages/generator/src/generator-without-ts-morph/entity-api/import.spec.ts
+++ b/packages/generator/src/generator-without-ts-morph/entity-api/import.spec.ts
@@ -1,5 +1,5 @@
-import type { Import } from '@sap-cloud-sdk/generator-common/internal';
 import { mergeImports } from './imports';
+import type { Import } from '@sap-cloud-sdk/generator-common/internal';
 
 describe('entity api import', () => {
   it('merge imports', () => {

--- a/packages/generator/src/generator-without-ts-morph/entity-api/imports.ts
+++ b/packages/generator/src/generator-without-ts-morph/entity-api/imports.ts
@@ -1,8 +1,8 @@
-import type { ODataVersion } from '@sap-cloud-sdk/util';
 import { unique } from '@sap-cloud-sdk/util';
+import { potentialExternalImportDeclarations } from '../../imports';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
 import type { Import } from '@sap-cloud-sdk/generator-common/internal';
 import type { VdmMappedEdmType, VdmProperty } from '../../vdm-types';
-import { potentialExternalImportDeclarations } from '../../imports';
 
 /**
  * @internal

--- a/packages/generator/src/generator-without-ts-morph/entity-api/navigation-properties.ts
+++ b/packages/generator/src/generator-without-ts-morph/entity-api/navigation-properties.ts
@@ -1,12 +1,12 @@
 import { codeBlock, documentationBlock } from '@sap-cloud-sdk/util';
 import { linkClass } from '../../generator-utils';
 import { getStaticNavPropertyDescription } from '../../typedoc';
+import { matchEntity } from './match-entity';
 import type {
   VdmEntity,
   VdmServiceMetadata,
   VdmNavigationProperty
 } from '../../vdm-types';
-import { matchEntity } from './match-entity';
 
 /**
  * @internal

--- a/packages/generator/src/generator-without-ts-morph/entity-api/schema-type.ts
+++ b/packages/generator/src/generator-without-ts-morph/entity-api/schema-type.ts
@@ -1,10 +1,10 @@
+import { createPropertyFieldType } from '../../entity';
+import { navigationPropertyTypes } from './navigation-properties';
 import type {
   VdmEntity,
   VdmProperty,
   VdmServiceMetadata
 } from '../../vdm-types';
-import { createPropertyFieldType } from '../../entity';
-import { navigationPropertyTypes } from './navigation-properties';
 
 /**
  * @internal

--- a/packages/generator/src/generator-without-ts-morph/entity-api/schema.ts
+++ b/packages/generator/src/generator-without-ts-morph/entity-api/schema.ts
@@ -1,7 +1,7 @@
 import { documentationBlock } from '@sap-cloud-sdk/util';
-import type { VdmEntity, VdmProperty } from '../../vdm-types';
 import { addLeadingNewline, getStaticPropertyDescription } from '../../typedoc';
 import { createPropertyFieldInitializerForEntity } from '../../entity';
+import type { VdmEntity, VdmProperty } from '../../vdm-types';
 
 /**
  * @internal

--- a/packages/generator/src/generator-without-ts-morph/imports.ts
+++ b/packages/generator/src/generator-without-ts-morph/imports.ts
@@ -1,7 +1,7 @@
-import type { Import } from '@sap-cloud-sdk/generator-common/internal';
-import type { ODataVersion } from '@sap-cloud-sdk/util';
 import { unique } from '@sap-cloud-sdk/util';
 import { potentialExternalImportDeclarations } from '../imports';
+import type { Import } from '@sap-cloud-sdk/generator-common/internal';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
 import type { VdmMappedEdmType } from '../vdm-types';
 
 /**

--- a/packages/generator/src/generator-without-ts-morph/request-builder/class.spec.ts
+++ b/packages/generator/src/generator-without-ts-morph/request-builder/class.spec.ts
@@ -1,6 +1,6 @@
 import { breakfastEntity } from '../../../test/test-util/data-model';
-import type { VdmProperty } from '../../vdm-types';
 import { requestBuilderClass } from './class';
+import type { VdmProperty } from '../../vdm-types';
 
 describe('request builder class', () => {
   it('should generate request builder correctly', () => {

--- a/packages/generator/src/generator-without-ts-morph/request-builder/file.ts
+++ b/packages/generator/src/generator-without-ts-morph/request-builder/file.ts
@@ -1,9 +1,9 @@
 import { serializeImports } from '@sap-cloud-sdk/generator-common/internal';
-import type { ODataVersion } from '@sap-cloud-sdk/util';
 import { unixEOL } from '@sap-cloud-sdk/util';
-import type { VdmEntity } from '../../vdm-types';
 import { requestBuilderClass } from './class';
 import { requestBuilderImportDeclarations } from './imports';
+import type { VdmEntity } from '../../vdm-types';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
 
 /**
  * @internal

--- a/packages/generator/src/generator-without-ts-morph/request-builder/imports.ts
+++ b/packages/generator/src/generator-without-ts-morph/request-builder/imports.ts
@@ -1,9 +1,9 @@
-import type { Import } from '@sap-cloud-sdk/generator-common/internal';
-import type { ODataVersion } from '@sap-cloud-sdk/util';
 import { unique } from '@sap-cloud-sdk/util';
 import { propertyTypeImportNames } from '../../imports';
-import type { VdmEntity, VdmProperty } from '../../vdm-types';
 import { externalImportDeclarations, odataImportDeclaration } from '../imports';
+import type { Import } from '@sap-cloud-sdk/generator-common/internal';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
+import type { VdmEntity, VdmProperty } from '../../vdm-types';
 
 /**
  * @internal

--- a/packages/generator/src/generator-without-ts-morph/service/class.spec.ts
+++ b/packages/generator/src/generator-without-ts-morph/service/class.spec.ts
@@ -1,5 +1,5 @@
-import type { VdmOperation, VdmServiceMetadata } from '../../vdm-types';
 import { serviceClass } from './class';
+import type { VdmOperation, VdmServiceMetadata } from '../../vdm-types';
 
 describe('class', () => {
   const service: VdmServiceMetadata = {

--- a/packages/generator/src/generator-without-ts-morph/service/class.ts
+++ b/packages/generator/src/generator-without-ts-morph/service/class.ts
@@ -1,7 +1,5 @@
-import type { ODataVersion } from '@sap-cloud-sdk/util';
 import { codeBlock } from '@sap-cloud-sdk/util';
 import voca from 'voca';
-import type { VdmEntity, VdmServiceMetadata } from '../../vdm-types';
 // eslint-disable-next-line import/no-internal-modules
 import { matchEntity } from '../entity-api/match-entity';
 import {
@@ -9,6 +7,8 @@ import {
   getGenericTypesWithDefault
 } from '../de-serializers-generic-types';
 import { hasEntities } from '../../generator-utils';
+import type { VdmEntity, VdmServiceMetadata } from '../../vdm-types';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
 
 /**
  * @internal

--- a/packages/generator/src/generator-without-ts-morph/service/file.ts
+++ b/packages/generator/src/generator-without-ts-morph/service/file.ts
@@ -1,9 +1,9 @@
 import { codeBlock } from '@sap-cloud-sdk/util';
-import type { Import } from '@sap-cloud-sdk/generator-common/internal';
 import { serializeImports } from '@sap-cloud-sdk/generator-common/internal';
 import { hasEntities } from '../../generator-utils';
-import type { VdmServiceMetadata } from '../../vdm-types';
 import { serviceBuilder, serviceClass } from './class';
+import type { VdmServiceMetadata } from '../../vdm-types';
+import type { Import } from '@sap-cloud-sdk/generator-common/internal';
 
 /**
  * @internal

--- a/packages/generator/src/generator.spec.ts
+++ b/packages/generator/src/generator.spec.ts
@@ -1,7 +1,6 @@
 import { join, resolve } from 'path';
 import { promises } from 'fs';
 import { transports } from 'winston';
-import type { SourceFile } from 'ts-morph';
 import mock from 'mock-fs';
 import prettier from 'prettier';
 import { createLogger } from '@sap-cloud-sdk/util';
@@ -22,6 +21,7 @@ import {
   generateProject,
   getInstallODataErrorMessage
 } from './generator';
+import type { SourceFile } from 'ts-morph';
 
 const { readFile } = promises;
 

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -1,9 +1,5 @@
 import { existsSync, promises as fsPromises } from 'fs';
 import { dirname, join, resolve } from 'path';
-import type {
-  CreateFileOptions,
-  OptionsPerService
-} from '@sap-cloud-sdk/generator-common/internal';
 import {
   copyFiles,
   createFile,
@@ -26,7 +22,6 @@ import {
   splitInChunks
 } from '@sap-cloud-sdk/util';
 import { emptyDirSync } from 'fs-extra';
-import type { ProjectOptions } from 'ts-morph';
 import {
   IndentationText,
   ModuleKind,
@@ -40,7 +35,6 @@ import { complexTypeSourceFile } from './complex-type';
 import { entitySourceFile } from './entity';
 import { enumTypeSourceFile } from './enum-type';
 import { sourceFile } from './file-generator';
-import type { GeneratorOptions, ParsedGeneratorOptions } from './options';
 import { cliOptions } from './options';
 import { hasEntities } from './generator-utils';
 import {
@@ -52,6 +46,12 @@ import { operationsSourceFile } from './operations';
 import { sdkMetadata } from './sdk-metadata';
 import { parseAllServices } from './service-generator';
 import { indexFile, packageJson, readme } from './service';
+import type { GeneratorOptions, ParsedGeneratorOptions } from './options';
+import type { ProjectOptions } from 'ts-morph';
+import type {
+  CreateFileOptions,
+  OptionsPerService
+} from '@sap-cloud-sdk/generator-common/internal';
 import type { VdmServiceMetadata } from './vdm-types';
 
 const { mkdir, readdir } = fsPromises;

--- a/packages/generator/src/imports.spec.ts
+++ b/packages/generator/src/imports.spec.ts
@@ -1,10 +1,8 @@
-import type { ImportDeclarationStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
 import {
   bigNumberImport,
   momentImport
 } from '../test/test-util/import-declaration-structures';
-import type { VdmNavigationProperty, VdmProperty } from './vdm-types';
 import {
   complexTypeImportDeclarations,
   navPropertyFieldTypeImportNames,
@@ -13,6 +11,8 @@ import {
   externalImportDeclarationsTsMorph,
   mergeImportDeclarations
 } from './imports';
+import type { VdmNavigationProperty, VdmProperty } from './vdm-types';
+import type { ImportDeclarationStructure } from 'ts-morph';
 
 const momentProperty = {
   jsType: 'Moment',

--- a/packages/generator/src/imports.ts
+++ b/packages/generator/src/imports.ts
@@ -1,8 +1,8 @@
-import type { ODataVersion } from '@sap-cloud-sdk/util';
 import { unique } from '@sap-cloud-sdk/util';
-import type { ImportDeclarationStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
 import { linkClass } from './generator-utils';
+import type { ImportDeclarationStructure } from 'ts-morph';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
 import type {
   VdmMappedEdmType,
   VdmNavigationProperty,

--- a/packages/generator/src/input-path-provider.ts
+++ b/packages/generator/src/input-path-provider.ts
@@ -1,6 +1,6 @@
-import type { PathLike } from 'fs';
 import { lstatSync, readdirSync, existsSync } from 'fs';
 import { join, extname, parse } from 'path';
+import type { PathLike } from 'fs';
 
 const validFileExtensions = ['.edmx', '.xml'];
 

--- a/packages/generator/src/operations/export-statement.ts
+++ b/packages/generator/src/operations/export-statement.ts
@@ -1,5 +1,5 @@
-import type { VariableStatementStructure } from 'ts-morph';
 import { StructureKind, VariableDeclarationKind } from 'ts-morph';
+import type { VariableStatementStructure } from 'ts-morph';
 import type { VdmOperation } from '../vdm-types';
 
 /**

--- a/packages/generator/src/operations/file.ts
+++ b/packages/generator/src/operations/file.ts
@@ -1,15 +1,15 @@
 import { flat } from '@sap-cloud-sdk/util';
+import { StructureKind } from 'ts-morph';
+import { parametersInterface } from './parameters-interface';
+import { exportStatement } from './export-statement';
+import { operationDeclarations } from './import';
+import { operationFunction } from './operation';
+import type { VdmOperation, VdmServiceMetadata } from '../vdm-types';
 import type {
   FunctionDeclarationStructure,
   InterfaceDeclarationStructure,
   SourceFileStructure
 } from 'ts-morph';
-import { StructureKind } from 'ts-morph';
-import type { VdmOperation, VdmServiceMetadata } from '../vdm-types';
-import { parametersInterface } from './parameters-interface';
-import { exportStatement } from './export-statement';
-import { operationDeclarations } from './import';
-import { operationFunction } from './operation';
 
 /**
  * @internal

--- a/packages/generator/src/operations/import.spec.ts
+++ b/packages/generator/src/operations/import.spec.ts
@@ -1,6 +1,6 @@
 import { orderBreakfast } from '../../test/test-util/data-model';
-import type { VdmServiceMetadata } from '../vdm-types';
 import { operationDeclarations } from './import';
+import type { VdmServiceMetadata } from '../vdm-types';
 
 describe('import declarations for operations', () => {
   it('returns empty list when there are no functions', () => {

--- a/packages/generator/src/operations/import.ts
+++ b/packages/generator/src/operations/import.ts
@@ -1,11 +1,5 @@
-import type { ImportDeclarationStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
 import voca from 'voca';
-import type {
-  VdmOperationReturnType,
-  VdmOperation,
-  VdmServiceMetadata
-} from '../vdm-types';
 import {
   odataImportDeclarationTsMorph,
   propertyTypeImportNames,
@@ -14,6 +8,12 @@ import {
 } from '../imports';
 import { cannotDeserialize } from '../edmx-to-vdm';
 import { responseTransformerFunctionName } from './response-transformer-function';
+import type {
+  VdmOperationReturnType,
+  VdmOperation,
+  VdmServiceMetadata
+} from '../vdm-types';
+import type { ImportDeclarationStructure } from 'ts-morph';
 
 function complexTypeRelatedImports(returnTypes: VdmOperationReturnType[]) {
   return returnTypes.some(

--- a/packages/generator/src/operations/operation.ts
+++ b/packages/generator/src/operations/operation.ts
@@ -1,12 +1,12 @@
+import { StructureKind } from 'ts-morph';
+import { cannotDeserialize } from '../edmx-to-vdm';
+import { getRequestBuilderArguments } from './request-builder-arguments';
+import { operationReturnType } from './return-type';
+import type { VdmOperation, VdmServiceMetadata } from '../vdm-types';
 import type {
   FunctionDeclarationStructure,
   FunctionLikeDeclarationStructure
 } from 'ts-morph';
-import { StructureKind } from 'ts-morph';
-import { cannotDeserialize } from '../edmx-to-vdm';
-import type { VdmOperation, VdmServiceMetadata } from '../vdm-types';
-import { getRequestBuilderArguments } from './request-builder-arguments';
-import { operationReturnType } from './return-type';
 
 const parameterName = 'parameters';
 

--- a/packages/generator/src/operations/parameters-interface.ts
+++ b/packages/generator/src/operations/parameters-interface.ts
@@ -1,7 +1,7 @@
-import type { InterfaceDeclarationStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
-import type { VdmOperation } from '../vdm-types';
 import { addLeadingNewline } from '../typedoc';
+import type { InterfaceDeclarationStructure } from 'ts-morph';
+import type { VdmOperation } from '../vdm-types';
 
 /**
  * @internal

--- a/packages/generator/src/operations/request-builder-arguments.ts
+++ b/packages/generator/src/operations/request-builder-arguments.ts
@@ -1,6 +1,6 @@
-import type { VdmOperation, VdmServiceMetadata } from '../vdm-types';
 import { cannotDeserialize } from '../edmx-to-vdm';
 import { responseTransformerFunctionName } from './response-transformer-function';
+import type { VdmOperation, VdmServiceMetadata } from '../vdm-types';
 
 /**
  * @internal

--- a/packages/generator/src/operations/response-transformer-function.spec.ts
+++ b/packages/generator/src/operations/response-transformer-function.spec.ts
@@ -1,6 +1,6 @@
 import { orderBreakfast } from '../../test/test-util/data-model';
-import type { VdmOperationReturnType } from '../vdm-types';
 import { responseTransformerFunctionName } from './response-transformer-function';
+import type { VdmOperationReturnType } from '../vdm-types';
 
 const returnTypeEntity: VdmOperationReturnType = {
   builderFunction: '',

--- a/packages/generator/src/operations/return-type.ts
+++ b/packages/generator/src/operations/return-type.ts
@@ -1,5 +1,5 @@
-import type { VdmOperation } from '../vdm-types';
 import { cannotDeserialize } from '../edmx-to-vdm';
+import type { VdmOperation } from '../vdm-types';
 /**
  * @internal
  */

--- a/packages/generator/src/options/options.ts
+++ b/packages/generator/src/options/options.ts
@@ -1,9 +1,9 @@
+import { getCommonCliOptions } from '@sap-cloud-sdk/generator-common/internal';
 import type {
   Options,
   ParsedOptions,
   CommonGeneratorOptions
 } from '@sap-cloud-sdk/generator-common/internal';
-import { getCommonCliOptions } from '@sap-cloud-sdk/generator-common/internal';
 
 /**
  * Options to configure OData client generation when using the generator programmatically.

--- a/packages/generator/src/sdk-metadata/code-sample-util.spec.ts
+++ b/packages/generator/src/sdk-metadata/code-sample-util.spec.ts
@@ -1,5 +1,4 @@
 import { getLevenshteinClosest } from '@sap-cloud-sdk/generator-common/internal';
-import type { VdmEntity, VdmOperation, VdmParameter } from '../vdm-types';
 import {
   sampleOperation,
   getOperationParams,
@@ -7,6 +6,7 @@ import {
   getOperationWithoutParameters,
   getODataEntity
 } from './code-sample-util';
+import type { VdmEntity, VdmOperation, VdmParameter } from '../vdm-types';
 
 describe('code-sample-utils entity', () => {
   it('gets entity based on levenshtein algorithm', () => {

--- a/packages/generator/src/sdk-metadata/code-samples.ts
+++ b/packages/generator/src/sdk-metadata/code-samples.ts
@@ -1,9 +1,9 @@
 import { codeBlock } from '@sap-cloud-sdk/util';
-import type { MultiLineText } from '@sap-cloud-sdk/generator-common/internal';
 import voca from 'voca';
-import type { VdmOperation } from '../vdm-types';
 import { getApiName } from '../generator-without-ts-morph';
 import { getOperationParams } from './code-sample-util';
+import type { VdmOperation } from '../vdm-types';
+import type { MultiLineText } from '@sap-cloud-sdk/generator-common/internal';
 
 /**
  * @internal

--- a/packages/generator/src/sdk-metadata/generation-and-usage.spec.ts
+++ b/packages/generator/src/sdk-metadata/generation-and-usage.spec.ts
@@ -1,9 +1,9 @@
 import { resolve } from 'path';
 import { writeFile, readFile, removeSync } from 'fs-extra';
 import execa from 'execa';
-import type { VdmServiceMetadata } from '../vdm-types';
 import { getApiSpecificUsage } from './generation-and-usage';
 import { entityCodeSample } from './code-samples';
+import type { VdmServiceMetadata } from '../vdm-types';
 
 describe('generation-and-usage', () => {
   const service = {

--- a/packages/generator/src/sdk-metadata/generation-and-usage.ts
+++ b/packages/generator/src/sdk-metadata/generation-and-usage.ts
@@ -1,7 +1,7 @@
-import type { MultiLineText } from '@sap-cloud-sdk/generator-common/internal';
-import type { VdmServiceMetadata } from '../vdm-types';
 import { entityCodeSample, operationCodeSample } from './code-samples';
 import { sampleOperation, getODataEntity } from './code-sample-util';
+import type { MultiLineText } from '@sap-cloud-sdk/generator-common/internal';
+import type { VdmServiceMetadata } from '../vdm-types';
 
 /**
  * @internal

--- a/packages/generator/src/sdk-metadata/pregenerated-lib.spec.ts
+++ b/packages/generator/src/sdk-metadata/pregenerated-lib.spec.ts
@@ -3,11 +3,11 @@ import {
   packageDescription,
   parseOptions
 } from '@sap-cloud-sdk/generator-common/internal';
-import type { VdmServiceMetadata } from '../vdm-types';
 import { parseService } from '../service-generator';
 import { createOptions } from '../../test/test-util/create-generator-options';
 import { oDataServiceSpecs } from '../../../../test-resources/odata-service-specs';
 import { cliOptions } from '../options';
+import type { VdmServiceMetadata } from '../vdm-types';
 describe('pregenerated-lib', () => {
   it('returns description of the service', async () => {
     const service: VdmServiceMetadata = await getTestService();

--- a/packages/generator/src/sdk-metadata/sdk-metadata.ts
+++ b/packages/generator/src/sdk-metadata/sdk-metadata.ts
@@ -1,10 +1,10 @@
-import type { Client } from '@sap-cloud-sdk/generator-common/internal';
 import {
   getSdkMetadataClient,
   getSdkVersion
 } from '@sap-cloud-sdk/generator-common/internal';
-import type { VdmServiceMetadata } from '../vdm-types';
 import { getApiSpecificUsage } from './generation-and-usage';
+import type { Client } from '@sap-cloud-sdk/generator-common/internal';
+import type { VdmServiceMetadata } from '../vdm-types';
 
 /**
  * @internal

--- a/packages/generator/src/service-base-path.spec.ts
+++ b/packages/generator/src/service-base-path.spec.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import type { ServiceOptions } from '@sap-cloud-sdk/generator-common/dist/options-per-service';
 import { getBasePath } from './service-base-path';
+import type { ServiceOptions } from '@sap-cloud-sdk/generator-common/dist/options-per-service';
 
 describe('options-per-service', () => {
   it('gets basePath from optionsPerService over edmx self link and swagger', () => {

--- a/packages/generator/src/service-base-path.ts
+++ b/packages/generator/src/service-base-path.ts
@@ -1,7 +1,7 @@
 import { parse } from 'path';
 import { createLogger } from '@sap-cloud-sdk/util';
-import type { ServiceOptions } from '@sap-cloud-sdk/generator-common/internal';
 import { basePathFromSwagger } from './swagger-parser';
+import type { ServiceOptions } from '@sap-cloud-sdk/generator-common/internal';
 import type { ServiceMetadata } from './edmx-parser';
 
 const logger = createLogger({

--- a/packages/generator/src/service-generator.spec.ts
+++ b/packages/generator/src/service-generator.spec.ts
@@ -1,12 +1,12 @@
 import { resolve } from 'path';
-import type { ServiceOptions } from '@sap-cloud-sdk/generator-common/dist/options-per-service';
 import mock from 'mock-fs';
-import type { OptionsPerService } from '@sap-cloud-sdk/generator-common/internal';
 import { getRelPathWithPosixSeparator } from '@sap-cloud-sdk/generator-common/internal';
 import { createParsedOptions } from '../test/test-util/create-generator-options';
 import { oDataServiceSpecs } from '../../../test-resources/odata-service-specs';
-import type { VdmProperty } from './vdm-types';
 import { parseAllServices, parseService } from './service-generator';
+import type { VdmProperty } from './vdm-types';
+import type { OptionsPerService } from '@sap-cloud-sdk/generator-common/internal';
+import type { ServiceOptions } from '@sap-cloud-sdk/generator-common/dist/options-per-service';
 
 describe('service-generator', () => {
   describe('v2', () => {

--- a/packages/generator/src/service-generator.ts
+++ b/packages/generator/src/service-generator.ts
@@ -4,20 +4,20 @@ import {
   getOptionsPerService,
   getRelPathWithPosixSeparator
 } from '@sap-cloud-sdk/generator-common/internal';
-import type { ParsedGeneratorOptions } from './options';
-import type { ServiceMetadata } from './edmx-parser';
 import { readEdmxAndSwaggerFile } from './edmx-parser';
 import { apiBusinessHubMetadata } from './swagger-parser';
-import type {
-  VdmServiceMetadata,
-  VdmServicePackageMetaData
-} from './vdm-types';
 import {
   isV2Metadata,
   getServiceEntitiesV2,
   getServiceEntitiesV4
 } from './edmx-to-vdm';
 import { getBasePath } from './service-base-path';
+import type {
+  VdmServiceMetadata,
+  VdmServicePackageMetaData
+} from './vdm-types';
+import type { ServiceMetadata } from './edmx-parser';
+import type { ParsedGeneratorOptions } from './options';
 
 class ServiceGenerator {
   constructor(readonly options: ParsedGeneratorOptions) {}

--- a/packages/generator/src/service/index-file.ts
+++ b/packages/generator/src/service/index-file.ts
@@ -1,7 +1,7 @@
-import type { ExportDeclarationStructure, SourceFileStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
-import type { VdmServiceMetadata } from '../vdm-types';
 import { hasEntities } from '../generator-utils';
+import type { ExportDeclarationStructure, SourceFileStructure } from 'ts-morph';
+import type { VdmServiceMetadata } from '../vdm-types';
 
 /**
  * @internal

--- a/packages/generator/src/service/package-json.spec.ts
+++ b/packages/generator/src/service/package-json.spec.ts
@@ -1,6 +1,6 @@
+import { packageJson } from './package-json';
 import type { ODataVersion } from '@sap-cloud-sdk/util';
 import type { PackageJsonOptions } from './package-json';
-import { packageJson } from './package-json';
 describe('package-json', () => {
   const packageJsonStatic = {
     homepage: 'https://sap.github.io/cloud-sdk/docs/js/getting-started',

--- a/packages/generator/src/service/package-json.ts
+++ b/packages/generator/src/service/package-json.ts
@@ -1,7 +1,7 @@
-import type { ODataVersion } from '@sap-cloud-sdk/util';
 import { unixEOL } from '@sap-cloud-sdk/util';
-import type { PackageJsonOptions as PackageJsonOptionsBase } from '@sap-cloud-sdk/generator-common/internal';
 import { packageJsonBase } from '@sap-cloud-sdk/generator-common/internal';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
+import type { PackageJsonOptions as PackageJsonOptionsBase } from '@sap-cloud-sdk/generator-common/internal';
 
 /**
  * @internal

--- a/packages/generator/src/service/readme.spec.ts
+++ b/packages/generator/src/service/readme.spec.ts
@@ -1,10 +1,10 @@
 import { getExpectedHelpfulLinks } from '../../test/test-util/readme-util';
+import { readme } from './readme';
 import type {
   ApiBusinessHubMetadata,
   VdmOperation,
   VdmServiceMetadata
 } from '../vdm-types';
-import { readme } from './readme';
 
 const packageName = 'business-partner-service';
 const speakingModuleName = 'Business Partner Service';

--- a/packages/generator/src/swagger-parser/swagger-parser.ts
+++ b/packages/generator/src/swagger-parser/swagger-parser.ts
@@ -1,6 +1,6 @@
-import type { PathLike } from 'fs';
 import { readFileSync } from 'fs';
 import path from 'path';
+import type { PathLike } from 'fs';
 import type { SwaggerMetadata, SwaggerPath } from './swagger-types';
 
 /**

--- a/packages/generator/src/typedoc.ts
+++ b/packages/generator/src/typedoc.ts
@@ -1,5 +1,6 @@
 import { unixEOL, titleFormat } from '@sap-cloud-sdk/util';
 import { endWithDot } from './generator-utils';
+import { getServiceName } from './service-generator';
 import type {
   VdmComplexType,
   VdmEntity,
@@ -9,7 +10,6 @@ import type {
   VdmPropertyValueConstraints,
   VdmServiceMetadata
 } from './vdm-types';
-import { getServiceName } from './service-generator';
 
 /**
  * @internal

--- a/packages/generator/test/test-util/create-generator-options.ts
+++ b/packages/generator/test/test-util/create-generator-options.ts
@@ -1,9 +1,9 @@
 import { parseOptions } from '@sap-cloud-sdk/generator-common/internal';
+import { cliOptions } from '../../src/options';
 import type {
   GeneratorOptions,
   ParsedGeneratorOptions
 } from '../../src/options';
-import { cliOptions } from '../../src/options';
 
 export function createOptions(
   options?: Partial<GeneratorOptions>

--- a/packages/generator/test/test-util/generator.ts
+++ b/packages/generator/test/test-util/generator.ts
@@ -1,15 +1,15 @@
 import { resolve } from 'path';
-import type {
-  ClassDeclaration,
-  FunctionDeclaration,
-  SourceFile
-} from 'ts-morph';
-import type { ODataVersion } from '@sap-cloud-sdk/util';
 import { parseOptions } from '@sap-cloud-sdk/generator-common/internal';
 import { generateProject } from '../../src/generator';
 import { oDataServiceSpecs } from '../../../../test-resources/odata-service-specs';
 import { cliOptions } from '../../src/options';
 import { createOptions } from './create-generator-options';
+import type { ODataVersion } from '@sap-cloud-sdk/util';
+import type {
+  ClassDeclaration,
+  FunctionDeclaration,
+  SourceFile
+} from 'ts-morph';
 
 export function checkStaticProperties(entityClass: ClassDeclaration): void {
   const properties = entityClass.getProperties();

--- a/packages/generator/test/test-util/import-declaration-structures.ts
+++ b/packages/generator/test/test-util/import-declaration-structures.ts
@@ -1,5 +1,5 @@
-import type { ImportDeclarationStructure } from 'ts-morph';
 import { StructureKind } from 'ts-morph';
+import type { ImportDeclarationStructure } from 'ts-morph';
 
 export const momentImport = {
   kind: StructureKind.ImportDeclaration,

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -11,14 +11,8 @@ import {
   circuitBreakers,
   circuitBreaker
 } from '@sap-cloud-sdk/resilience/internal';
-import type {
-  DestinationWithName,
-  Destination,
-  HttpDestination
-} from '@sap-cloud-sdk/connectivity';
 import { registerDestination } from '@sap-cloud-sdk/connectivity';
 import { registerDestinationCache } from '@sap-cloud-sdk/connectivity/internal';
-import type { ProxyConfiguration } from '@sap-cloud-sdk/connectivity/src';
 import { responseWithPublicKey } from '@sap-cloud-sdk/connectivity/src/scp-cf/jwt/verify.spec';
 import {
   basicMultipleResponse,
@@ -39,14 +33,6 @@ import {
   xsuaaBindingMock
 } from '../../../test-resources/test/test-util';
 import * as csrf from './csrf-token-middleware';
-import type {
-  DestinationHttpRequestConfig,
-  HttpMiddleware,
-  HttpMiddlewareOptions,
-  HttpRequestConfig,
-  HttpRequestConfigWithOrigin,
-  HttpResponse
-} from './http-client-types';
 import {
   buildHttpRequest,
   buildRequestWithMergedHeadersAndQueryParameters,
@@ -56,6 +42,20 @@ import {
   executeHttpRequestWithOrigin,
   buildHttpRequestConfigWithOrigin
 } from './http-client';
+import type {
+  DestinationHttpRequestConfig,
+  HttpMiddleware,
+  HttpMiddlewareOptions,
+  HttpRequestConfig,
+  HttpRequestConfigWithOrigin,
+  HttpResponse
+} from './http-client-types';
+import type { ProxyConfiguration } from '@sap-cloud-sdk/connectivity/src';
+import type {
+  DestinationWithName,
+  Destination,
+  HttpDestination
+} from '@sap-cloud-sdk/connectivity';
 
 describe('generic http client', () => {
   const httpsDestination: HttpDestination = {

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -1,18 +1,10 @@
 import * as http from 'http';
 import * as https from 'https';
-import type {
-  Destination,
-  HttpDestinationOrFetchOptions
-} from '@sap-cloud-sdk/connectivity';
 import {
   buildHeadersForDestination,
   getAgentConfigAsync,
   getTenantId
 } from '@sap-cloud-sdk/connectivity';
-import type {
-  DestinationConfiguration,
-  HttpDestination
-} from '@sap-cloud-sdk/connectivity/internal';
 import {
   assertHttpDestination,
   getAdditionalHeaders,
@@ -29,6 +21,9 @@ import {
   unixEOL
 } from '@sap-cloud-sdk/util';
 import axios from 'axios';
+import { isHttpRequestConfigWithOrigin } from './http-client-types';
+import { mergeOptionsWithPriority } from './http-request-config';
+import { csrf } from './csrf-token-middleware';
 import type {
   DestinationHttpRequestConfig,
   ExecuteHttpRequestFn,
@@ -42,9 +37,14 @@ import type {
   OriginOptionsInternal,
   ParameterEncoder
 } from './http-client-types';
-import { isHttpRequestConfigWithOrigin } from './http-client-types';
-import { mergeOptionsWithPriority } from './http-request-config';
-import { csrf } from './csrf-token-middleware';
+import type {
+  DestinationConfiguration,
+  HttpDestination
+} from '@sap-cloud-sdk/connectivity/internal';
+import type {
+  Destination,
+  HttpDestinationOrFetchOptions
+} from '@sap-cloud-sdk/connectivity';
 
 const logger = createLogger({
   package: 'http-client',

--- a/packages/mail-client/src/mail-client.spec.ts
+++ b/packages/mail-client/src/mail-client.spec.ts
@@ -1,8 +1,6 @@
 import nodemailer from 'nodemailer';
 import { SocksClient } from 'socks';
-import type { DestinationWithName } from '@sap-cloud-sdk/connectivity';
 import { registerDestination } from '@sap-cloud-sdk/connectivity';
-import type { DestinationConfiguration } from '@sap-cloud-sdk/connectivity/internal';
 import * as tokenAccessor from '@sap-cloud-sdk/connectivity/dist/scp-cf/token-accessor';
 import {
   mockFetchDestinationCalls,
@@ -14,6 +12,8 @@ import {
   isMailSentInSequential,
   sendMail
 } from './mail-client';
+import type { DestinationConfiguration } from '@sap-cloud-sdk/connectivity/internal';
+import type { DestinationWithName } from '@sap-cloud-sdk/connectivity';
 import type {
   MailDestination,
   MailConfig,

--- a/packages/mail-client/src/mail-client.ts
+++ b/packages/mail-client/src/mail-client.ts
@@ -1,14 +1,14 @@
-import type {
-  Destination,
-  DestinationOrFetchOptions
-} from '@sap-cloud-sdk/connectivity';
 import { toDestinationNameUrl } from '@sap-cloud-sdk/connectivity';
 import { resolveDestination } from '@sap-cloud-sdk/connectivity/internal';
 import { createLogger } from '@sap-cloud-sdk/util';
-import type { SentMessageInfo, Transporter } from 'nodemailer';
 import nodemailer from 'nodemailer';
-import type { SocksClientOptions, SocksProxy } from 'socks';
 import { SocksClient } from 'socks';
+import {
+  customAuthRequestHandler,
+  customAuthResponseHandler
+} from './socket-proxy';
+import type { SentMessageInfo, Transporter } from 'nodemailer';
+import type { SocksClientOptions, SocksProxy } from 'socks';
 // eslint-disable-next-line import/no-internal-modules
 import type { Options } from 'nodemailer/lib/smtp-pool';
 import type {
@@ -18,10 +18,10 @@ import type {
   MailResponse,
   SocksSocket
 } from './mail-client-types';
-import {
-  customAuthRequestHandler,
-  customAuthResponseHandler
-} from './socket-proxy';
+import type {
+  Destination,
+  DestinationOrFetchOptions
+} from '@sap-cloud-sdk/connectivity';
 
 const logger = createLogger({
   package: 'mail-client',

--- a/packages/odata-common/src/de-serializers/custom-de-serializers.ts
+++ b/packages/odata-common/src/de-serializers/custom-de-serializers.ts
@@ -1,3 +1,4 @@
+import { defaultDeSerializers } from './default-de-serializers';
 import type BigNumber from 'bignumber.js';
 import type {
   DeserializedType,
@@ -5,7 +6,6 @@ import type {
   DeSerializers
 } from './de-serializers';
 import type { DefaultDeSerializers } from './default-de-serializers';
-import { defaultDeSerializers } from './default-de-serializers';
 
 /**
  * Infers the deserialized type for an EDM type, based on custom (de-)serializers.

--- a/packages/odata-common/src/de-serializers/default-de-serializers.spec.ts
+++ b/packages/odata-common/src/de-serializers/default-de-serializers.spec.ts
@@ -1,5 +1,5 @@
-import type { DeSerializers } from './de-serializers';
 import { wrapDefaultDeSerializers } from './default-de-serializers';
+import type { DeSerializers } from './de-serializers';
 
 describe('wrapDefaultDeSerializers', () => {
   const wrappedDeSerializers = wrapDefaultDeSerializers({

--- a/packages/odata-common/src/de-serializers/default-de-serializers.ts
+++ b/packages/odata-common/src/de-serializers/default-de-serializers.ts
@@ -1,6 +1,4 @@
 import { identity, isNullish } from '@sap-cloud-sdk/util';
-import type BigNumber from 'bignumber.js';
-import type { DeSerializer, DeSerializers } from './de-serializers';
 import {
   serializeFromBigNumber,
   deserializeToNumber,
@@ -9,6 +7,8 @@ import {
   validateGuid
 } from './payload-value-converter';
 import { convertToUriForEdmString, isInfOrNan } from './uri-value-converter';
+import type BigNumber from 'bignumber.js';
+import type { DeSerializer, DeSerializers } from './de-serializers';
 
 /**
  * Type of the default (de-)serializers.

--- a/packages/odata-common/src/entity-deserializer.ts
+++ b/packages/odata-common/src/entity-deserializer.ts
@@ -3,17 +3,9 @@ import {
   createLogger,
   pickValueIgnoreCase
 } from '@sap-cloud-sdk/util';
-import type { DeSerializers } from './de-serializers';
 import { createValueDeserializer } from './de-serializers';
-import type { EntityBase } from './entity-base';
 import { isExpandedProperty, isSelectedProperty } from './entity-base';
-import type { EdmTypeShared } from './edm-types';
 import { isEdmType } from './edm-types';
-import type {
-  ComplexTypeNamespace,
-  PropertyMetadata,
-  Field
-} from './selectable';
 import {
   isComplexTypeNameSpace,
   Link,
@@ -22,6 +14,14 @@ import {
   CollectionField,
   ComplexTypeField,
   OneToOneLink
+} from './selectable';
+import type { DeSerializers } from './de-serializers';
+import type { EntityBase } from './entity-base';
+import type { EdmTypeShared } from './edm-types';
+import type {
+  ComplexTypeNamespace,
+  PropertyMetadata,
+  Field
 } from './selectable';
 import type { EntityApi, EntityType } from './entity-api';
 

--- a/packages/odata-common/src/entity-serializer.ts
+++ b/packages/odata-common/src/entity-serializer.ts
@@ -1,6 +1,4 @@
 import { createLogger, upperCaseSnakeCase } from '@sap-cloud-sdk/util';
-import type { EntityBase } from './entity-base';
-import type { ComplexTypeNamespace, PropertyMetadata } from './selectable';
 import {
   isComplexTypeNameSpace,
   EdmTypeField,
@@ -10,10 +8,12 @@ import {
   CollectionField,
   EnumField
 } from './selectable';
-import type { EdmTypeShared } from './edm-types';
 import { isEdmType } from './edm-types';
-import type { DeSerializers } from './de-serializers';
 import { createValueSerializer } from './de-serializers';
+import type { EntityBase } from './entity-base';
+import type { ComplexTypeNamespace, PropertyMetadata } from './selectable';
+import type { EdmTypeShared } from './edm-types';
+import type { DeSerializers } from './de-serializers';
 import type { EntityApi } from './entity-api';
 
 const logger = createLogger({

--- a/packages/odata-common/src/filter/boolean-filter-function.ts
+++ b/packages/odata-common/src/filter/boolean-filter-function.ts
@@ -1,6 +1,6 @@
+import { FilterFunction } from './filter-function-base';
 import type { EntityBase } from '../entity-base';
 import type { FilterFunctionParameterType } from './filter-function-base';
-import { FilterFunction } from './filter-function-base';
 import type { Filterable } from './filterable';
 
 /**

--- a/packages/odata-common/src/filter/collection-filter-function.ts
+++ b/packages/odata-common/src/filter/collection-filter-function.ts
@@ -1,7 +1,7 @@
+import { FilterFunction } from './filter-function-base';
 import type { EntityBase } from '../entity-base';
 import type { EdmTypeShared } from '../edm-types';
 import type { FilterFunctionParameterType } from './filter-function-base';
-import { FilterFunction } from './filter-function-base';
 
 /**
  * Representation of a filter function, that returns a collection of values.

--- a/packages/odata-common/src/filter/filter-function-base.ts
+++ b/packages/odata-common/src/filter/filter-function-base.ts
@@ -1,8 +1,8 @@
+import { Filter } from './filter';
 import type moment from 'moment';
 import type { EdmTypeShared } from '../edm-types';
 import type { EntityBase, ODataVersionOf } from '../entity-base';
 import type { Field } from '../selectable';
-import { Filter } from './filter';
 
 /**
  * Data structure to represent OData filter functions.

--- a/packages/odata-common/src/filter/filter-function.ts
+++ b/packages/odata-common/src/filter/filter-function.ts
@@ -1,7 +1,7 @@
-import type { EntityBase } from '../entity-base';
 import { BooleanFilterFunction } from './boolean-filter-function';
 import { NumberFilterFunction } from './number-filter-function';
 import { StringFilterFunction } from './string-filter-function';
+import type { EntityBase } from '../entity-base';
 import type { FilterFunctionParameterType } from './filter-function-base';
 
 export function filterFunction<EntityT extends EntityBase>(

--- a/packages/odata-common/src/filter/filter-functions.ts
+++ b/packages/odata-common/src/filter/filter-functions.ts
@@ -1,3 +1,4 @@
+import { filterFunction } from './filter-function';
 import type moment from 'moment';
 import type BigNumber from 'bignumber.js';
 import type { DeSerializers } from '../de-serializers';
@@ -5,7 +6,6 @@ import type { EntityBase } from '../entity-base';
 import type { Field } from '../selectable';
 import type { StringFilterFunction } from './string-filter-function';
 import type { BooleanFilterFunction } from './boolean-filter-function';
-import { filterFunction } from './filter-function';
 import type { NumberFilterFunction } from './number-filter-function';
 
 /* String Functions */

--- a/packages/odata-common/src/filter/filter-list.ts
+++ b/packages/odata-common/src/filter/filter-list.ts
@@ -1,7 +1,7 @@
-import type { DeSerializers } from '../de-serializers';
-import type { EntityBase, EntityIdentifiable } from '../entity-base';
 // eslint-disable-next-line import/no-internal-modules
 import { OneToManyLink } from '../selectable/one-to-many-link';
+import type { DeSerializers } from '../de-serializers';
+import type { EntityBase, EntityIdentifiable } from '../entity-base';
 import type { Filterable } from './filterable';
 
 /**

--- a/packages/odata-common/src/filter/filterable.ts
+++ b/packages/odata-common/src/filter/filterable.ts
@@ -1,12 +1,12 @@
 import { transformVariadicArgumentToArray } from '@sap-cloud-sdk/util';
+import { UnaryFilter } from './unary-filter';
+import { FilterList } from './filter-list';
 import type { EntityBase } from '../entity-base';
 import type { OneToManyLink } from '../selectable';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi } from '../entity-api';
 import type { BooleanFilterFunction } from './boolean-filter-function';
 import type { Filter } from './filter';
-import { UnaryFilter } from './unary-filter';
-import { FilterList } from './filter-list';
 import type { FilterLambdaExpression } from './filter-lambda-expression';
 import type { FilterLink } from './filter-link';
 

--- a/packages/odata-common/src/filter/number-filter-function.ts
+++ b/packages/odata-common/src/filter/number-filter-function.ts
@@ -1,6 +1,6 @@
+import { OrderableFilterFunction } from './orderable-filter-function';
 import type { EntityBase } from '../entity-base';
 import type { FilterFunctionParameterType } from './filter-function-base';
-import { OrderableFilterFunction } from './orderable-filter-function';
 
 /**
  * Representation of a filter function, that returns a value of type number. This supports int, double and decimal values.

--- a/packages/odata-common/src/filter/orderable-filter-function.ts
+++ b/packages/odata-common/src/filter/orderable-filter-function.ts
@@ -1,8 +1,8 @@
+import { Filter } from './filter';
+import { FilterFunction } from './filter-function-base';
 import type { EntityBase, ODataVersionOf } from '../entity-base';
 import type { EdmTypeShared } from '../edm-types';
-import { Filter } from './filter';
 import type { FilterFunctionParameterType } from './filter-function-base';
-import { FilterFunction } from './filter-function-base';
 
 /**
  * Representation of a filter function, that returns a value of an orderable type. This supports int, double and decimal values.

--- a/packages/odata-common/src/filter/string-filter-function.ts
+++ b/packages/odata-common/src/filter/string-filter-function.ts
@@ -1,6 +1,6 @@
+import { OrderableFilterFunction } from './orderable-filter-function';
 import type { EntityBase } from '../entity-base';
 import type { FilterFunctionParameterType } from './filter-function-base';
-import { OrderableFilterFunction } from './orderable-filter-function';
 
 /**
  * Representation of a filter function, that returns a value of type string.

--- a/packages/odata-common/src/order/orderable.ts
+++ b/packages/odata-common/src/order/orderable.ts
@@ -1,13 +1,13 @@
+// eslint-disable-next-line import/no-internal-modules
+import { Link } from '../selectable/link';
+import { Order } from './order';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityBase } from '../entity-base';
 import type {
   ComplexTypePropertyFields,
   SimpleTypeFields
 } from '../selectable';
-// eslint-disable-next-line import/no-internal-modules
-import { Link } from '../selectable/link';
 import type { EntityApi } from '../entity-api';
-import { Order } from './order';
 import type { OrderLink } from './order-link';
 
 /**

--- a/packages/odata-common/src/request-builder/batch/batch-request-builder.ts
+++ b/packages/odata-common/src/request-builder/batch/batch-request-builder.ts
@@ -1,19 +1,19 @@
+import { first } from '@sap-cloud-sdk/util';
+import { ODataBatchRequestConfig } from '../../request';
+import { MethodRequestBuilder } from '../request-builder-base';
+import { BatchChangeSet } from './batch-change-set';
+import { serializeBatchRequest } from './batch-request-serializer';
 import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import type { HttpResponse } from '@sap-cloud-sdk/http-client';
-import { first } from '@sap-cloud-sdk/util';
 import type { DefaultDeSerializers, DeSerializers } from '../../de-serializers';
 import type { EntityApi } from '../../entity-api';
 import type { EntityBase } from '../../entity-base';
 import type { ODataRequestConfig, ODataRequest } from '../../request';
-import { ODataBatchRequestConfig } from '../../request';
 import type { OperationRequestBuilderBase } from '../operation-request-builder-base';
 import type { GetAllRequestBuilderBase } from '../get-all-request-builder-base';
 import type { GetByKeyRequestBuilderBase } from '../get-by-key-request-builder-base';
-import { MethodRequestBuilder } from '../request-builder-base';
 import type { ChangesetBuilderTypes } from './batch-change-set';
-import { BatchChangeSet } from './batch-change-set';
 import type { BatchSubRequestPathType } from './batch-request-options';
-import { serializeBatchRequest } from './batch-request-serializer';
 
 /**
  * Create a batch request to invoke multiple requests as a batch. The batch request builder accepts retrieve requests, i. e. {@link GetAllRequestBuilder | getAll} and {@link GetByKeyRequestBuilder | getByKey} requests and change sets, which in turn can contain {@link CreateRequestBuilder | create}, {@link UpdateRequestBuilder | update} or {@link DeleteRequestBuilder | delete} requests.

--- a/packages/odata-common/src/request-builder/batch/batch-request-serializer.spec.ts
+++ b/packages/odata-common/src/request-builder/batch/batch-request-serializer.spec.ts
@@ -1,9 +1,7 @@
-import type { CommonEntity } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 import {
   commonEntityApi,
   CommonEntityApi
 } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
-import type { WriteBuilder } from '@sap-cloud-sdk/test-services-odata-common/common-request-config';
 import {
   batchRequestBuilder,
   createRequestBuilder,
@@ -12,13 +10,15 @@ import {
   getByKeyRequestBuilder,
   updateRequestBuilder
 } from '@sap-cloud-sdk/test-services-odata-common/common-request-config';
-import type { HttpDestination } from '@sap-cloud-sdk/connectivity/internal';
 import {
   serializeBatchRequest,
   serializeRequest,
   serializeChangeSet
 } from './batch-request-serializer';
 import { BatchChangeSet } from './batch-change-set';
+import type { HttpDestination } from '@sap-cloud-sdk/connectivity/internal';
+import type { WriteBuilder } from '@sap-cloud-sdk/test-services-odata-common/common-request-config';
+import type { CommonEntity } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 
 jest.mock('uuid', () => ({
   v4: jest.fn(() => '<content-id>')

--- a/packages/odata-common/src/request-builder/batch/batch-request-serializer.ts
+++ b/packages/odata-common/src/request-builder/batch/batch-request-serializer.ts
@@ -1,6 +1,7 @@
 import { unixEOL } from '@sap-cloud-sdk/util';
 import voca from 'voca';
 import { ODataRequest } from '../../request';
+import { BatchChangeSet } from './batch-change-set';
 import type { ODataRequestConfig, WithBatchReference } from '../../request';
 import type { MethodRequestBuilder } from '../request-builder-base';
 import type { DeSerializers } from '../../de-serializers';
@@ -9,7 +10,6 @@ import type {
   BatchRequestSerializationOptions,
   BatchSubRequestPathType
 } from './batch-request-options';
-import { BatchChangeSet } from './batch-change-set';
 
 /**
  * Serialize change set to string.

--- a/packages/odata-common/src/request-builder/batch/batch-response-deserializer.spec.ts
+++ b/packages/odata-common/src/request-builder/batch/batch-response-deserializer.spec.ts
@@ -1,10 +1,10 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import type { EntityDeserializer } from '../../entity-deserializer';
-import type { ResponseDataAccessor } from '../../response-data-accessor';
 import {
   BatchResponseDeserializer,
   parseEntityNameFromMetadataUri
 } from './batch-response-deserializer';
+import type { EntityDeserializer } from '../../entity-deserializer';
+import type { ResponseDataAccessor } from '../../response-data-accessor';
 
 describe('batch response transformer', () => {
   describe('getEntityNameFromMetadata', () => {

--- a/packages/odata-common/src/request-builder/batch/batch-response-deserializer.ts
+++ b/packages/odata-common/src/request-builder/batch/batch-response-deserializer.ts
@@ -1,4 +1,5 @@
 import { createLogger, ErrorWithCause } from '@sap-cloud-sdk/util';
+import { isHttpSuccessCode } from './batch-response-parser';
 import type {
   BatchResponse,
   ErrorResponse,
@@ -12,7 +13,6 @@ import type { EntityDeserializer } from '../../entity-deserializer';
 import type { ResponseDataAccessor } from '../../response-data-accessor';
 import type { EntityApi } from '../../entity-api';
 import type { ResponseData } from './batch-response-parser';
-import { isHttpSuccessCode } from './batch-response-parser';
 
 const logger = createLogger({
   package: 'odata-common',

--- a/packages/odata-common/src/request-builder/batch/batch-response-parser.spec.ts
+++ b/packages/odata-common/src/request-builder/batch/batch-response-parser.spec.ts
@@ -1,5 +1,4 @@
 import { unixEOL, createLogger } from '@sap-cloud-sdk/util';
-import type { HttpResponse } from '@sap-cloud-sdk/http-client';
 import {
   detectNewLineSymbol,
   getResponseBody,
@@ -9,6 +8,7 @@ import {
   splitBatchResponse,
   splitChangeSetResponse
 } from './batch-response-parser';
+import type { HttpResponse } from '@sap-cloud-sdk/http-client';
 
 describe('batch response parser', () => {
   describe('detectNewLineSymbol', () => {

--- a/packages/odata-common/src/request-builder/count-request-builder.ts
+++ b/packages/odata-common/src/request-builder/count-request-builder.ts
@@ -1,9 +1,9 @@
+import { ODataCountRequestConfig } from '../request';
+import { MethodRequestBuilder } from './request-builder-base';
 import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import type { HttpResponse } from '@sap-cloud-sdk/http-client';
 import type { EntityBase } from '../entity-base';
-import { ODataCountRequestConfig } from '../request';
 import type { DeSerializers } from '../de-serializers';
-import { MethodRequestBuilder } from './request-builder-base';
 import type { GetAllRequestBuilderBase } from './get-all-request-builder-base';
 
 /**

--- a/packages/odata-common/src/request-builder/create-request-builder-base.spec.ts
+++ b/packages/odata-common/src/request-builder/create-request-builder-base.spec.ts
@@ -1,6 +1,6 @@
-import type { CommonEntity } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 import { CommonEntityApi } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 import { createRequestBuilder } from '@sap-cloud-sdk/test-services-odata-common/common-request-config';
+import type { CommonEntity } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 const mockBatchId = '<content-id>';
 jest.mock('uuid', () => ({
   v4: jest.fn(() => mockBatchId)

--- a/packages/odata-common/src/request-builder/create-request-builder-base.ts
+++ b/packages/odata-common/src/request-builder/create-request-builder-base.ts
@@ -1,18 +1,18 @@
 import { ErrorWithCause } from '@sap-cloud-sdk/util';
+import { v4 as uuid } from 'uuid';
+import { ODataCreateRequestConfig } from '../request';
+import { MethodRequestBuilder } from './request-builder-base';
 import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import type { HttpResponse } from '@sap-cloud-sdk/http-client';
-import { v4 as uuid } from 'uuid';
 import type { EntitySerializer } from '../entity-serializer';
 import type { ODataUri } from '../uri-conversion';
 import type { EntityBase, EntityIdentifiable } from '../entity-base';
 import type { EntityDeserializer } from '../entity-deserializer';
 import type { ResponseDataAccessor } from '../response-data-accessor';
-import { ODataCreateRequestConfig } from '../request';
 import type { Link } from '../selectable';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi } from '../entity-api';
 import type { BatchReference, WithBatchReference } from '../request';
-import { MethodRequestBuilder } from './request-builder-base';
 
 /**
  * Abstract create request class holding the parts shared in OData v2 and v4.

--- a/packages/odata-common/src/request-builder/delete-request-builder-base.ts
+++ b/packages/odata-common/src/request-builder/delete-request-builder-base.ts
@@ -1,15 +1,15 @@
 import { ErrorWithCause } from '@sap-cloud-sdk/util';
+import { v4 as uuid } from 'uuid';
+import { EntityBase } from '../entity-base';
+import { ODataDeleteRequestConfig } from '../request';
+import { MethodRequestBuilder } from './request-builder-base';
 import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import type { HttpResponse } from '@sap-cloud-sdk/http-client';
-import { v4 as uuid } from 'uuid';
 import type { EntityIdentifiable } from '../entity-base';
-import { EntityBase } from '../entity-base';
 import type { ODataUri } from '../uri-conversion';
-import { ODataDeleteRequestConfig } from '../request';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi } from '../entity-api';
 import type { BatchReference, WithBatchReference } from '../request';
-import { MethodRequestBuilder } from './request-builder-base';
 /**
  * Abstract class to delete an entity holding the shared parts between OData v2 and v4.
  * @typeParam EntityT - Type of the entity to be deleted

--- a/packages/odata-common/src/request-builder/get-all-request-builder-base.ts
+++ b/packages/odata-common/src/request-builder/get-all-request-builder-base.ts
@@ -1,16 +1,16 @@
 import { transformVariadicArgumentToArray } from '@sap-cloud-sdk/util';
+import { isOrderable, asc } from '../order';
+import { CountRequestBuilder } from './count-request-builder';
+import { GetRequestBuilderBase } from './get-request-builder-base';
 import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import type { EntityBase } from '../entity-base';
 import type { Selectable } from '../selectable';
 import type { OrderableAndOrderableInput } from '../order';
-import { isOrderable, asc } from '../order';
 import type { ODataGetAllRequestConfig } from '../request';
 import type { EntityDeserializer } from '../entity-deserializer';
 import type { ResponseDataAccessor } from '../response-data-accessor';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi } from '../entity-api';
-import { CountRequestBuilder } from './count-request-builder';
-import { GetRequestBuilderBase } from './get-request-builder-base';
 
 /**
  * Base class for the get all request builders {@link @sap-cloud-sdk/odata-v2!GetAllRequestBuilder | GetAllRequestBuilderV2} and {@link @sap-cloud-sdk/odata-v4!GetAllRequestBuilder | GetAllRequestBuilderV4}.

--- a/packages/odata-common/src/request-builder/get-by-key-request-builder-base.ts
+++ b/packages/odata-common/src/request-builder/get-by-key-request-builder-base.ts
@@ -2,18 +2,18 @@ import {
   ErrorWithCause,
   transformVariadicArgumentToArray
 } from '@sap-cloud-sdk/util';
-import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import { v4 as uuid } from 'uuid';
+import { ODataGetByKeyRequestConfig } from '../request';
+import { GetRequestBuilderBase } from './get-request-builder-base';
+import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import type { EntityBase } from '../entity-base';
 import type { EntityDeserializer } from '../entity-deserializer';
 import type { ResponseDataAccessor } from '../response-data-accessor';
-import { ODataGetByKeyRequestConfig } from '../request';
 import type { Selectable } from '../selectable';
 import type { ODataUri } from '../uri-conversion';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi } from '../entity-api';
 import type { BatchReference, WithBatchReference } from '../request';
-import { GetRequestBuilderBase } from './get-request-builder-base';
 /**
  * Abstract class to create a get by key request containing the shared functionality for OData v2 and v4.
  * @typeParam EntityT - Type of the entity to be requested

--- a/packages/odata-common/src/request-builder/get-request-builder-base.ts
+++ b/packages/odata-common/src/request-builder/get-request-builder-base.ts
@@ -1,4 +1,5 @@
 import { transformVariadicArgumentToArray } from '@sap-cloud-sdk/util';
+import { MethodRequestBuilder } from './request-builder-base';
 import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import type { HttpResponse } from '@sap-cloud-sdk/http-client';
 import type {
@@ -13,7 +14,6 @@ import type {
 } from '../request';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi } from '../entity-api';
-import { MethodRequestBuilder } from './request-builder-base';
 
 /**
  * @internal

--- a/packages/odata-common/src/request-builder/operation-request-builder-base.ts
+++ b/packages/odata-common/src/request-builder/operation-request-builder-base.ts
@@ -1,13 +1,13 @@
+import { v4 as uuid } from 'uuid';
+import { MethodRequestBuilder } from './request-builder-base';
 import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import type { HttpResponse } from '@sap-cloud-sdk/http-client';
-import { v4 as uuid } from 'uuid';
 import type {
   ODataRequestConfig,
   BatchReference,
   WithBatchReference
 } from '../request';
 import type { DeSerializers } from '../de-serializers';
-import { MethodRequestBuilder } from './request-builder-base';
 
 /**
  * Create OData request to execute an action or function.

--- a/packages/odata-common/src/request-builder/request-builder-base.ts
+++ b/packages/odata-common/src/request-builder/request-builder-base.ts
@@ -2,15 +2,15 @@ import {
   ErrorWithCause,
   transformVariadicArgumentToArray
 } from '@sap-cloud-sdk/util';
-import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import { useOrFetchDestination } from '@sap-cloud-sdk/connectivity';
 import {
   assertHttpDestination,
   noDestinationErrorMessage
 } from '@sap-cloud-sdk/connectivity/internal';
+import { ODataRequest } from '../request';
+import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import type { HttpMiddleware } from '@sap-cloud-sdk/http-client/internal';
 import type { CustomRequestConfig } from '@sap-cloud-sdk/http-client';
-import { ODataRequest } from '../request';
 import type { ODataRequestConfig } from '../request';
 
 /**

--- a/packages/odata-common/src/request-builder/update-request-builder-base.ts
+++ b/packages/odata-common/src/request-builder/update-request-builder-base.ts
@@ -2,22 +2,22 @@ import {
   ErrorWithCause,
   transformVariadicArgumentToArray
 } from '@sap-cloud-sdk/util';
-import type { HttpResponse } from '@sap-cloud-sdk/http-client';
 import { v4 as uuid } from 'uuid';
-import type { EntityBase, EntityIdentifiable } from '../entity-base';
 import { extractEtagFromHeader } from '../entity-deserializer';
+import { ODataUpdateRequestConfig } from '../request';
+import { MethodRequestBuilder } from './request-builder-base';
+import type { HttpResponse } from '@sap-cloud-sdk/http-client';
+import type { EntityBase, EntityIdentifiable } from '../entity-base';
 import type { EntitySerializer } from '../entity-serializer';
 import type {
   ODataRequest,
   BatchReference,
   WithBatchReference
 } from '../request';
-import { ODataUpdateRequestConfig } from '../request';
 import type { ODataUri } from '../uri-conversion';
 import type { Selectable } from '../selectable';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi } from '../entity-api';
-import { MethodRequestBuilder } from './request-builder-base';
 
 /**
  * Abstract class to create OData query to update an entity containing methods shared for OData v2 and v4.

--- a/packages/odata-common/src/request/odata-batch-request-config.ts
+++ b/packages/odata-common/src/request/odata-batch-request-config.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid';
-import type { BatchSubRequestPathType } from '../request-builder';
 import { ODataRequestConfig } from './odata-request-config';
+import type { BatchSubRequestPathType } from '../request-builder';
 
 /**
  * OData batch request configuration for an entity type.

--- a/packages/odata-common/src/request/odata-count-request-config.ts
+++ b/packages/odata-common/src/request/odata-count-request-config.ts
@@ -1,8 +1,8 @@
 import { createLogger, pick, removeTrailingSlashes } from '@sap-cloud-sdk/util';
+import { ODataRequestConfig } from './odata-request-config';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityBase } from '../entity-base';
 import type { GetAllRequestBuilderBase } from '../request-builder';
-import { ODataRequestConfig } from './odata-request-config';
 
 const logger = createLogger({
   package: 'odata-common',

--- a/packages/odata-common/src/request/odata-create-request-config.ts
+++ b/packages/odata-common/src/request/odata-create-request-config.ts
@@ -1,9 +1,9 @@
+import { ODataRequestConfig } from './odata-request-config';
 import type { EntityBase } from '../entity-base';
 import type { ODataUri } from '../uri-conversion';
 import type { Link } from '../selectable';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi } from '../entity-api';
-import { ODataRequestConfig } from './odata-request-config';
 
 /**
  * OData create request configuration for an entity type.

--- a/packages/odata-common/src/request/odata-delete-request-config.spec.ts
+++ b/packages/odata-common/src/request/odata-delete-request-config.spec.ts
@@ -1,10 +1,10 @@
 import { v4 as uuid } from 'uuid';
-import type { CommonEntity } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 import { commonEntityApi } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 import { commonODataUri } from '@sap-cloud-sdk/test-services-odata-common/common-request-config';
 import { testEntityResourcePath } from '../../test/test-util';
-import type { DefaultDeSerializers } from '../de-serializers';
 import { ODataDeleteRequestConfig } from './odata-delete-request-config';
+import type { DefaultDeSerializers } from '../de-serializers';
+import type { CommonEntity } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 
 describe('ODataDeleteRequestConfig', () => {
   let config: ODataDeleteRequestConfig<CommonEntity, DefaultDeSerializers>;

--- a/packages/odata-common/src/request/odata-delete-request-config.ts
+++ b/packages/odata-common/src/request/odata-delete-request-config.ts
@@ -1,8 +1,8 @@
+import { ODataRequestConfig } from './odata-request-config';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityBase } from '../entity-base';
 import type { ODataUri } from '../uri-conversion';
 import type { EntityApi } from '../entity-api';
-import { ODataRequestConfig } from './odata-request-config';
 import type { WithKeys, WithETag } from './odata-request-traits';
 
 /**

--- a/packages/odata-common/src/request/odata-function-request-config.ts
+++ b/packages/odata-common/src/request/odata-function-request-config.ts
@@ -1,8 +1,8 @@
+import { ODataRequestConfig } from './odata-request-config';
 import type { DeSerializers } from '../de-serializers';
 import type { ODataUri } from '../uri-conversion';
 import type { OperationParameters } from './operation-parameter';
 import type { RequestMethodType } from './odata-request-config';
-import { ODataRequestConfig } from './odata-request-config';
 
 /**
  * Function request configuration for an entity type.

--- a/packages/odata-common/src/request/odata-get-all-request-config.spec.ts
+++ b/packages/odata-common/src/request/odata-get-all-request-config.spec.ts
@@ -3,9 +3,9 @@ import {
   commonEntityApi
 } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 import { commonODataUri } from '@sap-cloud-sdk/test-services-odata-common/common-request-config';
-import type { DefaultDeSerializers } from '../de-serializers';
 import { asc } from '../order';
 import { ODataGetAllRequestConfig } from './odata-get-all-request-config';
+import type { DefaultDeSerializers } from '../de-serializers';
 
 describe('ODataGetAllRequestConfig', () => {
   let config: ODataGetAllRequestConfig<CommonEntity, DefaultDeSerializers>;

--- a/packages/odata-common/src/request/odata-get-all-request-config.ts
+++ b/packages/odata-common/src/request/odata-get-all-request-config.ts
@@ -1,3 +1,4 @@
+import { ODataRequestConfig } from './odata-request-config';
 import type { EntityBase } from '../entity-base';
 import type { Selectable } from '../selectable';
 import type { Filterable } from '../filter';
@@ -6,7 +7,6 @@ import type { Orderable } from '../order';
 import type { ODataUri } from '../uri-conversion';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi } from '../entity-api';
-import { ODataRequestConfig } from './odata-request-config';
 import type { WithGetAllRestrictions } from './odata-request-traits';
 
 /**

--- a/packages/odata-common/src/request/odata-get-by-key-request-config.spec.ts
+++ b/packages/odata-common/src/request/odata-get-by-key-request-config.spec.ts
@@ -1,10 +1,10 @@
 import { v4 as uuid } from 'uuid';
-import type { CommonEntity } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 import { commonEntityApi } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 import { commonODataUri } from '@sap-cloud-sdk/test-services-odata-common/common-request-config';
 import { testEntityResourcePath } from '../../test/test-util';
-import type { DefaultDeSerializers } from '../de-serializers';
 import { ODataGetByKeyRequestConfig } from './odata-get-by-key-request-config';
+import type { DefaultDeSerializers } from '../de-serializers';
+import type { CommonEntity } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 
 describe('ODataGetByKeyRequestConfig', () => {
   let config: ODataGetByKeyRequestConfig<CommonEntity, DefaultDeSerializers>;

--- a/packages/odata-common/src/request/odata-get-by-key-request-config.ts
+++ b/packages/odata-common/src/request/odata-get-by-key-request-config.ts
@@ -1,3 +1,4 @@
+import { ODataRequestConfig } from './odata-request-config';
 import type { EntityBase } from '../entity-base';
 import type { Expandable } from '../expandable';
 import type { Selectable } from '../selectable';
@@ -5,7 +6,6 @@ import type { ODataUri } from '../uri-conversion';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi } from '../entity-api';
 import type { WithKeys, WithSelection } from './odata-request-traits';
-import { ODataRequestConfig } from './odata-request-config';
 
 /**
  * OData getByKey request configuration for an entity type.

--- a/packages/odata-common/src/request/odata-request.spec.ts
+++ b/packages/odata-common/src/request/odata-request.spec.ts
@@ -1,12 +1,12 @@
 import { v4 as uuid } from 'uuid';
 import { oDataTypedClientParameterEncoder } from '@sap-cloud-sdk/http-client/internal';
 import { commonODataUri } from '@sap-cloud-sdk/test-services-odata-common/common-request-config';
-import type { CommonEntity } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 import { commonEntityApi } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
-import type { HttpDestination } from '@sap-cloud-sdk/connectivity/internal';
-import type { DefaultDeSerializers } from '../de-serializers';
 import { ODataGetAllRequestConfig } from './odata-get-all-request-config';
 import { ODataRequest } from './odata-request';
+import type { CommonEntity } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
+import type { HttpDestination } from '@sap-cloud-sdk/connectivity/internal';
+import type { DefaultDeSerializers } from '../de-serializers';
 
 describe('OData Request', () => {
   it('should be noParamEncoder', async () => {

--- a/packages/odata-common/src/request/odata-request.ts
+++ b/packages/odata-common/src/request/odata-request.ts
@@ -9,22 +9,22 @@ import {
   removeSlashes,
   removeTrailingSlashes
 } from '@sap-cloud-sdk/util';
-import type { Destination } from '@sap-cloud-sdk/connectivity';
 import { sanitizeDestination } from '@sap-cloud-sdk/connectivity';
-import type {
-  HttpResponse,
-  HttpRequestConfigWithOrigin
-} from '@sap-cloud-sdk/http-client';
 import { executeHttpRequest } from '@sap-cloud-sdk/http-client';
-import type { OriginOptions } from '@sap-cloud-sdk/http-client/internal';
 import {
   filterCustomRequestConfig,
   mergeOptionsWithPriority
 } from '@sap-cloud-sdk/http-client/internal';
-import type { HttpDestination } from '@sap-cloud-sdk/connectivity/internal';
 import { assertHttpDestination } from '@sap-cloud-sdk/connectivity/internal';
-import type { ODataRequestConfig } from './odata-request-config';
 import { isWithETag } from './odata-request-traits';
+import type { Destination } from '@sap-cloud-sdk/connectivity';
+import type {
+  HttpResponse,
+  HttpRequestConfigWithOrigin
+} from '@sap-cloud-sdk/http-client';
+import type { OriginOptions } from '@sap-cloud-sdk/http-client/internal';
+import type { HttpDestination } from '@sap-cloud-sdk/connectivity/internal';
+import type { ODataRequestConfig } from './odata-request-config';
 
 /**
  * OData request configuration for an entity type.

--- a/packages/odata-common/src/request/odata-update-request-config.spec.ts
+++ b/packages/odata-common/src/request/odata-update-request-config.spec.ts
@@ -1,9 +1,9 @@
 import { v4 as uuid } from 'uuid';
 import { updateRequestConfig } from '@sap-cloud-sdk/test-services-odata-common/common-request-config';
-import type { CommonEntity } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
 import { commonEntityApi } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
-import type { DefaultDeSerializers } from '../de-serializers';
 import { testEntityResourcePath } from '../../test/test-util';
+import type { CommonEntity } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
+import type { DefaultDeSerializers } from '../de-serializers';
 import type { ODataUpdateRequestConfig } from './odata-update-request-config';
 
 describe('ODataUpdateRequestConfig', () => {

--- a/packages/odata-common/src/request/odata-update-request-config.ts
+++ b/packages/odata-common/src/request/odata-update-request-config.ts
@@ -1,8 +1,8 @@
+import { ODataRequestConfig } from './odata-request-config';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityBase } from '../entity-base';
 import type { ODataUri } from '../uri-conversion';
 import type { EntityApi } from '../entity-api';
-import { ODataRequestConfig } from './odata-request-config';
 import type { WithKeys, WithETag } from './odata-request-traits';
 
 /**

--- a/packages/odata-common/src/selectable/collection-field.ts
+++ b/packages/odata-common/src/selectable/collection-field.ts
@@ -1,10 +1,10 @@
+import { Field } from './field';
+import { ComplexTypeField, getEntityConstructor } from './complex-type-field';
 import type { EntityBase } from '../entity-base';
 import type { EdmTypeShared } from '../edm-types';
 import type { DeSerializers } from '../de-serializers';
 import type { FieldOptions } from './field';
-import { Field } from './field';
 import type { ConstructorOrField } from './constructor-or-field';
-import { ComplexTypeField, getEntityConstructor } from './complex-type-field';
 import type { ComplexTypeNamespace } from './complex-type-namespace';
 
 /**

--- a/packages/odata-common/src/selectable/complex-type-field.ts
+++ b/packages/odata-common/src/selectable/complex-type-field.ts
@@ -1,10 +1,10 @@
+import { isEdmType } from '../edm-types';
+import { Field } from './field';
 import type { ODataVersion } from '@sap-cloud-sdk/util';
 import type { EdmTypeShared } from '../edm-types';
-import { isEdmType } from '../edm-types';
 import type { Constructable, EntityBase } from '../entity-base';
 import type { DeSerializers } from '../de-serializers';
 import type { FieldOptions } from './field';
-import { Field } from './field';
 import type { ComplexTypeNamespace } from './complex-type-namespace';
 import type { ConstructorOrField } from './constructor-or-field';
 

--- a/packages/odata-common/src/selectable/custom-field.ts
+++ b/packages/odata-common/src/selectable/custom-field.ts
@@ -1,8 +1,8 @@
+import { Field } from './field';
+import { FieldBuilder } from './field-builder';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityBase, Constructable } from '../entity-base';
 import type { EdmTypeField } from './edm-type-field';
-import { Field } from './field';
-import { FieldBuilder } from './field-builder';
 import type { OrderableEdmTypeField } from './orderable-edm-type-field';
 
 /**

--- a/packages/odata-common/src/selectable/edm-type-field.ts
+++ b/packages/odata-common/src/selectable/edm-type-field.ts
@@ -1,11 +1,11 @@
-import type { EntityBase, EntityIdentifiable } from '../entity-base';
 import { Filter } from '../filter';
+import { ComplexTypeField, getEntityConstructor } from './complex-type-field';
+import { Field } from './field';
+import type { EntityBase, EntityIdentifiable } from '../entity-base';
 import type { EdmTypeShared } from '../edm-types';
 import type { DeSerializers, DeserializedType } from '../de-serializers';
-import { ComplexTypeField, getEntityConstructor } from './complex-type-field';
 import type { ConstructorOrField } from './constructor-or-field';
 import type { FieldOptions } from './field';
-import { Field } from './field';
 
 /**
  * Convenience type that maps the given field type to a new type that is either nullable or not, depending on the given `NullableT`.

--- a/packages/odata-common/src/selectable/enum-field.ts
+++ b/packages/odata-common/src/selectable/enum-field.ts
@@ -1,11 +1,11 @@
-import type { EntityBase } from '../entity-base';
 import { Filter } from '../filter';
+import { Field } from './field';
+import { ComplexTypeField, getEntityConstructor } from './complex-type-field';
+import type { EntityBase } from '../entity-base';
 import type { EdmTypeShared } from '../edm-types';
 import type { DeSerializers } from '../de-serializers';
 import type { FieldOptions } from './field';
-import { Field } from './field';
 import type { ConstructorOrField } from './constructor-or-field';
-import { ComplexTypeField, getEntityConstructor } from './complex-type-field';
 
 /**
  * Represents a property with an enum value.

--- a/packages/odata-common/src/selectable/field-builder.ts
+++ b/packages/odata-common/src/selectable/field-builder.ts
@@ -1,17 +1,17 @@
 /* eslint-disable max-classes-per-file */
 
-import type { EdmTypeShared, OrderableEdmType } from '../edm-types';
 import { isOrderableEdmType } from '../edm-types';
-import type { Constructable, EntityBase } from '../entity-base';
-import type { DeSerializers } from '../de-serializers';
 import { ComplexTypeField } from './complex-type-field';
 import { EdmTypeField } from './edm-type-field';
 import { OrderableEdmTypeField } from './orderable-edm-type-field';
-import type { CollectionFieldType } from './collection-field';
 import { CollectionField } from './collection-field';
+import { EnumField } from './enum-field';
+import type { EdmTypeShared, OrderableEdmType } from '../edm-types';
+import type { Constructable, EntityBase } from '../entity-base';
+import type { DeSerializers } from '../de-serializers';
+import type { CollectionFieldType } from './collection-field';
 import type { ConstructorOrField } from './constructor-or-field';
 import type { FieldOptions } from './field';
-import { EnumField } from './enum-field';
 
 /**
  * Constructor function creating a {@link ComplexTypeField}.

--- a/packages/odata-common/src/selectable/one-to-many-link.ts
+++ b/packages/odata-common/src/selectable/one-to-many-link.ts
@@ -1,11 +1,11 @@
-import type { EntityBase } from '../entity-base';
 // eslint-disable-next-line import/no-internal-modules
 import { FilterLink } from '../filter/filter-link';
+import { Link } from './link';
+import type { EntityBase } from '../entity-base';
 import type { Orderable } from '../order';
 import type { Filterable } from '../filter';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi, EntityType } from '../entity-api';
-import { Link } from './link';
 
 /**
  * @param filters - filters

--- a/packages/odata-common/src/selectable/one-to-one-link.ts
+++ b/packages/odata-common/src/selectable/one-to-one-link.ts
@@ -1,11 +1,11 @@
+import { OrderLink } from '../order';
+import { FilterLink } from '../filter';
+import { Link } from './link';
 import type { EntityBase } from '../entity-base';
 import type { Order, Orderable } from '../order';
-import { OrderLink } from '../order';
 import type { Filterable } from '../filter';
-import { FilterLink } from '../filter';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi, EntityType } from '../entity-api';
-import { Link } from './link';
 
 /**
  * Represents a link from one entity to one other linked entity (as opposed to a list of linked entities). In OData v2 a `OneToOneLink` can be used to filter and order a selection on an entity based on filters and orders on a linked entity.

--- a/packages/odata-common/src/selectable/orderable-edm-type-field.spec.ts
+++ b/packages/odata-common/src/selectable/orderable-edm-type-field.spec.ts
@@ -2,11 +2,11 @@ import {
   CommonComplexTypeField,
   CommonEntity
 } from '@sap-cloud-sdk/test-services-odata-common/common-entity';
-import type { DeSerializers } from '../de-serializers';
 import { defaultDeSerializers } from '../de-serializers';
+import { OrderableEdmTypeField } from './orderable-edm-type-field';
+import type { DeSerializers } from '../de-serializers';
 import type { EntityBase } from '../entity-base';
 import type { Filter } from '../filter';
-import { OrderableEdmTypeField } from './orderable-edm-type-field';
 
 export function checkFilter<
   EntityT extends EntityBase,

--- a/packages/odata-common/src/selectable/orderable-edm-type-field.ts
+++ b/packages/odata-common/src/selectable/orderable-edm-type-field.ts
@@ -1,9 +1,9 @@
+import { Filter } from '../filter';
+import { EdmTypeField } from './edm-type-field';
 import type { EntityBase } from '../entity-base';
 import type { EdmTypeShared } from '../edm-types';
-import { Filter } from '../filter';
 import type { DeSerializers } from '../de-serializers';
 import type { FieldTypeByEdmType } from './edm-type-field';
-import { EdmTypeField } from './edm-type-field';
 
 /**
  * {@link EdmTypeField}, that represents a property with an EDM type, that can be compared with `greaterThan`, `greaterOrEqual`, `lessThan` and `lessOrEqual`.

--- a/packages/odata-common/src/uri-conversion/get-filter.ts
+++ b/packages/odata-common/src/uri-conversion/get-filter.ts
@@ -1,5 +1,15 @@
 import moment from 'moment';
 import { upperCaseSnakeCase } from '@sap-cloud-sdk/util';
+import {
+  isFilterLambdaExpression,
+  isFilterList,
+  isBooleanFilterFunction,
+  isFilterLink,
+  isUnaryFilter,
+  FilterFunction,
+  isFilter
+} from '../filter';
+import { ComplexTypeField, OneToManyLink } from '../selectable';
 import type { EntityBase } from '../entity-base';
 import type { EdmTypeShared } from '../edm-types';
 import type {
@@ -11,21 +21,11 @@ import type {
   FilterFunctionParameterType,
   Filter
 } from '../filter';
-import {
-  isFilterLambdaExpression,
-  isFilterList,
-  isBooleanFilterFunction,
-  isFilterLink,
-  isUnaryFilter,
-  FilterFunction,
-  isFilter
-} from '../filter';
 import type {
   DefaultDeSerializers,
   DeSerializers,
   UriConverter
 } from '../de-serializers';
-import { ComplexTypeField, OneToManyLink } from '../selectable';
 import type { EntityApi } from '../entity-api';
 
 type GetFilterType = <

--- a/packages/odata-common/src/uri-conversion/get-orderby.ts
+++ b/packages/odata-common/src/uri-conversion/get-orderby.ts
@@ -1,6 +1,6 @@
+import { OrderLink } from '../order';
 import type { EntityBase } from '../entity-base';
 import type { Orderable, Order } from '../order';
-import { OrderLink } from '../order';
 import type { DeSerializers } from '../de-serializers';
 import type { EntityApi } from '../entity-api';
 

--- a/packages/odata-common/src/uri-conversion/odata-uri.ts
+++ b/packages/odata-common/src/uri-conversion/odata-uri.ts
@@ -1,3 +1,8 @@
+import { createUriConverter } from '../de-serializers';
+import { getEntityKeys } from './get-keys';
+import { getOrderBy } from './get-orderby';
+import { createGetFilter } from './get-filter';
+import { createGetResourcePathForKeys } from './get-resource-path';
 import type { Expandable } from '../expandable';
 import type { EntityBase } from '../entity-base';
 import type { EdmTypeShared } from '../edm-types';
@@ -5,12 +10,7 @@ import type { Selectable } from '../selectable';
 import type { Orderable } from '../order';
 import type { Filterable } from '../filter';
 import type { DeSerializers } from '../de-serializers';
-import { createUriConverter } from '../de-serializers';
 import type { EntityApi } from '../entity-api';
-import { getEntityKeys } from './get-keys';
-import { getOrderBy } from './get-orderby';
-import { createGetFilter } from './get-filter';
-import { createGetResourcePathForKeys } from './get-resource-path';
 
 /**
  * Union of necessary methods for the OData URI conversion.

--- a/packages/odata-v2/src/de-serializers/custom-de-serializers.ts
+++ b/packages/odata-v2/src/de-serializers/custom-de-serializers.ts
@@ -1,3 +1,4 @@
+import { defaultDeSerializers } from './default-de-serializers';
 import type {
   Time,
   CustomOrDefaultType as CustomOrDefaultTypeCommon
@@ -5,7 +6,6 @@ import type {
 import type BigNumber from 'bignumber.js';
 import type { DeSerializers } from './de-serializers';
 import type { DefaultDeSerializers } from './default-de-serializers';
-import { defaultDeSerializers } from './default-de-serializers';
 
 /**
  * Get a complete set of (de-)serializers, that consists of the given partial custom (de-)serializers and default (de-)serializers (aka. default (de-)serializers merged with custom (de-)serializers).

--- a/packages/odata-v2/src/de-serializers/default-de-serializers.ts
+++ b/packages/odata-v2/src/de-serializers/default-de-serializers.ts
@@ -1,15 +1,15 @@
-import type { Time } from '@sap-cloud-sdk/odata-common/internal';
 import {
   defaultDeSerializersRaw as defaultDeSerializersCommon,
   wrapDefaultDeSerializers
 } from '@sap-cloud-sdk/odata-common/internal';
-import type BigNumber from 'bignumber.js';
 import {
   deserializeToMoment,
   deserializeToTime,
   serializeFromMoment,
   serializeFromTime
 } from './converters';
+import type { Time } from '@sap-cloud-sdk/odata-common/internal';
+import type BigNumber from 'bignumber.js';
 import type { DeSerializers } from './de-serializers';
 
 /**

--- a/packages/odata-v2/src/de-serializers/entity-deserializer.ts
+++ b/packages/odata-v2/src/de-serializers/entity-deserializer.ts
@@ -1,8 +1,8 @@
-import type { EntityDeserializer } from '@sap-cloud-sdk/odata-common';
 import { entityDeserializer as entityDeserializerBase } from '@sap-cloud-sdk/odata-common';
 // eslint-disable-next-line import/no-internal-modules
 import { getLinkedCollectionResult } from '../request-builder/response-data-accessor';
 import { extractODataEtag } from '../extract-odata-etag';
+import type { EntityDeserializer } from '@sap-cloud-sdk/odata-common';
 import type { DeSerializers } from './de-serializers';
 
 /**

--- a/packages/odata-v2/src/de-serializers/payload-value-converter.spec.ts
+++ b/packages/odata-v2/src/de-serializers/payload-value-converter.spec.ts
@@ -4,9 +4,9 @@ import {
   deserializeToNumber,
   serializeFromNumber
 } from '@sap-cloud-sdk/odata-common/internal';
-import type { EdmType } from '../edm-types';
 import { defaultDeSerializers } from './default-de-serializers';
 import { edmToTs, tsToEdm } from './payload-value-converter';
+import type { EdmType } from '../edm-types';
 
 describe('edmToTs()', () => {
   it('should parse Edm.String to string', () => {

--- a/packages/odata-v2/src/entity.spec.ts
+++ b/packages/odata-v2/src/entity.spec.ts
@@ -1,11 +1,11 @@
 import { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
-import type { customTestDeSerializers } from '../../../test-resources/test/test-util';
 import {
   testEntityApi,
   testEntityApiCustom,
   testEntityMultiLinkApi,
   testEntitySingleLinkApi
 } from '../test/test-util';
+import type { customTestDeSerializers } from '../../../test-resources/test/test-util';
 import type { CustomDeSerializers } from './de-serializers';
 
 describe('entity', () => {

--- a/packages/odata-v2/src/filter-functions.ts
+++ b/packages/odata-v2/src/filter-functions.ts
@@ -1,3 +1,11 @@
+import {
+  filterFunction,
+  filterFunctions as filterFunctionsCommon
+} from '@sap-cloud-sdk/odata-common/internal';
+import {
+  defaultDeSerializers,
+  mergeDefaultDeSerializersWith
+} from './de-serializers';
 import type {
   Field,
   StringFilterFunction,
@@ -6,16 +14,8 @@ import type {
   Time,
   FilterFunctionNames as FilterFunctionNamesCommon
 } from '@sap-cloud-sdk/odata-common/internal';
-import {
-  filterFunction,
-  filterFunctions as filterFunctionsCommon
-} from '@sap-cloud-sdk/odata-common/internal';
 import type BigNumber from 'bignumber.js';
 import type { DeSerializers } from './de-serializers';
-import {
-  defaultDeSerializers,
-  mergeDefaultDeSerializersWith
-} from './de-serializers';
 import type { Entity } from './entity';
 
 /* String Functions */

--- a/packages/odata-v2/src/request-builder/batch-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/batch-request-builder.ts
@@ -1,14 +1,14 @@
 import { ErrorWithCause } from '@sap-cloud-sdk/util';
-import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import {
   deserializeBatchResponse,
   parseBatchResponse,
   BatchRequestBuilder
 } from '@sap-cloud-sdk/odata-common/internal';
-import type { DeSerializers, DefaultDeSerializers } from '../de-serializers';
 import { entityDeserializer } from '../de-serializers';
-import type { BatchResponse } from '../batch-response';
 import { responseDataAccessor } from './response-data-accessor';
+import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
+import type { DeSerializers, DefaultDeSerializers } from '../de-serializers';
+import type { BatchResponse } from '../batch-response';
 
 /**
  * Create a batch request to invoke multiple requests as a batch. The batch request builder accepts retrieve requests, i.e. {@link GetAllRequestBuilder | getAll} and {@link GetByKeyRequestBuilder | getByKey} requests and change sets, which in turn can contain {@link CreateRequestBuilder | create}, {@link UpdateRequestBuilder | update} or {@link DeleteRequestBuilder | delete} requests.

--- a/packages/odata-v2/src/request-builder/create-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/create-request-builder.ts
@@ -1,16 +1,16 @@
-import type {
-  EntityIdentifiable,
-  EntityApi
-} from '@sap-cloud-sdk/odata-common/internal';
 import {
   CreateRequestBuilderBase,
   entitySerializer
 } from '@sap-cloud-sdk/odata-common/internal';
-import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import { entityDeserializer } from '../de-serializers';
-import type { Entity } from '../entity';
 import { createODataUri } from '../uri-conversion';
 import { responseDataAccessor } from './response-data-accessor';
+import type { Entity } from '../entity';
+import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
+import type {
+  EntityIdentifiable,
+  EntityApi
+} from '@sap-cloud-sdk/odata-common/internal';
 
 /**
  * Create OData request to create an entity.

--- a/packages/odata-v2/src/request-builder/delete-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/delete-request-builder.ts
@@ -1,8 +1,8 @@
-import type { EntityApi } from '@sap-cloud-sdk/odata-common/internal';
 import { DeleteRequestBuilderBase } from '@sap-cloud-sdk/odata-common/internal';
+import { createODataUri } from '../uri-conversion';
+import type { EntityApi } from '@sap-cloud-sdk/odata-common/internal';
 import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import type { Entity } from '../entity';
-import { createODataUri } from '../uri-conversion';
 
 /**
  * Create OData query to delete an entity.

--- a/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v2/src/request-builder/get-all-request-builder.spec.ts
@@ -1,6 +1,5 @@
 import nock from 'nock';
 import * as httpClient from '@sap-cloud-sdk/http-client';
-import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import { oDataTypedClientParameterEncoder } from '@sap-cloud-sdk/http-client/dist/http-client';
 import { asc, desc } from '@sap-cloud-sdk/odata-common';
 import { timeout } from '@sap-cloud-sdk/resilience';
@@ -30,8 +29,9 @@ import {
   testEntityApiCustom,
   createTestEntityWithCustomDeSerializers
 } from '../../test/test-util';
-import type { DefaultDeSerializers } from '../de-serializers';
 import { GetAllRequestBuilder } from './get-all-request-builder';
+import type { DefaultDeSerializers } from '../de-serializers';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 
 describe('GetAllRequestBuilder', () => {
   let requestBuilder: GetAllRequestBuilder<TestEntity, DefaultDeSerializers>;

--- a/packages/odata-v2/src/request-builder/get-all-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/get-all-request-builder.ts
@@ -1,19 +1,19 @@
-import type {
-  EntityIdentifiable,
-  Filterable,
-  EntityApi
-} from '@sap-cloud-sdk/odata-common/internal';
 import {
   GetAllRequestBuilderBase,
   ODataGetAllRequestConfig,
   and
 } from '@sap-cloud-sdk/odata-common/internal';
 import { transformVariadicArgumentToArray } from '@sap-cloud-sdk/util';
-import type { Entity } from '../entity';
-import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import { entityDeserializer } from '../de-serializers';
 import { createODataUri } from '../uri-conversion';
 import { responseDataAccessor } from './response-data-accessor';
+import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
+import type { Entity } from '../entity';
+import type {
+  EntityIdentifiable,
+  Filterable,
+  EntityApi
+} from '@sap-cloud-sdk/odata-common/internal';
 
 export class GetAllRequestBuilder<
     EntityT extends Entity,

--- a/packages/odata-v2/src/request-builder/get-by-key-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/get-by-key-request-builder.ts
@@ -1,13 +1,13 @@
+import { GetByKeyRequestBuilderBase } from '@sap-cloud-sdk/odata-common/internal';
+import { entityDeserializer } from '../de-serializers';
+import { createODataUri } from '../uri-conversion';
+import { responseDataAccessor } from './response-data-accessor';
+import type { Entity } from '../entity';
+import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import type {
   EntityApi,
   EntityIdentifiable
 } from '@sap-cloud-sdk/odata-common/internal';
-import { GetByKeyRequestBuilderBase } from '@sap-cloud-sdk/odata-common/internal';
-import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
-import { entityDeserializer } from '../de-serializers';
-import type { Entity } from '../entity';
-import { createODataUri } from '../uri-conversion';
-import { responseDataAccessor } from './response-data-accessor';
 
 /**
  * Create an OData request to get a single entity based on its key properties.

--- a/packages/odata-v2/src/request-builder/operation-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/operation-request-builder.ts
@@ -1,11 +1,11 @@
+import { OperationRequestBuilderBase } from '@sap-cloud-sdk/odata-common/internal';
+import { ODataFunctionRequestConfig } from '../request';
+import { createODataUri } from '../uri-conversion';
+import type { DeSerializers } from '../de-serializers';
 import type {
   OperationParameters,
   RequestMethodType
 } from '@sap-cloud-sdk/odata-common/internal';
-import { OperationRequestBuilderBase } from '@sap-cloud-sdk/odata-common/internal';
-import type { DeSerializers } from '../de-serializers';
-import { ODataFunctionRequestConfig } from '../request';
-import { createODataUri } from '../uri-conversion';
 
 /**
  * Create OData request to execute an operation.

--- a/packages/odata-v2/src/request-builder/response-transformers.ts
+++ b/packages/odata-v2/src/request-builder/response-transformers.ts
@@ -1,8 +1,8 @@
-import type { EntityApi } from '@sap-cloud-sdk/odata-common';
 import { entityDeserializer } from '../de-serializers';
+import { getSingleResult, getCollectionResult } from './response-data-accessor';
+import type { EntityApi } from '@sap-cloud-sdk/odata-common';
 import type { DeSerializers } from '../de-serializers';
 import type { Entity } from '../entity';
-import { getSingleResult, getCollectionResult } from './response-data-accessor';
 
 /**
  * Transform the payload of the OData response to undefined.

--- a/packages/odata-v2/src/request-builder/update-request-builder.ts
+++ b/packages/odata-v2/src/request-builder/update-request-builder.ts
@@ -1,4 +1,12 @@
 import { createLogger, isNullish } from '@sap-cloud-sdk/util';
+import {
+  UpdateRequestBuilderBase,
+  isNavigationProperty,
+  removePropertyOnCondition,
+  entitySerializer
+} from '@sap-cloud-sdk/odata-common/internal';
+import { extractODataEtag } from '../extract-odata-etag';
+import { createODataUri } from '../uri-conversion';
 import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import type { HttpResponse } from '@sap-cloud-sdk/http-client';
 import type {
@@ -7,16 +15,8 @@ import type {
   ODataUpdateRequestConfig,
   EntityApi
 } from '@sap-cloud-sdk/odata-common/internal';
-import {
-  UpdateRequestBuilderBase,
-  isNavigationProperty,
-  removePropertyOnCondition,
-  entitySerializer
-} from '@sap-cloud-sdk/odata-common/internal';
 import type { Entity } from '../entity';
-import { extractODataEtag } from '../extract-odata-etag';
 import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
-import { createODataUri } from '../uri-conversion';
 
 const logger = createLogger({
   package: 'odata-v2',

--- a/packages/odata-v2/src/request/odata-function-request-config.spec.ts
+++ b/packages/odata-v2/src/request/odata-function-request-config.spec.ts
@@ -1,8 +1,8 @@
 import { OperationParameter } from '@sap-cloud-sdk/odata-common';
-import type { DefaultDeSerializers } from '../de-serializers';
 import { defaultDeSerializers } from '../de-serializers';
 import { createODataUri } from '../uri-conversion';
 import { ODataFunctionRequestConfig } from './odata-function-request-config';
+import type { DefaultDeSerializers } from '../de-serializers';
 
 interface TestParameterType {
   test1: string;

--- a/packages/odata-v2/src/request/odata-function-request-config.ts
+++ b/packages/odata-v2/src/request/odata-function-request-config.ts
@@ -1,10 +1,10 @@
+import { ODataFunctionRequestConfig as ODataFunctionRequestConfigBase } from '@sap-cloud-sdk/odata-common/internal';
 import type {
   ODataUri,
   OperationParameter,
   OperationParameters,
   RequestMethodType
 } from '@sap-cloud-sdk/odata-common/internal';
-import { ODataFunctionRequestConfig as ODataFunctionRequestConfigBase } from '@sap-cloud-sdk/odata-common/internal';
 import type { DeSerializers } from '../de-serializers';
 
 /**

--- a/packages/odata-v2/src/selectable/custom-field.ts
+++ b/packages/odata-v2/src/selectable/custom-field.ts
@@ -1,5 +1,5 @@
-import type { OrderableEdmTypeField } from '@sap-cloud-sdk/odata-common/internal';
 import { CustomField as CustomFieldBase } from '@sap-cloud-sdk/odata-common/internal';
+import type { OrderableEdmTypeField } from '@sap-cloud-sdk/odata-common/internal';
 import type { DeSerializers } from '../de-serializers';
 import type { Entity } from '../entity';
 

--- a/packages/odata-v2/src/uri-conversion/get-expand.ts
+++ b/packages/odata-v2/src/uri-conversion/get-expand.ts
@@ -1,5 +1,5 @@
-import type { Selectable } from '@sap-cloud-sdk/odata-common';
 import { Link } from '@sap-cloud-sdk/odata-common';
+import type { Selectable } from '@sap-cloud-sdk/odata-common';
 import type { DeSerializers } from '../de-serializers';
 import type { Entity } from '../entity';
 

--- a/packages/odata-v2/src/uri-conversion/get-select.ts
+++ b/packages/odata-v2/src/uri-conversion/get-select.ts
@@ -1,5 +1,5 @@
-import type { Selectable } from '@sap-cloud-sdk/odata-common';
 import { Link } from '@sap-cloud-sdk/odata-common';
+import type { Selectable } from '@sap-cloud-sdk/odata-common';
 import type { DeSerializers } from '../de-serializers';
 import type { Entity } from '../entity';
 

--- a/packages/odata-v2/src/uri-conversion/odata-uri.ts
+++ b/packages/odata-v2/src/uri-conversion/odata-uri.ts
@@ -1,10 +1,10 @@
+import { createODataUri as createODataUriBase } from '@sap-cloud-sdk/odata-common/internal';
+import { getExpand } from './get-expand';
+import { getSelect } from './get-select';
 import type {
   ODataUri,
   DeSerializers
 } from '@sap-cloud-sdk/odata-common/internal';
-import { createODataUri as createODataUriBase } from '@sap-cloud-sdk/odata-common/internal';
-import { getExpand } from './get-expand';
-import { getSelect } from './get-select';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getExpandWrapped(selects, expands, entityConstructor) {

--- a/packages/odata-v2/test/test-util/test-data.ts
+++ b/packages/odata-v2/test/test-util/test-data.ts
@@ -1,12 +1,12 @@
 import { createUriConverter } from '@sap-cloud-sdk/odata-common/internal';
-import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
-import type { CustomDeSerializers } from '../../src';
 import { defaultDeSerializers } from '../../src';
 import {
   customStringPropertyValue,
   customTestDeSerializers
 } from '../../../../test-resources/test/test-util';
+import type { CustomDeSerializers } from '../../src';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 
 export const {
   testEntityApi,

--- a/packages/odata-v4/src/de-serializers/converters.ts
+++ b/packages/odata-v4/src/de-serializers/converters.ts
@@ -1,6 +1,6 @@
 import { durationRegexV4 } from '@sap-cloud-sdk/odata-common/internal';
-import type { Time } from '@sap-cloud-sdk/odata-common';
 import moment from 'moment';
+import type { Time } from '@sap-cloud-sdk/odata-common';
 /**
  * @internal
  */

--- a/packages/odata-v4/src/de-serializers/custom-de-serializers.ts
+++ b/packages/odata-v4/src/de-serializers/custom-de-serializers.ts
@@ -1,3 +1,4 @@
+import { defaultDeSerializers } from './default-de-serializers';
 import type {
   Time,
   CustomOrDefaultType as CustomOrDefaultTypeCommon
@@ -6,7 +7,6 @@ import type BigNumber from 'bignumber.js';
 import type moment from 'moment';
 import type { DeSerializers } from './de-serializers';
 import type { DefaultDeSerializers } from './default-de-serializers';
-import { defaultDeSerializers } from './default-de-serializers';
 
 /**
  * Get a complete set of (de-)serializers, that consists of the given partial custom (de-)serializers and default (de-)serializers (aka. default (de-)serializers merged with custom (de-)serializers).

--- a/packages/odata-v4/src/de-serializers/default-de-serializers.ts
+++ b/packages/odata-v4/src/de-serializers/default-de-serializers.ts
@@ -1,11 +1,9 @@
-import type { Time } from '@sap-cloud-sdk/odata-common/internal';
 import {
   convertToUriForEdmString,
   defaultDeSerializersRaw as defaultDeSerializersCommon,
   wrapDefaultDeSerializers
 } from '@sap-cloud-sdk/odata-common/internal';
 import { identity } from '@sap-cloud-sdk/util';
-import type BigNumber from 'bignumber.js';
 import {
   serializeToDate,
   deserializeDateTimeOffsetToMoment,
@@ -16,6 +14,8 @@ import {
   serializeToTime,
   deserializeDateToMoment
 } from './converters';
+import type BigNumber from 'bignumber.js';
+import type { Time } from '@sap-cloud-sdk/odata-common/internal';
 import type { DeSerializers } from './de-serializers';
 
 /**

--- a/packages/odata-v4/src/de-serializers/entity-deserializer.ts
+++ b/packages/odata-v4/src/de-serializers/entity-deserializer.ts
@@ -1,8 +1,8 @@
-import type { EntityDeserializer } from '@sap-cloud-sdk/odata-common/internal';
 import { entityDeserializer as entityDeserializerBase } from '@sap-cloud-sdk/odata-common/internal';
 import { extractODataEtag } from '../extract-odata-etag';
 // eslint-disable-next-line import/no-internal-modules
 import { getLinkedCollectionResult } from '../request-builder/response-data-accessor';
+import type { EntityDeserializer } from '@sap-cloud-sdk/odata-common/internal';
 import type { DeSerializers } from './de-serializers';
 
 /**

--- a/packages/odata-v4/src/entity-builder.spec.ts
+++ b/packages/odata-v4/src/entity-builder.spec.ts
@@ -1,4 +1,3 @@
-import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import moment from 'moment';
 import BigNumber from 'bignumber.js';
 import {
@@ -7,6 +6,7 @@ import {
   testEntityMultiLinkApi,
   testEntitySingleLinkApi
 } from '../test/test-util';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 
 describe('entity-builder', () => {
   it('should build an entity with non-primitive JS types (moment, BigNumber etc.)', () => {

--- a/packages/odata-v4/src/filter-function.ts
+++ b/packages/odata-v4/src/filter-function.ts
@@ -1,3 +1,9 @@
+import {
+  createFilterFunction,
+  numberReturnTypeMapping,
+  CollectionFilterFunction
+} from '@sap-cloud-sdk/odata-common/internal';
+import { DateFilterFunction } from './filter';
 import type moment from 'moment';
 import type {
   FilterFunctionParameterType,
@@ -6,13 +12,7 @@ import type {
   StringFilterFunction,
   FilterFunctionReturnType as FilterFunctionReturnTypeBase
 } from '@sap-cloud-sdk/odata-common/internal';
-import {
-  createFilterFunction,
-  numberReturnTypeMapping,
-  CollectionFilterFunction
-} from '@sap-cloud-sdk/odata-common/internal';
 import type { Entity } from './entity';
-import { DateFilterFunction } from './filter';
 // eslint-disable valid-jsdoc
 
 export function filterFunction<EntityT extends Entity>(

--- a/packages/odata-v4/src/filter-functions.ts
+++ b/packages/odata-v4/src/filter-functions.ts
@@ -1,3 +1,9 @@
+import { filterFunctions as filterFunctionsCommon } from '@sap-cloud-sdk/odata-common/internal';
+import { filterFunction } from './filter-function';
+import {
+  defaultDeSerializers,
+  mergeDefaultDeSerializersWith
+} from './de-serializers';
 import type moment from 'moment';
 import type {
   Field,
@@ -11,15 +17,9 @@ import type {
   FilterFunctionsType as FilterFunctionsCommonType,
   Time
 } from '@sap-cloud-sdk/odata-common/internal';
-import { filterFunctions as filterFunctionsCommon } from '@sap-cloud-sdk/odata-common/internal';
 import type BigNumber from 'bignumber.js';
 import type { Entity } from './entity';
-import { filterFunction } from './filter-function';
 import type { DeSerializers } from './de-serializers';
-import {
-  defaultDeSerializers,
-  mergeDefaultDeSerializersWith
-} from './de-serializers';
 
 /* String Functions */
 /**

--- a/packages/odata-v4/src/filter/date-filter-function.ts
+++ b/packages/odata-v4/src/filter/date-filter-function.ts
@@ -1,9 +1,9 @@
+import { OrderableFilterFunction } from '@sap-cloud-sdk/odata-common/internal';
 import type moment from 'moment';
 import type {
   EntityBase,
   FilterFunctionParameterType
 } from '@sap-cloud-sdk/odata-common/internal';
-import { OrderableFilterFunction } from '@sap-cloud-sdk/odata-common/internal';
 
 /**
  * Representation of a filter function, that returns a value of type date. This supports DateTimeOffset values.

--- a/packages/odata-v4/src/filter/filter-lambda-expression.ts
+++ b/packages/odata-v4/src/filter/filter-lambda-expression.ts
@@ -1,12 +1,12 @@
-import type {
-  EntityBase,
-  Filterable,
-  EntityApi
-} from '@sap-cloud-sdk/odata-common/internal';
 import {
   FilterLambdaExpression,
   and,
   toFilterableList
+} from '@sap-cloud-sdk/odata-common/internal';
+import type {
+  EntityBase,
+  Filterable,
+  EntityApi
 } from '@sap-cloud-sdk/odata-common/internal';
 import type { DeSerializers } from '../de-serializers';
 import type { Entity } from '../entity';

--- a/packages/odata-v4/src/request-builder/batch-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/batch-request-builder.ts
@@ -1,14 +1,14 @@
 import { ErrorWithCause } from '@sap-cloud-sdk/util';
-import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import {
   parseBatchResponse,
   BatchRequestBuilder,
   deserializeBatchResponse
 } from '@sap-cloud-sdk/odata-common/internal';
-import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import { entityDeserializer } from '../de-serializers';
-import type { BatchResponse } from '../batch-response';
 import { responseDataAccessor } from './response-data-accessor';
+import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
+import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
+import type { BatchResponse } from '../batch-response';
 
 /**
  * Create a batch request to invoke multiple requests as a batch. The batch request builder accepts retrieve requests, i.e. {@link GetAllRequestBuilder | getAll} and {@link GetByKeyRequestBuilder | getByKey} requests and change sets, which in turn can contain {@link CreateRequestBuilder | create}, {@link UpdateRequestBuilder | update} or {@link DeleteRequestBuilder | delete} requests.

--- a/packages/odata-v4/src/request-builder/bound-operation-request-builder.spec.ts
+++ b/packages/odata-v4/src/request-builder/bound-operation-request-builder.spec.ts
@@ -1,10 +1,10 @@
-import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 import {
   TestEntity,
   testService
 } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import moment from 'moment';
 import nock from 'nock';
+import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 
 describe('bound function import request builder', () => {
   const { testEntityApi } = testService();

--- a/packages/odata-v4/src/request-builder/bound-operation-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/bound-operation-request-builder.ts
@@ -1,16 +1,16 @@
 // eslint-disable-next-line max-classes-per-file
-import type {
-  EntityApi,
-  EntityBase,
-  OperationParameters
-} from '@sap-cloud-sdk/odata-common/internal';
 import { OperationRequestBuilderBase } from '@sap-cloud-sdk/odata-common/internal';
-import type { DeSerializers } from '../de-serializers';
 import {
   ODataBoundActionRequestConfig,
   ODataBoundFunctionRequestConfig
 } from '../request';
 import { createODataUri } from '../uri-conversion';
+import type { DeSerializers } from '../de-serializers';
+import type {
+  EntityApi,
+  EntityBase,
+  OperationParameters
+} from '@sap-cloud-sdk/odata-common/internal';
 
 /**
  * Create bound OData request to execute an operation.

--- a/packages/odata-v4/src/request-builder/create-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/create-request-builder.ts
@@ -1,16 +1,16 @@
-import type {
-  EntityApi,
-  EntityIdentifiable
-} from '@sap-cloud-sdk/odata-common/internal';
 import {
   CreateRequestBuilderBase,
   entitySerializer
 } from '@sap-cloud-sdk/odata-common/internal';
-import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import { entityDeserializer } from '../de-serializers';
-import type { Entity } from '../entity';
 import { createODataUri } from '../uri-conversion';
 import { responseDataAccessor } from './response-data-accessor';
+import type { Entity } from '../entity';
+import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
+import type {
+  EntityApi,
+  EntityIdentifiable
+} from '@sap-cloud-sdk/odata-common/internal';
 /**
  * Create OData request to create an entity.
  * @typeParam EntityT - Type of the entity to be created.

--- a/packages/odata-v4/src/request-builder/delete-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/delete-request-builder.ts
@@ -1,8 +1,8 @@
-import type { EntityApi } from '@sap-cloud-sdk/odata-common/internal';
 import { DeleteRequestBuilderBase } from '@sap-cloud-sdk/odata-common/internal';
+import { createODataUri } from '../uri-conversion';
+import type { EntityApi } from '@sap-cloud-sdk/odata-common/internal';
 import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import type { Entity } from '../entity';
-import { createODataUri } from '../uri-conversion';
 
 /**
  * Create OData query to delete an entity.

--- a/packages/odata-v4/src/request-builder/get-all-request-builder.spec.ts
+++ b/packages/odata-v4/src/request-builder/get-all-request-builder.spec.ts
@@ -1,4 +1,3 @@
-import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import {
   createOriginalTestEntityDataV4_1,
   createOriginalTestEntityDataV4_2,
@@ -15,9 +14,10 @@ import {
   testEntityMultiLinkApi,
   testEntitySingleLinkApi
 } from '../../test/test-util';
-import type { DefaultDeSerializers } from '../de-serializers';
 import { any } from '../filter';
 import { GetAllRequestBuilder } from './get-all-request-builder';
+import type { DefaultDeSerializers } from '../de-serializers';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 
 describe('GetAllRequestBuilder', () => {
   let requestBuilder: GetAllRequestBuilder<TestEntity, DefaultDeSerializers>;

--- a/packages/odata-v4/src/request-builder/get-all-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/get-all-request-builder.ts
@@ -1,10 +1,3 @@
-import type {
-  EntityIdentifiable,
-  Filterable,
-  Expandable,
-  EntityApi,
-  EntityBase
-} from '@sap-cloud-sdk/odata-common/internal';
 import {
   GetAllRequestBuilderBase,
   ODataGetAllRequestConfig,
@@ -12,11 +5,18 @@ import {
   and
 } from '@sap-cloud-sdk/odata-common/internal';
 import { transformVariadicArgumentToArray } from '@sap-cloud-sdk/util';
-import type { Entity } from '../entity';
-import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import { entityDeserializer } from '../de-serializers';
 import { createODataUri } from '../uri-conversion';
 import { responseDataAccessor } from './response-data-accessor';
+import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
+import type { Entity } from '../entity';
+import type {
+  EntityIdentifiable,
+  Filterable,
+  Expandable,
+  EntityApi,
+  EntityBase
+} from '@sap-cloud-sdk/odata-common/internal';
 
 export class GetAllRequestBuilder<
     EntityT extends Entity,

--- a/packages/odata-v4/src/request-builder/get-by-key-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/get-by-key-request-builder.ts
@@ -1,16 +1,16 @@
 import { transformVariadicArgumentToArray } from '@sap-cloud-sdk/util';
+import { GetByKeyRequestBuilderBase } from '@sap-cloud-sdk/odata-common/internal';
+import { entityDeserializer } from '../de-serializers';
+import { createODataUri } from '../uri-conversion';
+import { responseDataAccessor } from './response-data-accessor';
+import type { Entity } from '../entity';
+import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
 import type {
   EntityIdentifiable,
   Expandable,
   EntityApi,
   EntityBase
 } from '@sap-cloud-sdk/odata-common/internal';
-import { GetByKeyRequestBuilderBase } from '@sap-cloud-sdk/odata-common/internal';
-import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
-import { entityDeserializer } from '../de-serializers';
-import type { Entity } from '../entity';
-import { createODataUri } from '../uri-conversion';
-import { responseDataAccessor } from './response-data-accessor';
 
 /**
  * Create an OData request to get a single entity based on its key properties.

--- a/packages/odata-v4/src/request-builder/operation-request-builder.spec.ts
+++ b/packages/odata-v4/src/request-builder/operation-request-builder.spec.ts
@@ -1,5 +1,4 @@
 import nock from 'nock';
-import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 import {
   testActionImportMultipleParameterComplexReturnType,
   testActionImportNoParameterNoReturnType,
@@ -12,6 +11,7 @@ import {
 import { entitySerializer } from '@sap-cloud-sdk/odata-common';
 import { defaultDestination } from '../../../../test-resources/test/test-util/request-mocker';
 import { defaultDeSerializers } from '../de-serializers';
+import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 
 const basePath = '/sap/opu/odata/sap/API_TEST_SRV';
 const host = 'https://example.com';

--- a/packages/odata-v4/src/request-builder/operation-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/operation-request-builder.ts
@@ -1,15 +1,15 @@
 // eslint-disable-next-line max-classes-per-file
-import type {
-  ODataRequestConfig,
-  OperationParameters
-} from '@sap-cloud-sdk/odata-common/internal';
 import { OperationRequestBuilderBase } from '@sap-cloud-sdk/odata-common/internal';
-import type { DeSerializers } from '../de-serializers';
 import {
   ODataFunctionRequestConfig,
   ODataActionRequestConfig
 } from '../request';
 import { createODataUri } from '../uri-conversion';
+import type { DeSerializers } from '../de-serializers';
+import type {
+  ODataRequestConfig,
+  OperationParameters
+} from '@sap-cloud-sdk/odata-common/internal';
 
 /**
  * Create OData request to execute an operation.

--- a/packages/odata-v4/src/request-builder/response-transformers.ts
+++ b/packages/odata-v4/src/request-builder/response-transformers.ts
@@ -1,8 +1,8 @@
+import { entityDeserializer } from '../de-serializers';
+import { getSingleResult, getCollectionResult } from './response-data-accessor';
 import type { EntityApi } from '@sap-cloud-sdk/odata-common';
 import type { Entity } from '../entity';
 import type { DeSerializers } from '../de-serializers';
-import { entityDeserializer } from '../de-serializers';
-import { getSingleResult, getCollectionResult } from './response-data-accessor';
 
 /**
  * Transform the payload of the OData response to undefined.

--- a/packages/odata-v4/src/request-builder/update-request-builder.ts
+++ b/packages/odata-v4/src/request-builder/update-request-builder.ts
@@ -1,18 +1,18 @@
 import { identity } from '@sap-cloud-sdk/util';
+import {
+  UpdateRequestBuilderBase,
+  entitySerializer
+} from '@sap-cloud-sdk/odata-common/internal';
+import { extractODataEtag } from '../extract-odata-etag';
+import { createODataUri } from '../uri-conversion';
 import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import type { HttpResponse } from '@sap-cloud-sdk/http-client';
 import type {
   EntityIdentifiable,
   EntityApi
 } from '@sap-cloud-sdk/odata-common/internal';
-import {
-  UpdateRequestBuilderBase,
-  entitySerializer
-} from '@sap-cloud-sdk/odata-common/internal';
 import type { Entity } from '../entity';
-import { extractODataEtag } from '../extract-odata-etag';
 import type { DefaultDeSerializers, DeSerializers } from '../de-serializers';
-import { createODataUri } from '../uri-conversion';
 
 /**
  * Create OData query to update an entity.

--- a/packages/odata-v4/src/request/odata-action-request-config.ts
+++ b/packages/odata-v4/src/request/odata-action-request-config.ts
@@ -1,9 +1,9 @@
+import { ODataRequestConfig } from '@sap-cloud-sdk/odata-common';
 import type {
   ODataUri,
   OperationParameter,
   OperationParameters
 } from '@sap-cloud-sdk/odata-common';
-import { ODataRequestConfig } from '@sap-cloud-sdk/odata-common';
 import type { DeSerializers } from '../de-serializers';
 
 /**

--- a/packages/odata-v4/src/request/odata-bound-action-request-config.ts
+++ b/packages/odata-v4/src/request/odata-bound-action-request-config.ts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line max-classes-per-file
+import { ODataActionRequestConfig } from './odata-action-request-config';
 import type {
   ODataUri,
   EntityBase,
@@ -8,7 +9,6 @@ import type {
   WithKeys
 } from '@sap-cloud-sdk/odata-common';
 import type { DeSerializers } from '../de-serializers';
-import { ODataActionRequestConfig } from './odata-action-request-config';
 
 /**
  * Action request configuration for an entity type.

--- a/packages/odata-v4/src/request/odata-bound-function-request-config.ts
+++ b/packages/odata-v4/src/request/odata-bound-function-request-config.ts
@@ -1,3 +1,4 @@
+import { ODataFunctionRequestConfig } from './odata-function-request-config';
 import type {
   ODataUri,
   OperationParameters,
@@ -7,7 +8,6 @@ import type {
   EntityBase
 } from '@sap-cloud-sdk/odata-common';
 import type { DeSerializers } from '../de-serializers';
-import { ODataFunctionRequestConfig } from './odata-function-request-config';
 
 /**
  * Function request configuration for an entity type.

--- a/packages/odata-v4/src/request/odata-function-request-config.ts
+++ b/packages/odata-v4/src/request/odata-function-request-config.ts
@@ -1,10 +1,10 @@
+import { ODataFunctionRequestConfig as ODataFunctionRequestConfigBase } from '@sap-cloud-sdk/odata-common';
 import type {
   ODataUri,
   OperationParameter,
   OperationParameters,
   RequestMethodType
 } from '@sap-cloud-sdk/odata-common';
-import { ODataFunctionRequestConfig as ODataFunctionRequestConfigBase } from '@sap-cloud-sdk/odata-common';
 import type { DeSerializers } from '../de-serializers';
 
 /**

--- a/packages/odata-v4/src/selectable/custom-field.ts
+++ b/packages/odata-v4/src/selectable/custom-field.ts
@@ -1,5 +1,5 @@
-import type { OrderableEdmTypeField } from '@sap-cloud-sdk/odata-common/internal';
 import { CustomField as CustomFieldBase } from '@sap-cloud-sdk/odata-common/internal';
+import type { OrderableEdmTypeField } from '@sap-cloud-sdk/odata-common/internal';
 import type { DeSerializers } from '../de-serializers';
 import type { Entity } from '../entity';
 

--- a/packages/odata-v4/src/uri-conversion/get-expand.ts
+++ b/packages/odata-v4/src/uri-conversion/get-expand.ts
@@ -1,7 +1,3 @@
-import type {
-  Expandable,
-  EntityApi
-} from '@sap-cloud-sdk/odata-common/internal';
 import {
   OneToManyLink,
   AllFields,
@@ -10,10 +6,14 @@ import {
   createGetFilter,
   getOrderBy
 } from '@sap-cloud-sdk/odata-common/internal';
-import type { DeSerializers } from '../de-serializers';
-import type { Entity } from '../entity';
 import { getSelect } from './get-select';
 import { uriConverter } from './uri-value-converter';
+import type {
+  Expandable,
+  EntityApi
+} from '@sap-cloud-sdk/odata-common/internal';
+import type { DeSerializers } from '../de-serializers';
+import type { Entity } from '../entity';
 
 function prependDollar(param: string): string {
   return `$${param}`;

--- a/packages/odata-v4/src/uri-conversion/odata-uri.ts
+++ b/packages/odata-v4/src/uri-conversion/odata-uri.ts
@@ -1,3 +1,6 @@
+import { createODataUri as createODataUriBase } from '@sap-cloud-sdk/odata-common/internal';
+import { getExpand } from './get-expand';
+import { getSelect } from './get-select';
 import type {
   EntityApi,
   EntityBase,
@@ -5,11 +8,8 @@ import type {
   ODataUri,
   Selectable
 } from '@sap-cloud-sdk/odata-common/internal';
-import { createODataUri as createODataUriBase } from '@sap-cloud-sdk/odata-common/internal';
 import type { DeSerializers } from '../de-serializers';
 import type { Entity } from '../entity';
-import { getExpand } from './get-expand';
-import { getSelect } from './get-select';
 
 /**
  * Instance of the {@link ODataUri} conversion interface for OData v4.

--- a/packages/odata-v4/test/test-util/test-data.ts
+++ b/packages/odata-v4/test/test-util/test-data.ts
@@ -1,11 +1,11 @@
 import { createUriConverter } from '@sap-cloud-sdk/odata-common/internal';
+import { testService } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
+import { customTestDeSerializers } from '../../../../test-resources/test/test-util';
+import { defaultDeSerializers } from '../../src';
 import type {
   TestEntity,
   TestEntityWithEnumKey
 } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
-import { testService } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
-import { customTestDeSerializers } from '../../../../test-resources/test/test-util';
-import { defaultDeSerializers } from '../../src';
 
 export const {
   testEntityApi,

--- a/packages/openapi-generator/src/cli-parser.ts
+++ b/packages/openapi-generator/src/cli-parser.ts
@@ -1,6 +1,6 @@
 import { parseCmdArgsBuilder } from '@sap-cloud-sdk/generator-common/internal';
-import type { GeneratorOptions } from './options';
 import { cliOptions } from './options';
+import type { GeneratorOptions } from './options';
 
 const commandText =
   'OpenAPI Client Code Generator. Generates typed clients from OpenAPI files for usage with the SAP Cloud SDK for JavaScript.';

--- a/packages/openapi-generator/src/document-converter.spec.ts
+++ b/packages/openapi-generator/src/document-converter.spec.ts
@@ -1,6 +1,6 @@
-import type { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import mock from 'mock-fs';
 import { convertDocToOpenApiV3, parseFileAsJson } from './document-converter';
+import type { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 
 describe('document-converter', () => {
   describe('convertDocToOpenApiV3', () => {

--- a/packages/openapi-generator/src/document-converter.ts
+++ b/packages/openapi-generator/src/document-converter.ts
@@ -1,9 +1,9 @@
 import { promises } from 'fs';
 import { parse } from 'path';
-import type { OpenAPIV3 } from 'openapi-types';
 import { convert } from 'swagger2openapi';
 import { load } from 'js-yaml';
 import { ErrorWithCause } from '@sap-cloud-sdk/util';
+import type { OpenAPIV3 } from 'openapi-types';
 const { readFile } = promises;
 
 /**

--- a/packages/openapi-generator/src/file-serializer/api-file.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/api-file.spec.ts
@@ -1,6 +1,6 @@
 import { readPrettierConfig } from '@sap-cloud-sdk/generator-common/internal';
-import type { OpenApiApi, OpenApiReferenceSchema } from '../openapi-types';
 import { apiDocumentation, apiFile } from './api-file';
+import type { OpenApiApi, OpenApiReferenceSchema } from '../openapi-types';
 
 const singleOperationApi: OpenApiApi = {
   name: 'TestApi',

--- a/packages/openapi-generator/src/file-serializer/api-file.ts
+++ b/packages/openapi-generator/src/file-serializer/api-file.ts
@@ -1,16 +1,16 @@
 import { codeBlock, documentationBlock, unixEOL } from '@sap-cloud-sdk/util';
-import type {
-  Import,
-  CreateFileOptions
-} from '@sap-cloud-sdk/generator-common/internal';
 import { serializeImports } from '@sap-cloud-sdk/generator-common/internal';
+import { collectRefs, getUniqueRefs } from '../schema-util';
+import { serializeOperation } from './operation';
 import type {
   OpenApiApi,
   OpenApiOperation,
   OpenApiReferenceSchema
 } from '../openapi-types';
-import { collectRefs, getUniqueRefs } from '../schema-util';
-import { serializeOperation } from './operation';
+import type {
+  Import,
+  CreateFileOptions
+} from '@sap-cloud-sdk/generator-common/internal';
 
 /**
  * Serialize an API representation to a string representing the resulting API file.

--- a/packages/openapi-generator/src/file-serializer/index-file.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/index-file.spec.ts
@@ -1,7 +1,7 @@
-import type { CreateFileOptions } from '@sap-cloud-sdk/generator-common/internal';
 import { readPrettierConfig } from '@sap-cloud-sdk/generator-common/internal';
-import type { OpenApiDocument } from '../openapi-types';
 import { apiIndexFile, schemaIndexFile } from './index-file';
+import type { CreateFileOptions } from '@sap-cloud-sdk/generator-common/internal';
+import type { OpenApiDocument } from '../openapi-types';
 
 describe('index-file', () => {
   describe('apiIndexFile', () => {

--- a/packages/openapi-generator/src/file-serializer/operation.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/operation.spec.ts
@@ -1,9 +1,9 @@
+import { operationDocumentation, serializeOperation } from './operation';
 import type {
   OpenApiOperation,
   OpenApiParameter,
   OpenApiReferenceSchema
 } from '../openapi-types';
-import { operationDocumentation, serializeOperation } from './operation';
 
 describe('serializeOperation', () => {
   it('serializes operation with path, query and header parameters', () => {

--- a/packages/openapi-generator/src/file-serializer/operation.ts
+++ b/packages/openapi-generator/src/file-serializer/operation.ts
@@ -1,10 +1,10 @@
 import { codeBlock, documentationBlock, unixEOL } from '@sap-cloud-sdk/util';
+import { serializeSchema } from './schema';
 import type {
   OpenApiOperation,
   OpenApiParameter,
   OpenApiRequestBody
 } from '../openapi-types';
-import { serializeSchema } from './schema';
 
 /**
  * Serialize an operation to a string.

--- a/packages/openapi-generator/src/file-serializer/package-json.ts
+++ b/packages/openapi-generator/src/file-serializer/package-json.ts
@@ -1,6 +1,6 @@
 import { unixEOL } from '@sap-cloud-sdk/util';
-import type { PackageJsonOptions } from '@sap-cloud-sdk/generator-common/internal';
 import { packageJsonBase } from '@sap-cloud-sdk/generator-common/internal';
+import type { PackageJsonOptions } from '@sap-cloud-sdk/generator-common/internal';
 
 /**
  * Generate the package.json for an openapi client so it can be released as an npm module.

--- a/packages/openapi-generator/src/file-serializer/readme.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/readme.spec.ts
@@ -1,5 +1,5 @@
-import type { OpenApiDocument } from '../openapi-types';
 import { readme } from './readme';
+import type { OpenApiDocument } from '../openapi-types';
 
 describe('readme', () => {
   it('returns the readme content', () => {

--- a/packages/openapi-generator/src/file-serializer/readme.ts
+++ b/packages/openapi-generator/src/file-serializer/readme.ts
@@ -3,8 +3,8 @@ import {
   helpfulLinksSection,
   usageHeaderText
 } from '@sap-cloud-sdk/generator-common/internal';
-import type { OpenApiDocument } from '../openapi-types';
 import { getApiSpecificUsage } from '../sdk-metadata';
+import type { OpenApiDocument } from '../openapi-types';
 /**
  * Generate the readme for an openapi client.
  * @param openApiDocument - Parsed service.

--- a/packages/openapi-generator/src/file-serializer/schema-file.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/schema-file.spec.ts
@@ -1,11 +1,11 @@
-import type { CreateFileOptions } from '@sap-cloud-sdk/generator-common/internal';
 import { readPrettierConfig } from '@sap-cloud-sdk/generator-common/internal';
+import { schemaDocumentation, schemaFile } from './schema-file';
+import { schemaPropertyDocumentation } from './schema';
 import type {
   OpenApiObjectSchemaProperty,
   OpenApiPersistedSchema
 } from '../openapi-types';
-import { schemaDocumentation, schemaFile } from './schema-file';
-import { schemaPropertyDocumentation } from './schema';
+import type { CreateFileOptions } from '@sap-cloud-sdk/generator-common/internal';
 
 const schema = {
   schemaName: 'MySchema',

--- a/packages/openapi-generator/src/file-serializer/schema-file.ts
+++ b/packages/openapi-generator/src/file-serializer/schema-file.ts
@@ -1,12 +1,12 @@
 import { codeBlock, documentationBlock, unixEOL } from '@sap-cloud-sdk/util';
+import { serializeImports } from '@sap-cloud-sdk/generator-common/internal';
+import { collectRefs, getSchemaPropertiesDocumentation } from '../schema-util';
+import { serializeSchema } from './schema';
+import type { OpenApiPersistedSchema } from '../openapi-types';
 import type {
   Import,
   CreateFileOptions
 } from '@sap-cloud-sdk/generator-common/internal';
-import { serializeImports } from '@sap-cloud-sdk/generator-common/internal';
-import type { OpenApiPersistedSchema } from '../openapi-types';
-import { collectRefs, getSchemaPropertiesDocumentation } from '../schema-util';
-import { serializeSchema } from './schema';
 
 /**
  * Serialize a schema representation to a string representing the according schema file contents.

--- a/packages/openapi-generator/src/file-serializer/schema.ts
+++ b/packages/openapi-generator/src/file-serializer/schema.ts
@@ -1,9 +1,4 @@
 import { codeBlock, documentationBlock, unixEOL } from '@sap-cloud-sdk/util';
-import type {
-  OpenApiSchema,
-  OpenApiObjectSchema,
-  OpenApiObjectSchemaProperty
-} from '../openapi-types';
 import { getType } from '../parser';
 import {
   isReferenceObject,
@@ -16,6 +11,11 @@ import {
   isNotSchema,
   getSchemaPropertiesDocumentation
 } from '../schema-util';
+import type {
+  OpenApiSchema,
+  OpenApiObjectSchema,
+  OpenApiObjectSchemaProperty
+} from '../openapi-types';
 
 /**
  * Serialize a schema.

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -7,10 +7,6 @@ import {
   setLogLevel,
   ErrorWithCause
 } from '@sap-cloud-sdk/util';
-import type {
-  CreateFileOptions,
-  ServiceOptions
-} from '@sap-cloud-sdk/generator-common/internal';
 import {
   getSdkMetadataFileNames,
   getSdkVersion,
@@ -33,12 +29,16 @@ import {
   apiIndexFile,
   schemaIndexFile
 } from './file-serializer';
-import type { OpenApiDocument } from './openapi-types';
 import { parseOpenApiDocument } from './parser';
 import { convertOpenApiSpec } from './document-converter';
 import { sdkMetadata } from './sdk-metadata';
-import type { GeneratorOptions, ParsedGeneratorOptions } from './options';
 import { cliOptions, tsconfigJson } from './options';
+import type { GeneratorOptions, ParsedGeneratorOptions } from './options';
+import type { OpenApiDocument } from './openapi-types';
+import type {
+  CreateFileOptions,
+  ServiceOptions
+} from '@sap-cloud-sdk/generator-common/internal';
 
 const { mkdir } = promisesFs;
 const logger = createLogger('openapi-generator');

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -1,9 +1,9 @@
+import { getCommonCliOptions } from '@sap-cloud-sdk/generator-common/internal';
 import type {
   ParsedOptions,
   Options,
   CommonGeneratorOptions
 } from '@sap-cloud-sdk/generator-common/internal';
-import { getCommonCliOptions } from '@sap-cloud-sdk/generator-common/internal';
 
 /**
  * Options to configure OData client generation when using the generator programmatically.

--- a/packages/openapi-generator/src/parser/api.spec.ts
+++ b/packages/openapi-generator/src/parser/api.spec.ts
@@ -1,8 +1,8 @@
-import type { OpenAPIV3 } from 'openapi-types';
 import { createTestRefs, emptyDocument } from '../../test/test-util';
 import { apiNameExtension } from '../extensions';
 import { parseApis } from './api';
 import { createRefs } from './refs';
+import type { OpenAPIV3 } from 'openapi-types';
 
 const options = { strictNaming: true, schemaPrefix: '' };
 describe('parseApis', () => {

--- a/packages/openapi-generator/src/parser/api.ts
+++ b/packages/openapi-generator/src/parser/api.ts
@@ -1,12 +1,12 @@
 import { flat, pascalCase } from '@sap-cloud-sdk/util';
-import type { OpenAPIV3 } from 'openapi-types';
-import type { OpenApiApi } from '../openapi-types';
 import { methods } from '../openapi-types';
 import { apiNameExtension, defaultApiName } from '../extensions';
 import { parseOperation } from './operation';
-import type { OperationInfo } from './parsing-info';
 import { nameOperations } from './operation-naming';
 import { ensureUniqueNames } from './unique-naming';
+import type { OperationInfo } from './parsing-info';
+import type { OpenApiApi } from '../openapi-types';
+import type { OpenAPIV3 } from 'openapi-types';
 import type { OpenApiDocumentRefs } from './refs';
 import type { ParserOptions } from './options';
 

--- a/packages/openapi-generator/src/parser/document.spec.ts
+++ b/packages/openapi-generator/src/parser/document.spec.ts
@@ -1,8 +1,8 @@
-import type { OpenAPIV3 } from 'openapi-types';
-import type { ServiceOptions } from '@sap-cloud-sdk/generator-common/dist/options-per-service';
 import { emptyDocument } from '../../test/test-util';
 import { parseOpenApiDocument } from './document';
 import * as api from './api';
+import type { ServiceOptions } from '@sap-cloud-sdk/generator-common/dist/options-per-service';
+import type { OpenAPIV3 } from 'openapi-types';
 
 const options = { strictNaming: true, schemaPrefix: '' };
 describe('parseOpenApiDocument', () => {

--- a/packages/openapi-generator/src/parser/document.ts
+++ b/packages/openapi-generator/src/parser/document.ts
@@ -1,12 +1,12 @@
+import { parseSchema, parseSchemaProperties } from './schema';
+import { parseApis } from './api';
+import { createRefs } from './refs';
+import { parseBound } from './swagger-parser-workaround';
 import type { OpenAPIV3 } from 'openapi-types';
 import type { ServiceOptions } from '@sap-cloud-sdk/generator-common/internal';
 import type { OpenApiDocument, OpenApiPersistedSchema } from '../openapi-types';
-import { parseSchema, parseSchemaProperties } from './schema';
-import { parseApis } from './api';
 import type { OpenApiDocumentRefs } from './refs';
-import { createRefs } from './refs';
 import type { ParserOptions } from './options';
-import { parseBound } from './swagger-parser-workaround';
 
 /**
  * Parse an OpenAPI document.

--- a/packages/openapi-generator/src/parser/media-type.ts
+++ b/packages/openapi-generator/src/parser/media-type.ts
@@ -1,8 +1,8 @@
 import { createLogger } from '@sap-cloud-sdk/util';
+import { parseSchema } from './schema';
 import type { OpenAPIV3 } from 'openapi-types';
 import type { OpenApiSchema } from '../openapi-types';
 import type { OpenApiDocumentRefs } from './refs';
-import { parseSchema } from './schema';
 import type { ParserOptions } from './options';
 
 const logger = createLogger('openapi-generator');

--- a/packages/openapi-generator/src/parser/operation-naming.spec.ts
+++ b/packages/openapi-generator/src/parser/operation-naming.spec.ts
@@ -1,9 +1,9 @@
 import { operationNameExtension } from '../extensions';
-import type { OperationInfo } from './parsing-info';
 import {
   getOperationNameFromPatternAndMethod,
   nameOperations
 } from './operation-naming';
+import type { OperationInfo } from './parsing-info';
 
 it('nameOperations adds retrieves initial names for operations', () => {
   const uniqueOperations = nameOperations([

--- a/packages/openapi-generator/src/parser/operation-naming.ts
+++ b/packages/openapi-generator/src/parser/operation-naming.ts
@@ -1,6 +1,6 @@
 import { partition, pascalCase, camelCase } from '@sap-cloud-sdk/util';
-import type { Method } from '../openapi-types';
 import { operationNameExtension } from '../extensions';
+import type { Method } from '../openapi-types';
 import type { OperationInfo } from './parsing-info';
 
 /**

--- a/packages/openapi-generator/src/parser/operation.spec.ts
+++ b/packages/openapi-generator/src/parser/operation.spec.ts
@@ -1,12 +1,12 @@
-import type { OpenAPIV3 } from 'openapi-types';
 import { createTestRefs, emptyObjectSchema } from '../../test/test-util';
-import type { OpenApiParameter } from '../openapi-types';
 import {
   parseParameters,
   getRelevantParameters,
   parsePathParameters,
   parsePathPattern
 } from './operation';
+import type { OpenAPIV3 } from 'openapi-types';
+import type { OpenApiParameter } from '../openapi-types';
 
 const defaultOptions = { strictNaming: true, schemaPrefix: '' };
 describe('getRelevantParameters', () => {

--- a/packages/openapi-generator/src/parser/operation.ts
+++ b/packages/openapi-generator/src/parser/operation.ts
@@ -1,13 +1,13 @@
-import type { OpenAPIV3 } from 'openapi-types';
 import { filterDuplicatesRight } from '@sap-cloud-sdk/util';
 import { reservedJsKeywords } from '@sap-cloud-sdk/generator-common/internal';
-import type { OpenApiOperation, OpenApiParameter } from '../openapi-types';
 import { parseRequestBody } from './request-body';
-import type { OpenApiDocumentRefs } from './refs';
 import { parseSchema } from './schema';
 import { parseResponses } from './responses';
-import type { OperationInfo } from './parsing-info';
 import { ensureUniqueNames } from './unique-naming';
+import type { OperationInfo } from './parsing-info';
+import type { OpenApiDocumentRefs } from './refs';
+import type { OpenApiOperation, OpenApiParameter } from '../openapi-types';
+import type { OpenAPIV3 } from 'openapi-types';
 import type { ParserOptions } from './options';
 
 /**

--- a/packages/openapi-generator/src/parser/refs.spec.ts
+++ b/packages/openapi-generator/src/parser/refs.spec.ts
@@ -1,7 +1,7 @@
-import type { OpenAPIV3 } from 'openapi-types';
 import { emptyDocument } from '../../test/test-util';
-import type { OpenApiDocumentRefs } from './refs';
 import { createRefs } from './refs';
+import type { OpenAPIV3 } from 'openapi-types';
+import type { OpenApiDocumentRefs } from './refs';
 describe('OpenApiDocumentRefs', () => {
   let refs: OpenApiDocumentRefs;
   const typeName: OpenAPIV3.SchemaObject = { type: 'string' };

--- a/packages/openapi-generator/src/parser/refs.ts
+++ b/packages/openapi-generator/src/parser/refs.ts
@@ -1,13 +1,13 @@
-import type { OpenAPIV3 } from 'openapi-types';
-import type { $Refs } from '@apidevtools/swagger-parser';
 import { pascalCase, kebabCase } from '@sap-cloud-sdk/util';
 import { isReferenceObject } from '../schema-util';
-import type { SchemaNaming } from '../openapi-types';
-import type { SchemaRefMapping } from './parsing-info';
 import { ensureUniqueNames } from './unique-naming';
-import type { ParserOptions } from './options';
 import { ensureValidSchemaNames } from './schema-naming';
 import { resolveBound } from './swagger-parser-workaround';
+import type { OpenAPIV3 } from 'openapi-types';
+import type { $Refs } from '@apidevtools/swagger-parser';
+import type { SchemaNaming } from '../openapi-types';
+import type { SchemaRefMapping } from './parsing-info';
+import type { ParserOptions } from './options';
 
 /**
  * Convenience function to invoke the creation of the OpenApiDocumentRefs builder.

--- a/packages/openapi-generator/src/parser/request-body.ts
+++ b/packages/openapi-generator/src/parser/request-body.ts
@@ -1,7 +1,7 @@
+import { parseMediaType } from './media-type';
 import type { OpenAPIV3 } from 'openapi-types';
 import type { OpenApiRequestBody } from '../openapi-types';
 import type { OpenApiDocumentRefs } from './refs';
-import { parseMediaType } from './media-type';
 import type { ParserOptions } from './options';
 
 /**

--- a/packages/openapi-generator/src/parser/responses.ts
+++ b/packages/openapi-generator/src/parser/responses.ts
@@ -1,7 +1,7 @@
+import { parseMediaType } from './media-type';
 import type { OpenAPIV3 } from 'openapi-types';
 import type { OpenApiSchema } from '../openapi-types';
 import type { OpenApiDocumentRefs } from './refs';
-import { parseMediaType } from './media-type';
 import type { ParserOptions } from './options';
 
 /**

--- a/packages/openapi-generator/src/parser/schema.spec.ts
+++ b/packages/openapi-generator/src/parser/schema.spec.ts
@@ -1,8 +1,8 @@
-import type { OpenAPIV3 } from 'openapi-types';
 import { createLogger } from '@sap-cloud-sdk/util';
 import { createTestRefs, emptyObjectSchema } from '../../test/test-util';
-import type { OpenApiObjectSchema } from '../openapi-types';
 import { parseSchema, parseSchemaProperties } from './schema';
+import type { OpenApiObjectSchema } from '../openapi-types';
+import type { OpenAPIV3 } from 'openapi-types';
 
 describe('parseSchema', () => {
   const defaultOptions = { strictNaming: true, schemaPrefix: '' };

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import type { OpenAPIV3 } from 'openapi-types';
 import { isReferenceObject } from '../schema-util';
+import { getType } from './type-mapping';
+import type { OpenAPIV3 } from 'openapi-types';
 import type {
   OpenApiArraySchema,
   OpenApiEnumSchema,
@@ -10,7 +11,6 @@ import type {
   OpenApiSchema,
   OpenApiSchemaProperties
 } from '../openapi-types';
-import { getType } from './type-mapping';
 import type { OpenApiDocumentRefs } from './refs';
 import type { ParserOptions } from './options';
 

--- a/packages/openapi-generator/src/parser/swagger-parser-workaround.ts
+++ b/packages/openapi-generator/src/parser/swagger-parser-workaround.ts
@@ -1,6 +1,6 @@
+import SwaggerParser, { parse, resolve } from '@apidevtools/swagger-parser';
 import type { OpenAPIV3 } from 'openapi-types';
 import type { $Refs } from '@apidevtools/swagger-parser';
-import SwaggerParser, { parse, resolve } from '@apidevtools/swagger-parser';
 
 /**
  * These to methods are a workaround until the swagger-parser is updated: https://github.com/APIDevTools/swagger-parser/issues/186

--- a/packages/openapi-generator/src/schema-util.spec.ts
+++ b/packages/openapi-generator/src/schema-util.spec.ts
@@ -1,8 +1,8 @@
+import { collectRefs, getSchemaPropertiesDocumentation } from './schema-util';
 import type {
   OpenApiReferenceSchema,
   OpenApiSchemaProperties
 } from './openapi-types';
-import { collectRefs, getSchemaPropertiesDocumentation } from './schema-util';
 
 describe('collectRefs', () => {
   it('collects empty array for undefined', () => {

--- a/packages/openapi-generator/src/sdk-metadata/code-sample-util.spec.ts
+++ b/packages/openapi-generator/src/sdk-metadata/code-sample-util.spec.ts
@@ -1,9 +1,4 @@
 import { getLevenshteinClosest } from '@sap-cloud-sdk/generator-common/internal';
-import type {
-  OpenApiApi,
-  OpenApiOperation,
-  OpenApiParameter
-} from '../openapi-types';
 import {
   getGetAllOperation,
   getGetOperation,
@@ -11,6 +6,11 @@ import {
   getMainOperation,
   getOperationParamCode
 } from './code-sample-util';
+import type {
+  OpenApiApi,
+  OpenApiOperation,
+  OpenApiParameter
+} from '../openapi-types';
 
 describe('code-sample-util api', () => {
   const pathParam1 = { name: 'path-Param1' };

--- a/packages/openapi-generator/src/sdk-metadata/code-sample.ts
+++ b/packages/openapi-generator/src/sdk-metadata/code-sample.ts
@@ -1,7 +1,7 @@
 import { codeBlock } from '@sap-cloud-sdk/util';
+import { getOperationParamCode } from './code-sample-util';
 import type { MultiLineText } from '@sap-cloud-sdk/generator-common/internal';
 import type { OpenApiOperation } from '../openapi-types';
-import { getOperationParamCode } from './code-sample-util';
 
 /**
  * @internal

--- a/packages/openapi-generator/src/sdk-metadata/generation-and-usage.ts
+++ b/packages/openapi-generator/src/sdk-metadata/generation-and-usage.ts
@@ -1,7 +1,7 @@
-import type { MultiLineText } from '@sap-cloud-sdk/generator-common/internal';
-import type { OpenApiDocument } from '../openapi-types';
 import { apiSpecificCodeSample } from './code-sample';
 import { getMainApi, getMainOperation } from './code-sample-util';
+import type { MultiLineText } from '@sap-cloud-sdk/generator-common/internal';
+import type { OpenApiDocument } from '../openapi-types';
 
 /**
  * @internal

--- a/packages/openapi-generator/src/sdk-metadata/sdk-metadata.ts
+++ b/packages/openapi-generator/src/sdk-metadata/sdk-metadata.ts
@@ -1,10 +1,10 @@
-import type { Client } from '@sap-cloud-sdk/generator-common/internal';
 import {
   getSdkMetadataClient,
   getSdkVersion
 } from '@sap-cloud-sdk/generator-common/internal';
-import type { OpenApiDocument } from '../openapi-types';
 import { getApiSpecificUsage } from './generation-and-usage';
+import type { Client } from '@sap-cloud-sdk/generator-common/internal';
+import type { OpenApiDocument } from '../openapi-types';
 
 /**
  * @internal

--- a/packages/openapi-generator/test/test-util.ts
+++ b/packages/openapi-generator/test/test-util.ts
@@ -1,6 +1,6 @@
+import { createRefs } from '../src/parser/refs';
 import type { OpenAPIV3 } from 'openapi-types';
 import type { OpenApiDocumentRefs } from '../src/parser/refs';
-import { createRefs } from '../src/parser/refs';
 import type { OpenApiDocument } from '../src/openapi-types';
 
 export const emptyDocument = {

--- a/packages/openapi/src/openapi-request-builder.spec.ts
+++ b/packages/openapi/src/openapi-request-builder.spec.ts
@@ -1,6 +1,5 @@
 import nock from 'nock';
 import * as httpClient from '@sap-cloud-sdk/http-client';
-import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 import {
   parseDestination,
   sanitizeDestination
@@ -18,6 +17,7 @@ import {
   mockFetchDestinationCalls
 } from '../../../test-resources/test/test-util';
 import { OpenApiRequestBuilder } from './openapi-request-builder';
+import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 
 const destination: HttpDestination = {
   url: 'http://example.com'

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -1,28 +1,28 @@
 /* eslint-disable max-classes-per-file */
 // eslint-disable-next-line import/named
-import type { AxiosResponse } from 'axios';
 import {
   isNullish,
   transformVariadicArgumentToArray
 } from '@sap-cloud-sdk/util';
-import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
 import { useOrFetchDestination } from '@sap-cloud-sdk/connectivity';
 import {
   assertHttpDestination,
   noDestinationErrorMessage
 } from '@sap-cloud-sdk/connectivity/internal';
+import { executeHttpRequest } from '@sap-cloud-sdk/http-client';
+import { filterCustomRequestConfig } from '@sap-cloud-sdk/http-client/internal';
 import type {
   Method,
   HttpResponse,
   HttpRequestConfigWithOrigin,
   CustomRequestConfig
 } from '@sap-cloud-sdk/http-client';
-import { executeHttpRequest } from '@sap-cloud-sdk/http-client';
 import type {
   OriginOptions,
   HttpMiddleware
 } from '@sap-cloud-sdk/http-client/internal';
-import { filterCustomRequestConfig } from '@sap-cloud-sdk/http-client/internal';
+import type { HttpDestinationOrFetchOptions } from '@sap-cloud-sdk/connectivity';
+import type { AxiosResponse } from 'axios';
 
 /**
  * Request builder for OpenAPI requests.

--- a/packages/resilience/src/circuit-breaker.spec.ts
+++ b/packages/resilience/src/circuit-breaker.spec.ts
@@ -1,10 +1,10 @@
 // eslint-disable-next-line import/named
-import type { AxiosResponse, RawAxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import nock from 'nock';
 import { circuitBreakers, circuitBreaker } from './circuit-breaker';
-import type { MiddlewareContext } from './middleware';
 import { executeWithMiddleware } from './middleware';
+import type { MiddlewareContext } from './middleware';
+import type { AxiosResponse, RawAxiosRequestConfig } from 'axios';
 
 describe('circuit-breaker', () => {
   beforeEach(() => {

--- a/packages/resilience/src/middleware.spec.ts
+++ b/packages/resilience/src/middleware.spec.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@sap-cloud-sdk/util/dist/logger';
-import type { MiddlewareContext, MiddlewareOptions } from './middleware';
 import { executeWithMiddleware } from './middleware';
+import type { MiddlewareContext, MiddlewareOptions } from './middleware';
 
 describe('middleware', () => {
   const logger = createLogger('middleware');

--- a/packages/resilience/src/resilience.spec.ts
+++ b/packages/resilience/src/resilience.spec.ts
@@ -1,13 +1,13 @@
 // eslint-disable-next-line import/named
-import type { AxiosResponse, RawAxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import nock from 'nock';
 import { circuitBreakers } from './circuit-breaker';
-import type { MiddlewareContext } from './middleware';
 import { executeWithMiddleware } from './middleware';
 import { resilience } from './resilience';
 import { retry } from './retry';
 import { timeout } from './timeout';
+import type { MiddlewareContext } from './middleware';
+import type { AxiosResponse, RawAxiosRequestConfig } from 'axios';
 
 describe('combined resilience features', () => {
   const HTTP_STATUS = {

--- a/packages/temporal-de-serializers/src/temporal-de-serializers-v2.ts
+++ b/packages/temporal-de-serializers/src/temporal-de-serializers-v2.ts
@@ -1,6 +1,6 @@
 import { Temporal } from '@js-temporal/polyfill';
-import type { DeSerializer } from '@sap-cloud-sdk/odata-common/internal';
 import { durationRegexV2 } from '@sap-cloud-sdk/odata-common/internal';
+import type { DeSerializer } from '@sap-cloud-sdk/odata-common/internal';
 
 /**
  * Temporal (de-)serializers for Odata-v2.

--- a/packages/temporal-de-serializers/src/temporal-de-serializers-v4.ts
+++ b/packages/temporal-de-serializers/src/temporal-de-serializers-v4.ts
@@ -1,6 +1,6 @@
 import { Temporal } from '@js-temporal/polyfill';
-import type { DeSerializer } from '@sap-cloud-sdk/odata-common/internal';
 import { durationRegexV4 } from '@sap-cloud-sdk/odata-common/internal';
+import type { DeSerializer } from '@sap-cloud-sdk/odata-common/internal';
 
 /**
  * Temporal (de-)serializers for Odata-v4.

--- a/packages/test-util/src/test-destination-mocker.spec.ts
+++ b/packages/test-util/src/test-destination-mocker.spec.ts
@@ -1,6 +1,5 @@
 import { resolve } from 'path';
 import mock from 'mock-fs';
-import type { Destination } from '@sap-cloud-sdk/connectivity';
 import { credentials, systems } from '../test/test-util/test-destinations';
 import {
   mockAllTestDestinations,
@@ -9,6 +8,7 @@ import {
   unmockAllTestDestinations,
   unmockTestDestination
 } from './test-destination-mocker';
+import type { Destination } from '@sap-cloud-sdk/connectivity';
 
 describe('setTestDestinationInEnv', () => {
   const pathRootNodeModules = resolve(__dirname, '../../../node_modules');

--- a/packages/test-util/src/test-destination-mocker.ts
+++ b/packages/test-util/src/test-destination-mocker.ts
@@ -1,13 +1,13 @@
-import type { Destination } from '@sap-cloud-sdk/connectivity/internal';
 import {
   validateNameAvailable,
   setDestinationsInEnv
 } from '@sap-cloud-sdk/connectivity/internal';
-import type { GetTestDestinationOptions } from './test-destination-provider';
 import {
   getTestDestinationByAlias,
   getTestDestinations
 } from './test-destination-provider';
+import type { Destination } from '@sap-cloud-sdk/connectivity/internal';
+import type { GetTestDestinationOptions } from './test-destination-provider';
 
 /**
  * Add a destination with the given name from the `systems.json` and `credentials.json` files to the `destinations` environment variable.

--- a/packages/util/src/error-with-cause.ts
+++ b/packages/util/src/error-with-cause.ts
@@ -1,5 +1,5 @@
-import type { AxiosError } from 'axios';
 import { unixEOL } from './string-formatter';
+import type { AxiosError } from 'axios';
 
 /**
  * Represents an error that was caused by another error.

--- a/packages/util/src/fs.ts
+++ b/packages/util/src/fs.ts
@@ -1,7 +1,7 @@
-import type { PathLike } from 'fs';
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 import { createLogger } from './logger';
+import type { PathLike } from 'fs';
 
 const logger = createLogger({
   package: 'util',

--- a/packages/util/src/logger/cloud-sdk-logger.ts
+++ b/packages/util/src/logger/cloud-sdk-logger.ts
@@ -1,8 +1,8 @@
+import { Container, transports } from 'winston';
+import { kibana, local } from './format';
 import type { Format } from 'logform';
 import type { Logger, LoggerOptions as WinstonLoggerOptions } from 'winston';
-import { Container, transports } from 'winston';
 import type TransportStream from 'winston-transport';
-import { kibana, local } from './format';
 const loggerReference = 'sap-cloud-sdk-logger';
 const exceptionLoggerId = 'sap-cloud-sdk-exception-logger';
 

--- a/packages/util/src/logger/format/kibana.ts
+++ b/packages/util/src/logger/format/kibana.ts
@@ -1,6 +1,6 @@
 import { format } from 'winston';
-import type { TransformableInfo } from 'logform';
 import { getMessageOrStack } from './local';
+import type { TransformableInfo } from 'logform';
 
 const { combine, timestamp, json } = format;
 

--- a/test-packages/e2e-tests/test/TripPin/request-builder.spec.ts
+++ b/test-packages/e2e-tests/test/TripPin/request-builder.spec.ts
@@ -1,6 +1,5 @@
 import { resetDataSource } from '@sap-cloud-sdk/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/operations';
 import { PersonGender } from '@sap-cloud-sdk/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service/PersonGender';
-import type { People } from '@sap-cloud-sdk/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service';
 import {
   microsoftODataServiceSampleTrippinInMemoryModelsService,
   batch,
@@ -11,6 +10,7 @@ import {
   defaultDeSerializers,
   entityDeserializer
 } from '@sap-cloud-sdk/odata-v4';
+import type { People } from '@sap-cloud-sdk/test-services-e2e/TripPin/microsoft-o-data-service-sample-trippin-in-memory-models-service';
 
 const url = 'https://services.odata.org/';
 const destination = { url };

--- a/test-packages/e2e-tests/test/batch.spec.ts
+++ b/test-packages/e2e-tests/test/batch.spec.ts
@@ -1,5 +1,4 @@
 import { BatchChangeSet } from '@sap-cloud-sdk/odata-common';
-import type { DefaultDeSerializers } from '@sap-cloud-sdk/odata-v4';
 import {
   batch,
   changeset,
@@ -14,6 +13,7 @@ import {
   deleteEntity,
   testEntityApi
 } from './test-utils/test-entity-operations';
+import type { DefaultDeSerializers } from '@sap-cloud-sdk/odata-v4';
 
 const entityKey = 456;
 const entityKeysUsedInTests = [77, 456, 1000, 1001];

--- a/test-packages/e2e-tests/test/bound-action.spec.ts
+++ b/test-packages/e2e-tests/test/bound-action.spec.ts
@@ -1,9 +1,9 @@
+import { testService } from '@sap-cloud-sdk/test-services-e2e/v4/test-service';
+import { getByKey } from '@sap-cloud-sdk/test-services-e2e/v4/test-service/operations';
 import type {
   TestEntity,
   TestEntityWithMultipleKeys
 } from '@sap-cloud-sdk/test-services-e2e/v4/test-service';
-import { testService } from '@sap-cloud-sdk/test-services-e2e/v4/test-service';
-import { getByKey } from '@sap-cloud-sdk/test-services-e2e/v4/test-service/operations';
 
 const url = 'http://localhost:4004/';
 const destination = { url };

--- a/test-packages/e2e-tests/test/bound-function.spec.ts
+++ b/test-packages/e2e-tests/test/bound-function.spec.ts
@@ -1,9 +1,9 @@
+import { testService } from '@sap-cloud-sdk/test-services-e2e/v4/test-service';
+import { getByKey } from '@sap-cloud-sdk/test-services-e2e/v4/test-service/operations';
 import type {
   TestEntity,
   TestEntityWithMultipleKeys
 } from '@sap-cloud-sdk/test-services-e2e/v4/test-service';
-import { testService } from '@sap-cloud-sdk/test-services-e2e/v4/test-service';
-import { getByKey } from '@sap-cloud-sdk/test-services-e2e/v4/test-service/operations';
 
 const url = 'http://localhost:4004/';
 const destination = { url };

--- a/test-packages/e2e-tests/test/http-agent.spec.ts
+++ b/test-packages/e2e-tests/test/http-agent.spec.ts
@@ -1,11 +1,11 @@
-import type { Server } from 'https';
 import { createServer } from 'https';
 import { promisify } from 'util';
+import { executeHttpRequest } from '@sap-cloud-sdk/http-client';
 import type {
   DestinationCertificate,
   HttpDestination
 } from '@sap-cloud-sdk/connectivity';
-import { executeHttpRequest } from '@sap-cloud-sdk/http-client';
+import type { Server } from 'https';
 
 describe('createAgent', () => {
   let server: Server = undefined as any;

--- a/test-packages/e2e-tests/test/mail/mail.spec.ts
+++ b/test-packages/e2e-tests/test/mail/mail.spec.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import { join, resolve } from 'path';
 import * as fsExtra from 'fs-extra';
-import type { MailConfig, MailResponse } from '@sap-cloud-sdk/mail-client';
 import { sendMail } from '@sap-cloud-sdk/mail-client';
+import type { MailConfig, MailResponse } from '@sap-cloud-sdk/mail-client';
 
 describe('Mail', () => {
   beforeEach(async () => {

--- a/test-packages/e2e-tests/test/openapi.spec.ts
+++ b/test-packages/e2e-tests/test/openapi.spec.ts
@@ -1,6 +1,6 @@
-import type { TestEntity } from '@sap-cloud-sdk/test-services-openapi/test-service';
 import { EntityApi } from '@sap-cloud-sdk/test-services-openapi/test-service';
 import { destination } from './test-util';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-openapi/test-service';
 
 // TODO: How do I handle paths in rest requests?
 // TODO: Transpilation needed + tsconfig needs dom typings

--- a/test-packages/e2e-tests/test/proxy/odata.spec.ts
+++ b/test-packages/e2e-tests/test/proxy/odata.spec.ts
@@ -1,12 +1,12 @@
+import { basicHeader } from '@sap-cloud-sdk/connectivity/internal';
+import { destination as e2eDestination } from '../test-util';
+import { testEntityApi } from '../test-utils/test-entity-operations';
 import type {
   ProxyConfiguration,
   HttpDestination
 } from '@sap-cloud-sdk/connectivity';
 import type { ErrorWithCause } from '@sap-cloud-sdk/util';
 import type { AxiosError } from 'axios';
-import { basicHeader } from '@sap-cloud-sdk/connectivity/internal';
-import { destination as e2eDestination } from '../test-util';
-import { testEntityApi } from '../test-utils/test-entity-operations';
 /* eslint-disable  @typescript-eslint/no-var-requires */
 const {
   proxyBearAuth,

--- a/test-packages/integration-tests/test/mtls.spec.ts
+++ b/test-packages/integration-tests/test/mtls.spec.ts
@@ -1,14 +1,14 @@
-import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
-import type {
-  DestinationWithName,
-  RegisterDestinationOptions
-} from '@sap-cloud-sdk/connectivity/src/scp-cf';
 import { registerDestination } from '@sap-cloud-sdk/connectivity/src/scp-cf';
 import { executeHttpRequest } from '@sap-cloud-sdk/http-client';
 import axios from 'axios';
 import mock from 'mock-fs';
 import nock from 'nock';
 import { mockServiceBindings } from '../../../test-resources/test/test-util/environment-mocks';
+import type {
+  DestinationWithName,
+  RegisterDestinationOptions
+} from '@sap-cloud-sdk/connectivity/src/scp-cf';
+import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 
 describe('mTLS on CloudFoundry', () => {
   beforeAll(() => {

--- a/test-packages/integration-tests/test/v2/batch.spec.ts
+++ b/test-packages/integration-tests/test/v2/batch.spec.ts
@@ -3,9 +3,7 @@ import {
   changeset
 } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import nock from 'nock';
-import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 import { basicHeader } from '@sap-cloud-sdk/connectivity/internal';
-import type { ErrorResponse } from '@sap-cloud-sdk/odata-common';
 import {
   createAsChildOfRequest,
   createRequest,
@@ -28,6 +26,8 @@ import {
   multiChangesetBatchResponse,
   multiRetrieveResponse
 } from '../test-data/batch/responses';
+import type { ErrorResponse } from '@sap-cloud-sdk/odata-common';
+import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 
 const basicHeaderCSRF = 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=';
 const basePath = '/sap/opu/odata/sap/API_TEST_SRV';

--- a/test-packages/integration-tests/test/v2/complex-types.spec.ts
+++ b/test-packages/integration-tests/test/v2/complex-types.spec.ts
@@ -4,7 +4,6 @@ import {
 } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import BigNumber from 'bignumber.js';
 import nock from 'nock';
-import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 import { basicHeader } from '@sap-cloud-sdk/connectivity/internal';
 import { asc } from '@sap-cloud-sdk/odata-common';
 import {
@@ -13,6 +12,7 @@ import {
 } from '@sap-cloud-sdk/odata-v2';
 import { testEntityCollectionResponse } from '../test-data/test-entity-collection-response';
 import { testEntityApi } from './test-util';
+import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 
 const basePath = '/sap/opu/odata/sap/API_TEST_SRV';
 const entityName = TestEntity._entityName;

--- a/test-packages/integration-tests/test/v2/custom-fields.spec.ts
+++ b/test-packages/integration-tests/test/v2/custom-fields.spec.ts
@@ -1,10 +1,10 @@
 import { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import nock from 'nock';
 import { basicHeader } from '@sap-cloud-sdk/connectivity/internal';
-import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 import { singleTestEntityResponse } from '../test-data/single-test-entity-response';
 import { testEntityCollectionResponse } from '../test-data/test-entity-collection-response';
 import { testEntityApi } from './test-util';
+import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 
 const basicHeaderCSRF = 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=';
 const basePath = '/sap/opu/odata/sap/API_TEST_SRV';

--- a/test-packages/integration-tests/test/v2/function-imports.spec.ts
+++ b/test-packages/integration-tests/test/v2/function-imports.spec.ts
@@ -1,9 +1,9 @@
 import { operations } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import nock from 'nock';
 import { basicHeader } from '@sap-cloud-sdk/connectivity/internal';
-import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 import { errorResponse } from '../test-data/error-response';
 import { singleTestEntityResponse } from '../test-data/single-test-entity-response';
+import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 
 const basePath = '/sap/opu/odata/sap/API_TEST_SRV';
 const basicHeaderCSRF = 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=';

--- a/test-packages/type-tests/test/duplicated-types.ts
+++ b/test-packages/type-tests/test/duplicated-types.ts
@@ -1,8 +1,8 @@
+import { mergeDefaultDeSerializersWith } from '@sap-cloud-sdk/odata-v4/internal';
 import type { DeSerializers as DeSerializersV2 } from '@sap-cloud-sdk/odata-v2';
 import type BigNumber from 'bignumber.js';
 import type { Time } from '@sap-cloud-sdk/odata-common/internal';
 import type { DeSerializers as DeSerializersV4 } from '@sap-cloud-sdk/odata-v4';
-import { mergeDefaultDeSerializersWith } from '@sap-cloud-sdk/odata-v4/internal';
 
 /*
 These types are duplicated from the published module to ensure a unintentional change breaks the type tests.

--- a/test-packages/type-tests/test/generator/generator-utils.test-d.ts
+++ b/test-packages/type-tests/test/generator/generator-utils.test-d.ts
@@ -1,5 +1,5 @@
-import type { EdmTypeShared } from '@sap-cloud-sdk/generator/internal';
 import { getFallbackEdmTypeIfNeeded } from '@sap-cloud-sdk/generator/internal';
 import { expectType } from 'tsd';
+import type { EdmTypeShared } from '@sap-cloud-sdk/generator/internal';
 
 expectType<EdmTypeShared>(getFallbackEdmTypeIfNeeded('Edm.Any'));

--- a/test-packages/type-tests/test/http-agent.test-d.ts
+++ b/test-packages/type-tests/test/http-agent.test-d.ts
@@ -1,9 +1,9 @@
+import { getAgentConfigAsync } from '@sap-cloud-sdk/connectivity';
+import { expectType } from 'tsd';
 import type {
   HttpAgentConfig,
   HttpsAgentConfig
 } from '@sap-cloud-sdk/connectivity';
-import { getAgentConfigAsync } from '@sap-cloud-sdk/connectivity';
-import { expectType } from 'tsd';
 
 expectType<Promise<HttpAgentConfig | HttpsAgentConfig>>(
   getAgentConfigAsync({ name: 'destination', url: 'url' })

--- a/test-packages/type-tests/test/http-client.test-d.ts
+++ b/test-packages/type-tests/test/http-client.test-d.ts
@@ -1,9 +1,9 @@
 import { expectError, expectType } from 'tsd';
-import type { HttpResponse } from '@sap-cloud-sdk/http-client';
 import {
   executeHttpRequest,
   executeHttpRequestWithOrigin
 } from '@sap-cloud-sdk/http-client';
+import type { HttpResponse } from '@sap-cloud-sdk/http-client';
 import type { ServiceBindingTransformFunction } from '@sap-cloud-sdk/connectivity';
 
 expectType<Promise<HttpResponse>>(

--- a/test-packages/type-tests/test/jwt.test-d.ts
+++ b/test-packages/type-tests/test/jwt.test-d.ts
@@ -1,5 +1,5 @@
-import type { JwtPayload } from '@sap-cloud-sdk/connectivity';
 import { decodeJwt } from '@sap-cloud-sdk/connectivity';
 import { expectType } from 'tsd';
+import type { JwtPayload } from '@sap-cloud-sdk/connectivity';
 
 expectType<JwtPayload>(decodeJwt(''));

--- a/test-packages/type-tests/test/mail-client/mail-client.test-d.ts
+++ b/test-packages/type-tests/test/mail-client/mail-client.test-d.ts
@@ -1,6 +1,6 @@
-import type { MailResponse } from '@sap-cloud-sdk/mail-client';
 import { sendMail } from '@sap-cloud-sdk/mail-client';
 import { expectType } from 'tsd';
+import type { MailResponse } from '@sap-cloud-sdk/mail-client';
 
 const mailConfig = { from: 'from', to: 'to' };
 

--- a/test-packages/type-tests/test/openapi/schema.test-d.ts
+++ b/test-packages/type-tests/test/openapi/schema.test-d.ts
@@ -1,5 +1,5 @@
-import type { SimpleTestEntity } from '@sap-cloud-sdk/test-services-openapi/test-service';
 import { expectType } from 'tsd';
+import type { SimpleTestEntity } from '@sap-cloud-sdk/test-services-openapi/test-service';
 
 const simpleTestEntity: SimpleTestEntity = { stringProperty: 'prop' };
 

--- a/test-packages/type-tests/test/v2/batch.test-d.ts
+++ b/test-packages/type-tests/test/v2/batch.test-d.ts
@@ -2,18 +2,18 @@ import {
   changeset as otherServiceChangeset,
   multipleSchemasService
 } from '@sap-cloud-sdk/test-services-odata-v2/multiple-schemas-service';
-import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import {
   batch,
   changeset as testEntityChangeset,
   testService
 } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
+import { mergeDefaultDeSerializersWith } from '@sap-cloud-sdk/odata-v2/internal';
+import { expectType } from 'tsd';
 import type {
   ReadResponse,
   WriteResponses
 } from '@sap-cloud-sdk/odata-v2/internal';
-import { mergeDefaultDeSerializersWith } from '@sap-cloud-sdk/odata-v2/internal';
-import { expectType } from 'tsd';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import type { BatchChangeSet } from '@sap-cloud-sdk/odata-common';
 import type {
   BatchResponse,

--- a/test-packages/type-tests/test/v2/complex-types.test-d.ts
+++ b/test-packages/type-tests/test/v2/complex-types.test-d.ts
@@ -1,11 +1,11 @@
+import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
+import { and, asc, desc, or } from '@sap-cloud-sdk/odata-common';
+import { expectError, expectType } from 'tsd';
+import type { OrderableEdmTypeField } from '@sap-cloud-sdk/odata-common';
 import type {
   TestComplexTypeField,
   TestEntity
 } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
-import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
-import type { OrderableEdmTypeField } from '@sap-cloud-sdk/odata-common';
-import { and, asc, desc, or } from '@sap-cloud-sdk/odata-common';
-import { expectError, expectType } from 'tsd';
 import type { GetAllRequestBuilder } from '@sap-cloud-sdk/odata-v2';
 import type {
   AnyDeserializerV2,

--- a/test-packages/type-tests/test/v2/de-serializers.test-d.ts
+++ b/test-packages/type-tests/test/v2/de-serializers.test-d.ts
@@ -1,9 +1,9 @@
 import { mergeDefaultDeSerializersWith } from '@sap-cloud-sdk/odata-v2/internal';
 import { temporalDeSerializersV2 } from '@sap-cloud-sdk/temporal-de-serializers';
 import { expectType } from 'tsd';
+import { customTestDeSerializers } from './batch.test-d';
 import type { CustomDeSerializers } from '@sap-cloud-sdk/odata-v2';
 import type { CustomDeSerializerV2 } from '../duplicated-types';
-import { customTestDeSerializers } from './batch.test-d';
 
 expectType<CustomDeSerializers<Partial<CustomDeSerializerV2>>>(
   mergeDefaultDeSerializersWith(customTestDeSerializers)

--- a/test-packages/type-tests/test/v2/entity-builder.test-d.ts
+++ b/test-packages/type-tests/test/v2/entity-builder.test-d.ts
@@ -1,6 +1,6 @@
-import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import { expectError, expectType } from 'tsd';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import type { EntityBuilderType } from '@sap-cloud-sdk/odata-common';
 import type { DefaultDeSerializerV2 } from '../duplicated-types';
 

--- a/test-packages/type-tests/test/v2/filter-functions.test-d.ts
+++ b/test-packages/type-tests/test/v2/filter-functions.test-d.ts
@@ -1,6 +1,4 @@
-import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
-import type { GetAllRequestBuilder } from '@sap-cloud-sdk/odata-v2';
 import {
   filterFunctions,
   length,
@@ -8,6 +6,8 @@ import {
   substringOf
 } from '@sap-cloud-sdk/odata-v2';
 import { expectError, expectType } from 'tsd';
+import type { GetAllRequestBuilder } from '@sap-cloud-sdk/odata-v2';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import type {
   BooleanFilterFunction,
   EntityBase,

--- a/test-packages/type-tests/test/v2/filter.test-d.ts
+++ b/test-packages/type-tests/test/v2/filter.test-d.ts
@@ -1,10 +1,10 @@
+import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
+import { and, or } from '@sap-cloud-sdk/odata-v2';
+import { expectError, expectType } from 'tsd';
 import type {
   TestEntity,
   TestEntityMultiLink
 } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
-import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
-import { and, or } from '@sap-cloud-sdk/odata-v2';
-import { expectError, expectType } from 'tsd';
 import type {
   Filter,
   FilterLink,

--- a/test-packages/type-tests/test/v2/function-imports.test-d.ts
+++ b/test-packages/type-tests/test/v2/function-imports.test-d.ts
@@ -1,13 +1,3 @@
-import type {
-  TestComplexType,
-  TestEntity,
-  TestFunctionImportComplexReturnTypeCollectionParameters,
-  TestFunctionImportComplexReturnTypeParameters,
-  TestFunctionImportEdmReturnTypeCollectionParameters,
-  TestFunctionImportEdmReturnTypeParameters,
-  TestFunctionImportEntityReturnTypeParameters,
-  TestFunctionImportNoReturnTypeParameters
-} from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import {
   testFunctionImportComplexReturnType,
   testFunctionImportComplexReturnTypeCollection,
@@ -19,6 +9,16 @@ import {
   testService
 } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import { expectError, expectType } from 'tsd';
+import type {
+  TestComplexType,
+  TestEntity,
+  TestFunctionImportComplexReturnTypeCollectionParameters,
+  TestFunctionImportComplexReturnTypeParameters,
+  TestFunctionImportEdmReturnTypeCollectionParameters,
+  TestFunctionImportEdmReturnTypeParameters,
+  TestFunctionImportEntityReturnTypeParameters,
+  TestFunctionImportNoReturnTypeParameters
+} from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import type { OperationRequestBuilder } from '@sap-cloud-sdk/odata-v2';
 import type { HttpResponse } from '@sap-cloud-sdk/http-client';
 import type { DefaultDeSerializerV2 } from '../duplicated-types';

--- a/test-packages/type-tests/test/v2/link.test-d.ts
+++ b/test-packages/type-tests/test/v2/link.test-d.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-unused-vars */
 import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import { expectType } from 'tsd';
+import { mergeDefaultDeSerializersWith } from '@sap-cloud-sdk/odata-v2';
 import type { TestEntitySingleLinkApi } from '@sap-cloud-sdk/test-services-odata-v2/test-service/TestEntitySingleLinkApi';
 import type { TestEntityLvl2MultiLinkApi } from '@sap-cloud-sdk/test-services-odata-v2/test-service/TestEntityLvl2MultiLinkApi';
-import { mergeDefaultDeSerializersWith } from '@sap-cloud-sdk/odata-v2';
 
 const custom = {
   'Edm.Binary': {

--- a/test-packages/type-tests/test/v2/request-builder.test-d.ts
+++ b/test-packages/type-tests/test/v2/request-builder.test-d.ts
@@ -1,11 +1,11 @@
+import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
+import { and, asc, desc, or } from '@sap-cloud-sdk/odata-common';
+import { expectError, expectType } from 'tsd';
 import type {
   TestEntity,
   TestEntityMultiLink,
   TestEntityRequestBuilder
 } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
-import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
-import { and, asc, desc, or } from '@sap-cloud-sdk/odata-common';
-import { expectError, expectType } from 'tsd';
 import type {
   CreateRequestBuilder,
   GetAllRequestBuilder,

--- a/test-packages/type-tests/test/v2/schema-properties.test-d.ts
+++ b/test-packages/type-tests/test/v2/schema-properties.test-d.ts
@@ -1,6 +1,6 @@
-import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import { expectType } from 'tsd';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import type {
   Link,
   OneToOneLink,

--- a/test-packages/type-tests/test/v2/selectable.test-d.ts
+++ b/test-packages/type-tests/test/v2/selectable.test-d.ts
@@ -1,7 +1,7 @@
-import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import { testService } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import { OneToOneLink } from '@sap-cloud-sdk/odata-common';
 import { expectError, expectType } from 'tsd';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v2/test-service';
 import type { TestEntitySingleLinkApi } from '@sap-cloud-sdk/test-services-odata-v2/test-service/TestEntitySingleLinkApi';
 import type { DefaultDeSerializerV2 } from '../duplicated-types';
 

--- a/test-packages/type-tests/test/v4/action-imports.test-d.ts
+++ b/test-packages/type-tests/test/v4/action-imports.test-d.ts
@@ -1,18 +1,18 @@
-import type {
-  TestActionImportMultipleParameterComplexReturnTypeParameters,
-  TestActionImportNoParameterNoReturnTypeParameters,
-  TestActionImportNullableTestParameters,
-  TestActionImportUnsupportedEdmTypesParameters
-} from '@sap-cloud-sdk/test-services-odata-v4/test-service/operations';
 import {
   testActionImportMultipleParameterComplexReturnType,
   testActionImportNoParameterNoReturnType,
   testActionImportNullableTest,
   testActionImportUnsupportedEdmTypes
 } from '@sap-cloud-sdk/test-services-odata-v4/test-service/operations';
-import type { TestComplexType } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import { testService } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import { expectError, expectType } from 'tsd';
+import type { TestComplexType } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
+import type {
+  TestActionImportMultipleParameterComplexReturnTypeParameters,
+  TestActionImportNoParameterNoReturnTypeParameters,
+  TestActionImportNullableTestParameters,
+  TestActionImportUnsupportedEdmTypesParameters
+} from '@sap-cloud-sdk/test-services-odata-v4/test-service/operations';
 import type { OperationRequestBuilder } from '@sap-cloud-sdk/odata-v4';
 import type { DefaultDeSerializersV4 } from '../duplicated-types';
 

--- a/test-packages/type-tests/test/v4/batch.test-d.ts
+++ b/test-packages/type-tests/test/v4/batch.test-d.ts
@@ -2,18 +2,18 @@ import {
   batch,
   testService
 } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
+import { expectType } from 'tsd';
+import { customTestDeSerializersV4 } from '../duplicated-types';
 import type {
   ReadResponse,
   WriteResponses
 } from '@sap-cloud-sdk/odata-v4/internal';
-import { expectType } from 'tsd';
 import type { BatchResponse } from '@sap-cloud-sdk/odata-v4';
 import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v4/test-service/TestEntity';
 import type {
   CustomDeSerializerV4,
   DefaultDeSerializersV4
 } from '../duplicated-types';
-import { customTestDeSerializersV4 } from '../duplicated-types';
 
 const { testEntityApi } = testService();
 

--- a/test-packages/type-tests/test/v4/de-serializers.test-d.ts
+++ b/test-packages/type-tests/test/v4/de-serializers.test-d.ts
@@ -1,9 +1,9 @@
 import { mergeDefaultDeSerializersWith } from '@sap-cloud-sdk/odata-v4/internal';
 import { temporalDeSerializersV4 } from '@sap-cloud-sdk/temporal-de-serializers';
 import { expectType } from 'tsd';
+import { customTestDeSerializersV4 } from '../duplicated-types';
 import type { CustomDeSerializers } from '@sap-cloud-sdk/odata-v4';
 import type { CustomDeSerializerV4 } from '../duplicated-types';
-import { customTestDeSerializersV4 } from '../duplicated-types';
 
 expectType<CustomDeSerializers<Partial<CustomDeSerializerV4>>>(
   mergeDefaultDeSerializersWith(customTestDeSerializersV4)

--- a/test-packages/type-tests/test/v4/entity-builder.test-d.ts
+++ b/test-packages/type-tests/test/v4/entity-builder.test-d.ts
@@ -1,6 +1,6 @@
-import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import { testService } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import { expectError, expectType } from 'tsd';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import type { DefaultDeSerializersV4 } from '../duplicated-types';
 
 const builder = testService().testEntityApi.entityBuilder();

--- a/test-packages/type-tests/test/v4/field-builder.test-d.ts
+++ b/test-packages/type-tests/test/v4/field-builder.test-d.ts
@@ -3,13 +3,13 @@ import {
   TestComplexTypeField,
   TestEntity
 } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
+import { defaultDeSerializers } from '@sap-cloud-sdk/odata-v4';
+import { FieldBuilder } from '@sap-cloud-sdk/odata-common';
+import { expectType } from 'tsd';
 import type {
   CollectionField,
   OrderableEdmTypeField
 } from '@sap-cloud-sdk/odata-v4';
-import { defaultDeSerializers } from '@sap-cloud-sdk/odata-v4';
-import { FieldBuilder } from '@sap-cloud-sdk/odata-common';
-import { expectType } from 'tsd';
 import type {
   AnyDeSerializerV4,
   DefaultDeSerializersV4

--- a/test-packages/type-tests/test/v4/filter-functions.test-d.ts
+++ b/test-packages/type-tests/test/v4/filter-functions.test-d.ts
@@ -1,7 +1,7 @@
 import { testService } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
-import type { DateFilterFunction, Entity } from '@sap-cloud-sdk/odata-v4';
 import { filterFunction, filterFunctions } from '@sap-cloud-sdk/odata-v4';
 import { expectError, expectType } from 'tsd';
+import type { DateFilterFunction, Entity } from '@sap-cloud-sdk/odata-v4';
 import type {
   BooleanFilterFunction,
   CollectionFilterFunction,

--- a/test-packages/type-tests/test/v4/filters.test-d.ts
+++ b/test-packages/type-tests/test/v4/filters.test-d.ts
@@ -1,11 +1,11 @@
-import type { OneToManyLink } from '@sap-cloud-sdk/odata-v4';
 import { and, any } from '@sap-cloud-sdk/odata-v4';
-import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import {
   TestEnumType,
   testService
 } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import { expectError, expectType } from 'tsd';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
+import type { OneToManyLink } from '@sap-cloud-sdk/odata-v4';
 import type { Filter, FilterList } from '@sap-cloud-sdk/odata-common';
 import type { TestEntityMultiLinkApi } from '@sap-cloud-sdk/test-services-odata-v4/test-service/TestEntityMultiLinkApi';
 import type {

--- a/test-packages/type-tests/test/v4/function-import.test-d.ts
+++ b/test-packages/type-tests/test/v4/function-import.test-d.ts
@@ -1,6 +1,6 @@
-import type { TestFunctionImportNullableTestParameters } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import { testFunctionImportNullableTest } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import { expectError, expectType } from 'tsd';
+import type { TestFunctionImportNullableTestParameters } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import type { OperationRequestBuilder } from '@sap-cloud-sdk/odata-v4';
 import type { DefaultDeSerializersV4 } from '../duplicated-types';
 

--- a/test-packages/type-tests/test/v4/schema-properties.test-d.ts
+++ b/test-packages/type-tests/test/v4/schema-properties.test-d.ts
@@ -1,6 +1,6 @@
-import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import { testService } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import { expectType } from 'tsd';
+import type { TestEntity } from '@sap-cloud-sdk/test-services-odata-v4/test-service';
 import type {
   OneToManyLink,
   OneToOneLink,


### PR DESCRIPTION
The rule currently uses the default, that ignores how types are treated. Now that we force types to be imported separately I think it is nicer to have this rule as well.