### PR TITLE
feat: Add default transform function for service bindings

### DIFF
--- a/.changeset/neat-parents-search.md
+++ b/.changeset/neat-parents-search.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[New Functionality] Add transform function for OAuth2ClientCredentials destinations.

--- a/.changeset/neat-parents-search.md
+++ b/.changeset/neat-parents-search.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/connectivity': minor
 ---
 
-[New Functionality] Add transform function for OAuth2ClientCredentials destinations.
+[New Functionality] Add transform function to create OAuth2ClientCredentials destinations from service bindings.

--- a/packages/connectivity/src/index.ts
+++ b/packages/connectivity/src/index.ts
@@ -59,7 +59,8 @@ export {
   ServiceBindingTransformOptions,
   transformServiceBindingToDestination,
   getAllDestinationsFromDestinationService,
-  getTenantId
+  getTenantId,
+  transformServiceBindingToClientCredentialsDestination
 } from './scp-cf';
 
 export type {

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.spec.ts
@@ -74,8 +74,7 @@ const services = {
       url: 'some-service-url',
       credentials: {
         clientid: 'some-service-clientid',
-        clientsecret: 'some-service-clientsecret',
-        uri: 'some-service-uri'
+        clientsecret: 'some-service-clientsecret'
       }
     }
   ],

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.spec.ts
@@ -1,7 +1,10 @@
 import { serviceToken } from '../token-accessor';
 import { resolveServiceBinding } from '../environment-accessor/service-bindings';
 import { decodeJwt } from '../jwt';
