### PR TITLE
fix: Sequential mail sending aborts after one mail is rejected

### DIFF
--- a/packages/mail-client/src/mail-client.spec.ts
+++ b/packages/mail-client/src/mail-client.spec.ts
@@ -34,195 +34,146 @@ describe('mail client', () => {
     set: jest.fn()
   };
 
-  it('should work with destination from service - proxy-type Internet', async () => {
-    jest
-      .spyOn(nodemailer, 'createTransport')
-      .mockReturnValue(mockTransport as any);
-    const mailOptions1: MailConfig = {
-      from: 'from2@example.com',
-      to: 'to2@example.com'
-    };
+  describe('internet', () => {
+    it('should work with destination from service - proxy-type Internet', async () => {
+      jest
+        .spyOn(nodemailer, 'createTransport')
+        .mockReturnValue(mockTransport as any);
+      const mailOptions1: MailConfig = {
+        from: 'from2@example.com',
+        to: 'to2@example.com'
+      };
 
-    const mailClientOptions: MailClientOptions = {
-      proxy: 'http://my.proxy.com:25',
-      tls: {
-        rejectUnauthorized: false
-      }
-    };
+      const mailClientOptions: MailClientOptions = {
+        proxy: 'http://my.proxy.com:25',
+        tls: {
+          rejectUnauthorized: false
+        }
+      };
 
-    const mailDestinationResponse: DestinationConfiguration = {
-      Name: 'MyMailDestination',
-      Type: 'MAIL',
-      Authentication: 'BasicAuthentication',
-      ProxyType: 'Internet',
-      User: 'user',
-      Password: 'password',
-      'mail.password': 'password',
-      'mail.user': 'user',
-      'mail.smtp.host': 'smtp.gmail.com',
-      'mail.smtp.port': '587'
-    };
+      const mailDestinationResponse: DestinationConfiguration = {
+        Name: 'MyMailDestination',
+        Type: 'MAIL',
+        Authentication: 'BasicAuthentication',
+        ProxyType: 'Internet',
+        User: 'user',
+        Password: 'password',
+        'mail.password': 'password',
+        'mail.user': 'user',
+        'mail.smtp.host': 'smtp.gmail.com',
+        'mail.smtp.port': '587'
+      };
 
-    mockServiceBindings();
-    // the mockServiceToken() method does not work outside connectivity module.
-    jest
-      .spyOn(tokenAccessor, 'serviceToken')
-      .mockImplementation(() => Promise.resolve(providerServiceToken));
-    mockFetchDestinationCalls(mailDestinationResponse);
+      mockServiceBindings();
+      // the mockServiceToken() method does not work outside connectivity module.
+      jest
+        .spyOn(tokenAccessor, 'serviceToken')
+        .mockImplementation(() => Promise.resolve(providerServiceToken));
+      mockFetchDestinationCalls(mailDestinationResponse);
 
-    await expect(
-      sendMail(
-        { destinationName: mailDestinationResponse.Name },
-        [mailOptions1],
-        mailClientOptions
-      )
-    ).resolves.not.toThrow();
-  });
-
-  it('should work with destination from service - proxy-type OnPremise', async () => {
-    const { connection } = mockSocketConnection();
-    jest
-      .spyOn(nodemailer, 'createTransport')
-      .mockReturnValue(mockTransport as any);
-
-    jest.spyOn(mockTransport, 'sendMail').mockImplementation(() => {
-      connection.socket.on('data', () => {});
+      await expect(
+        sendMail(
+          { destinationName: mailDestinationResponse.Name },
+          [mailOptions1],
+          mailClientOptions
+        )
+      ).resolves.not.toThrow();
     });
 
-    const mailOptions1: MailConfig = {
-      from: 'from2@example.com',
-      to: 'to2@example.com'
-    };
+    it('should work with registered destination', async () => {
+      jest
+        .spyOn(nodemailer, 'createTransport')
+        .mockReturnValue(mockTransport as any);
+      const mailOptions1: MailConfig = {
+        from: 'from2@example.com',
+        to: 'to2@example.com'
+      };
 
-    const mailClientOptions: MailClientOptions = {
-      tls: {
-        rejectUnauthorized: false
-      }
-    };
+      const mailClientOptions: MailClientOptions = {
+        proxy: 'http://my.proxy.com:25',
+        tls: {
+          rejectUnauthorized: false
+        }
+      };
 
-    const mailDestinationResponse: DestinationConfiguration = {
-      Name: 'MyMailDestination',
-      Type: 'MAIL',
-      Authentication: 'BasicAuthentication',
-      ProxyType: 'OnPremise',
-      User: 'user',
-      Password: 'password',
-      'mail.password': 'password',
-      'mail.user': 'user',
-      'mail.smtp.host': 'smtp.gmail.com',
-      'mail.smtp.port': '587'
-    };
+      mockServiceBindings();
+      const mailDestination: DestinationWithName = {
+        name: 'MyMailDestination',
+        type: 'MAIL',
+        authentication: 'BasicAuthentication',
+        proxyType: 'Internet',
+        username: 'user',
+        password: 'password',
+        originalProperties: {
+          'mail.password': 'password',
+          'mail.user': 'user',
+          'mail.smtp.host': 'smtp.gmail.com',
+          'mail.smtp.port': '587'
+        }
+      };
 
-    mockServiceBindings();
-    // the mockServiceToken() method does not work outside connectivity module.
-    jest
-      .spyOn(tokenAccessor, 'serviceToken')
-      .mockImplementation(() => Promise.resolve(providerServiceToken));
+      registerDestination(mailDestination);
+      await expect(
+        sendMail(
+          { destinationName: 'MyMailDestination' },
+          [mailOptions1],
+          mailClientOptions
+        )
+      ).resolves.not.toThrow();
+    });
 
-    mockFetchDestinationCalls(mailDestinationResponse);
+    it('should create transport, send mails and close the transport', async () => {
+      const spyCreateTransport = jest
+        .spyOn(nodemailer, 'createTransport')
+        .mockReturnValue(mockTransport as any);
+      const spySendMail = jest.spyOn(mockTransport, 'sendMail');
+      const spyCloseTransport = jest.spyOn(mockTransport, 'close');
+      const destination: any = {
+        originalProperties: {
+          'mail.password': 'password',
+          'mail.user': 'user',
+          'mail.smtp.host': 'smtp.gmail.com',
+          'mail.smtp.port': '587'
+        },
+        name: 'my-destination',
+        type: 'MAIL',
+        authentication: 'BasicAuthentication',
+        proxyType: 'Internet'
+      };
+      const mailOptions1: MailConfig = {
+        from: 'from1@example.com',
+        to: 'to1@example.com',
+        subject: 'subject',
+        text: 'txt',
+        html: 'html',
+        attachments: [{ content: 'content' }]
+      };
+      const mailOptions2: MailConfig = {
+        from: 'from2@example.com',
+        to: 'to2@example.com'
+      };
 
-    await expect(
-      sendMail(
-        { destinationName: mailDestinationResponse.Name },
-        [mailOptions1],
-        mailClientOptions
-      )
-    ).resolves.not.toThrow();
+      const mailClientOptions: MailClientOptions = {
+        proxy: 'http://my.proxy.com:25',
+        tls: {
+          rejectUnauthorized: false
+        }
+      };
+      await expect(
+        sendMail(destination, [mailOptions1, mailOptions2], mailClientOptions)
+      ).resolves.not.toThrow();
+      expect(spyCreateTransport).toHaveBeenCalledTimes(1);
+      expect(spyCreateTransport).toHaveBeenCalledWith(
+        expect.objectContaining(mailClientOptions)
+      );
+      expect(spySendMail).toHaveBeenCalledTimes(2);
+      expect(spySendMail).toHaveBeenCalledWith(mailOptions1);
+      expect(spySendMail).toHaveBeenCalledWith(mailOptions2);
+      expect(spyCloseTransport).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('should work with registered destination', async () => {
-    jest
-      .spyOn(nodemailer, 'createTransport')
-      .mockReturnValue(mockTransport as any);
-    const mailOptions1: MailConfig = {
-      from: 'from2@example.com',
-      to: 'to2@example.com'
-    };
-
-    const mailClientOptions: MailClientOptions = {
-      proxy: 'http://my.proxy.com:25',
-      tls: {
-        rejectUnauthorized: false
-      }
-    };
-
-    mockServiceBindings();
-    const mailDestination: DestinationWithName = {
-      name: 'MyMailDestination',
-      type: 'MAIL',
-      authentication: 'BasicAuthentication',
-      proxyType: 'Internet',
-      username: 'user',
-      password: 'password',
-      originalProperties: {
-        'mail.password': 'password',
-        'mail.user': 'user',
-        'mail.smtp.host': 'smtp.gmail.com',
-        'mail.smtp.port': '587'
-      }
-    };
-
-    registerDestination(mailDestination);
-    await expect(
-      sendMail(
-        { destinationName: 'MyMailDestination' },
-        [mailOptions1],
-        mailClientOptions
-      )
-    ).resolves.not.toThrow();
-  });
-
-  it('should create transport, send mails and close the transport', async () => {
-    const spyCreateTransport = jest
-      .spyOn(nodemailer, 'createTransport')
-      .mockReturnValue(mockTransport as any);
-    const spySendMail = jest.spyOn(mockTransport, 'sendMail');
-    const spyCloseTransport = jest.spyOn(mockTransport, 'close');
-    const destination: any = {
-      originalProperties: {
-        'mail.password': 'password',
-        'mail.user': 'user',
-        'mail.smtp.host': 'smtp.gmail.com',
-        'mail.smtp.port': '587'
-      },
-      name: 'my-destination',
-      type: 'MAIL',
-      authentication: 'BasicAuthentication',
-      proxyType: 'Internet'
-    };
-    const mailOptions1: MailConfig = {
-      from: 'from1@example.com',
-      to: 'to1@example.com',
-      subject: 'subject',
-      text: 'txt',
-      html: 'html',
-      attachments: [{ content: 'content' }]
-    };
-    const mailOptions2: MailConfig = {
-      from: 'from2@example.com',
-      to: 'to2@example.com'
-    };
-
-    const mailClientOptions: MailClientOptions = {
-      proxy: 'http://my.proxy.com:25',
-      tls: {
-        rejectUnauthorized: false
-      }
-    };
-    await expect(
-      sendMail(destination, [mailOptions1, mailOptions2], mailClientOptions)
-    ).resolves.not.toThrow();
-    expect(spyCreateTransport).toHaveBeenCalledTimes(1);
-    expect(spyCreateTransport).toHaveBeenCalledWith(
-      expect.objectContaining(mailClientOptions)
-    );
-    expect(spySendMail).toHaveBeenCalledTimes(2);
-    expect(spySendMail).toHaveBeenCalledWith(mailOptions1);
-    expect(spySendMail).toHaveBeenCalledWith(mailOptions2);
-    expect(spyCloseTransport).toHaveBeenCalledTimes(1);
-  });
-
-  describe('on premise', () => {
+  describe('on-premise', () => {
     const destination: any = {
       originalProperties: {
         'mail.password': 'password',
@@ -247,6 +198,57 @@ describe('mail client', () => {
       to: 'to1@example.com'
     };
 
+    it('should work with destination from service - proxy-type OnPremise', async () => {
+      const { connection } = mockSocketConnection();
+      jest
+        .spyOn(nodemailer, 'createTransport')
+        .mockReturnValue(mockTransport as any);
+
+      jest.spyOn(mockTransport, 'sendMail').mockImplementation(() => {
+        connection.socket.on('data', () => {});
+      });
+
+      const mailOptions1: MailConfig = {
+        from: 'from2@example.com',
+        to: 'to2@example.com'
+      };
+
+      const mailClientOptions: MailClientOptions = {
+        tls: {
+          rejectUnauthorized: false
+        }
+      };
+
+      const mailDestinationResponse: DestinationConfiguration = {
+        Name: 'MyMailDestination',
+        Type: 'MAIL',
+        Authentication: 'BasicAuthentication',
+        ProxyType: 'OnPremise',
+        User: 'user',
+        Password: 'password',
+        'mail.password': 'password',
+        'mail.user': 'user',
+        'mail.smtp.host': 'smtp.gmail.com',
+        'mail.smtp.port': '587'
+      };
+
+      mockServiceBindings();
+      // the mockServiceToken() method does not work outside connectivity module.
+      jest
+        .spyOn(tokenAccessor, 'serviceToken')
+        .mockImplementation(() => Promise.resolve(providerServiceToken));
+
+      mockFetchDestinationCalls(mailDestinationResponse);
+
+      await expect(
+        sendMail(
+          { destinationName: mailDestinationResponse.Name },
+          [mailOptions1],
+          mailClientOptions
+        )
+      ).resolves.not.toThrow();
+    });
+
     it('should create transport/socket, send mails and close the transport/socket', async () => {
       const spyCreateTransport = jest
         .spyOn(nodemailer, 'createTransport')
@@ -263,63 +265,63 @@ describe('mail client', () => {
       expect(spyCloseTransport).toHaveBeenCalledTimes(1);
     });
   });
-});
 
-describe('isMailSentInSequential', () => {
-  it('should return false when the mail client options are undefined', () => {
-    expect(isMailSentInSequential()).toBe(false);
+  describe('isMailSentInSequential', () => {
+    it('should return false when the mail client options are undefined', () => {
+      expect(isMailSentInSequential()).toBe(false);
+    });
+
+    it('should return false when the sdk options are undefined', () => {
+      const mailClientOptions: MailClientOptions = {};
+      expect(isMailSentInSequential(mailClientOptions)).toBe(false);
+    });
+
+    it('should return false when the parallel option is undefined', () => {
+      const mailClientOptions: MailClientOptions = { sdkOptions: {} };
+      expect(isMailSentInSequential(mailClientOptions)).toBe(false);
+    });
+
+    it('should return false when the parallel option is set to true', () => {
+      const mailClientOptions: MailClientOptions = {
+        sdkOptions: { parallel: true }
+      };
+      expect(isMailSentInSequential(mailClientOptions)).toBe(false);
+    });
+
+    it('should return true when the parallel option is set to false', () => {
+      const mailClientOptions: MailClientOptions = {
+        sdkOptions: { parallel: false }
+      };
+      expect(isMailSentInSequential(mailClientOptions)).toBe(true);
+    });
   });
 
-  it('should return false when the sdk options are undefined', () => {
-    const mailClientOptions: MailClientOptions = {};
-    expect(isMailSentInSequential(mailClientOptions)).toBe(false);
-  });
+  describe('buildSocksProxy', () => {
+    it('build valid socks proxy', () => {
+      const dest: MailDestination = {
+        proxyConfiguration: {
+          host: 'www.proxy.com',
+          port: 12345,
+          protocol: 'socks',
+          'proxy-authorization': 'jwt'
+        }
+      };
+      const proxy = buildSocksProxy(dest);
+      expect(isValidSocksProxy(proxy)).toBe(true);
+    });
 
-  it('should return false when the parallel option is undefined', () => {
-    const mailClientOptions: MailClientOptions = { sdkOptions: {} };
-    expect(isMailSentInSequential(mailClientOptions)).toBe(false);
-  });
-
-  it('should return false when the parallel option is set to true', () => {
-    const mailClientOptions: MailClientOptions = {
-      sdkOptions: { parallel: true }
-    };
-    expect(isMailSentInSequential(mailClientOptions)).toBe(false);
-  });
-
-  it('should return true when the parallel option is set to false', () => {
-    const mailClientOptions: MailClientOptions = {
-      sdkOptions: { parallel: false }
-    };
-    expect(isMailSentInSequential(mailClientOptions)).toBe(true);
-  });
-});
-
-describe('buildSocksProxy', () => {
-  it('build valid socks proxy', () => {
-    const dest: MailDestination = {
-      proxyConfiguration: {
-        host: 'www.proxy.com',
-        port: 12345,
-        protocol: 'socks',
-        'proxy-authorization': 'jwt'
-      }
-    };
-    const proxy = buildSocksProxy(dest);
-    expect(isValidSocksProxy(proxy)).toBe(true);
-  });
-
-  it('build valid socks proxy url', () => {
-    const dest: MailDestination = {
-      proxyConfiguration: {
-        host: 'www.proxy.com',
-        port: 12345,
-        protocol: 'socks',
-        'proxy-authorization': 'jwt'
-      }
-    };
-    const proxyUrl = buildSocksProxyUrl(dest);
-    expect(proxyUrl).toBe('socks5://www.proxy.com:12345');
+    it('build valid socks proxy url', () => {
+      const dest: MailDestination = {
+        proxyConfiguration: {
+          host: 'www.proxy.com',
+          port: 12345,
+          protocol: 'socks',
+          'proxy-authorization': 'jwt'
+        }
+      };
+      const proxyUrl = buildSocksProxyUrl(dest);
+      expect(proxyUrl).toBe('socks5://www.proxy.com:12345');
+    });
   });
 });
 

--- a/packages/mail-client/src/mail-client.ts
+++ b/packages/mail-client/src/mail-client.ts
@@ -194,19 +194,27 @@ async function sendMailInSequential<T extends MailConfig>(
   mailConfigs: T[]
 ): Promise<MailResponse[]> {
   const response: MailResponse[] = [];
-  for (const mailConfigIndex in mailConfigs) {
-    logger.debug(
-      `Sending email ${mailConfigIndex + 1}/${mailConfigs.length}...`
-    );
-    response[mailConfigIndex] = await transport.sendMail({
-      ...mailConfigsFromDestination,
-      ...mailConfigs[mailConfigIndex]
-    });
-    logger.debug(
-      `...email ${mailConfigIndex + 1}/${mailConfigs.length} for subject "${
-        mailConfigs[mailConfigIndex].subject
-      }" was sent successfully.`
-    );
+  for (const [mailConfigIndex, mailConfig] of mailConfigs.entries()) {
+    try {
+      logger.debug(
+        `Sending email ${mailConfigIndex + 1}/${mailConfigs.length}...`
+      );
+      response[mailConfigIndex] = await transport.sendMail({
+        ...mailConfigsFromDestination,
+        ...mailConfig
+      });
+      logger.debug(
+        `...email ${mailConfigIndex + 1}/${mailConfigs.length} with subject "${mailConfig.subject}" was sent successfully.`
+      );
+    } catch (error) {
+      logger.error(
+        `Failed to send email ${mailConfigIndex + 1}/${mailConfigs.length} with subject "${mailConfig.subject}". Error: ${error.message}`
+      );
+      response[mailConfigIndex] = {
+        response: error.response,
+        rejected: error.rejected
+      };
+    }
   }
   return response;
 }
@@ -217,27 +225,36 @@ async function sendMailInParallel<T extends MailConfig>(
   mailConfigs: T[]
 ): Promise<MailResponse[]> {
   const promises: Promise<MailResponse>[] = mailConfigs.map(
-    (mailConfig, mailConfigIndex, mailConfigsArray) => {
-      logger.debug(
-        `Sending email ${mailConfigIndex + 1}/${mailConfigsArray.length}...`
-      );
-      return transport.sendMail({
-        ...mailConfigsFromDestination,
-        ...mailConfig
-      });
+    async (mailConfig, mailConfigIndex, mailConfigsArray) => {
+      try {
+        logger.debug(
+          `Sending email ${mailConfigIndex + 1}/${mailConfigsArray.length}...`
+        );
+        const response = await transport.sendMail({
+          ...mailConfigsFromDestination,
+          ...mailConfig
+        });
+        logger.debug(
+          `...email ${mailConfigIndex + 1}/${mailConfigs.length} with subject "${
+            mailConfig.subject
+          }" was sent successfully.`
+        );
+        return response;
+      } catch (error) {
+        logger.error(
+          `Failed to send email ${mailConfigIndex + 1}/${mailConfigs.length} for subject "${
+            mailConfig.subject
+          }". Error: ${error.message}`
+        );
+        return {
+          response: error.response,
+          rejected: error.rejected
+        };
+      }
     }
   );
 
-  return Promise.all(promises).then(responses => {
-    responses.forEach((_, responseIndex) =>
-      logger.debug(
-        `...email ${responseIndex + 1}/${mailConfigs.length} for subject "${
-          mailConfigs[responseIndex].subject
-        }" was sent successfully`
-      )
-    );
-    return responses;
-  });
+  return Promise.all(promises);
 }
 
 async function sendMailWithNodemailer<T extends MailConfig>(


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Added error handling so other mails should be sent, even if one of them fails

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