-import { transformServiceBindingToClientCredentialsDestination, transformServiceBindingToDestination } from './service-binding-to-destination';
+import {
+  transformServiceBindingToClientCredentialsDestination,
+  transformServiceBindingToDestination
+} from './service-binding-to-destination';
 
 const services = {
   destination: [
@@ -214,9 +217,10 @@ describe('service binding to destination', () => {
   });
 
   it('transforms a generic service binding to a client credentials destination', async () => {
-    const destination = await transformServiceBindingToClientCredentialsDestination(
-      resolveServiceBinding('some-service')
-    );
+    const destination =
+      await transformServiceBindingToClientCredentialsDestination(
+        resolveServiceBinding('some-service')
+      );
     expect(destination).toEqual(
       expect.objectContaining({
         url: 'some-service-url',
@@ -233,10 +237,11 @@ describe('service binding to destination', () => {
   });
 
   it('transforms a generic service binding to a client credentials destination', async () => {
-    const destination = await transformServiceBindingToClientCredentialsDestination(
-      resolveServiceBinding('some-service'),
-      { url: 'some-custom-service-url' }
-    );
+    const destination =
+      await transformServiceBindingToClientCredentialsDestination(
+        resolveServiceBinding('some-service'),
+        { url: 'some-custom-service-url' }
+      );
     expect(destination).toEqual(
       expect.objectContaining({
         url: 'some-custom-service-url',

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.spec.ts
@@ -1,7 +1,7 @@
 import { serviceToken } from '../token-accessor';
 import { resolveServiceBinding } from '../environment-accessor/service-bindings';
 import { decodeJwt } from '../jwt';
-import { transformServiceBindingToDestination } from './service-binding-to-destination';
+import { transformServiceBindingToClientCredentialsDestination, transformServiceBindingToDestination } from './service-binding-to-destination';
 
 const services = {
   destination: [
@@ -68,6 +68,7 @@ const services = {
       name: 'some-service1',
       label: 'some-service',
       tags: ['some-service'],
+      url: 'some-service-url',
       credentials: {
         clientid: 'some-service-clientid',
         clientsecret: 'some-service-clientsecret',
@@ -209,6 +210,45 @@ describe('service binding to destination', () => {
       )
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       '"The provided service binding of type some-service is not supported out of the box for destination transformation."'
+    );
+  });
+
+  it('transforms a generic service binding to a client credentials destination', async () => {
+    const destination = await transformServiceBindingToClientCredentialsDestination(
+      resolveServiceBinding('some-service')
+    );
+    expect(destination).toEqual(
+      expect.objectContaining({
+        url: 'some-service-url',
+        name: 'some-service1',
+        authentication: 'OAuth2ClientCredentials',
+        authTokens: expect.arrayContaining([
+          expect.objectContaining({
+            value: 'access-token',
+            type: 'bearer'
+          })
+        ])
+      })
+    );
+  });
+
+  it('transforms a generic service binding to a client credentials destination', async () => {
+    const destination = await transformServiceBindingToClientCredentialsDestination(
+      resolveServiceBinding('some-service'),
+      { url: 'some-custom-service-url' }
+    );
+    expect(destination).toEqual(
+      expect.objectContaining({
+        url: 'some-custom-service-url',
+        name: 'some-service1',
+        authentication: 'OAuth2ClientCredentials',
+        authTokens: expect.arrayContaining([
+          expect.objectContaining({
+            value: 'access-token',
+            type: 'bearer'
+          })
+        ])
+      })
     );
   });
 });

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.spec.ts
@@ -236,7 +236,7 @@ describe('service binding to destination', () => {
     );
   });
 
-  it('transforms a generic service binding to a client credentials destination', async () => {
+  it('transforms a generic service binding to a client credentials destination with custom url', async () => {
     const destination =
       await transformServiceBindingToClientCredentialsDestination(
         resolveServiceBinding('some-service'),

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
@@ -58,19 +58,19 @@ export async function transformServiceBindingToDestination(
 
 /**
  * Transforms a service binding to a destination of type OAuth2ClientCredentials.
- * @param serviceBinding - The service binding to transform.
- * @param options - Options used for fetching the destination.
+ * @param service - The service binding to transform.
+ * @param options - Options used to transform the service binding.
  * @returns A promise returning the transformed destination on success.
  */
 export async function transformServiceBindingToClientCredentialsDestination(
   service: Service,
-  options?: ServiceBindingTransformOptions & { url: string }
+  options?: ServiceBindingTransformOptions & { url?: string }
 ): Promise<Destination> {
-  const token = await serviceToken(serviceBinding, options);
+  const token = await serviceToken(service, options);
   return buildClientCredentialsDestination(
     token,
-    options?.url ?? serviceBinding.url,
-    serviceBinding.name
+    options?.url ?? service.url,
+    service.name
   );
 }
 

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
@@ -57,7 +57,9 @@ export async function transformServiceBindingToDestination(
 }
 
 /**
+ * Convenience function to create a destination from the provided service binding.
  * Transforms a service binding to a destination of type OAuth2ClientCredentials.
+ * If a JWT is provided as part of the options, the tenant in the JWT is used for the client credentials grant, else the provider tenant is used, wherever applicable.
  * @param service - The service binding to transform.
  * @param options - Options used to transform the service binding.
  * @returns A promise returning the transformed destination on success.

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
@@ -63,7 +63,7 @@ export async function transformServiceBindingToDestination(
  * @returns A promise returning the transformed destination on success.
  */
 export async function transformServiceBindingToClientCredentialsDestination(
-  serviceBinding: Service,
+  service: Service,
   options?: ServiceBindingTransformOptions & { url: string }
 ): Promise<Destination> {
   const token = await serviceToken(serviceBinding, options);

--- a/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
+++ b/packages/connectivity/src/scp-cf/destination/service-binding-to-destination.ts
@@ -56,6 +56,24 @@ export async function transformServiceBindingToDestination(
   );
 }
 
+/**
+ * Transforms a service binding to a destination of type OAuth2ClientCredentials.
+ * @param serviceBinding - The service binding to transform.
+ * @param options - Options used for fetching the destination.
+ * @returns A promise returning the transformed destination on success.
+ */
+export async function transformServiceBindingToClientCredentialsDestination(
+  serviceBinding: Service,
+  options?: ServiceBindingTransformOptions & { url: string }
+): Promise<Destination> {
+  const token = await serviceToken(serviceBinding, options);
+  return buildClientCredentialsDestination(
+    token,
+    options?.url ?? serviceBinding.url,
+    serviceBinding.name
+  );
+}
+
 async function aicoreToDestination(
   service: Service,
   options?: ServiceBindingTransformOptions


### PR DESCRIPTION
With this PR, we add a default transform function our users can use to build client credentials-based destinations.

Closes SAP/cloud-sdk-backlog#1258.
