### PR TITLE
chore: Release major `next` 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,10 @@ jobs:
         run: |
           date=`date +%Y%m%d%H%M%S`
           rm -f .changeset/*.md
-          cp canary-release-changeset.md .changeset
+          project_version=$(cat package.json | jq '.version' | tr -d '"')
+          echo The project version is: $project_version
+          [[ $project_version == 4* ]] && cp canary-release-changeset.md .changeset          
+          [[ $project_version == 3* ]] && cp major-release-changeset.md .changeset
           yarn changeset pre enter ${date}
           yarn changeset version
           yarn changeset pre exit

--- a/major-release-changeset.md
+++ b/major-release-changeset.md
@@ -1,0 +1,25 @@
+---
+'@sap-cloud-sdk/connectivity': major
+'@sap-cloud-sdk/eslint-config': major
+'@sap-cloud-sdk/generator': major
+'@sap-cloud-sdk/generator-common': major
+'@sap-cloud-sdk/http-client': major
+'@sap-cloud-sdk/odata-common': major
+'@sap-cloud-sdk/odata-v2': major
+'@sap-cloud-sdk/odata-v4': major
+'@sap-cloud-sdk/openapi': major
+'@sap-cloud-sdk/openapi-generator': major
+'@sap-cloud-sdk/temporal-de-serializers': major
+'@sap-cloud-sdk/test-util': major
+'@sap-cloud-sdk/util': major
+'@sap-cloud-sdk/e2e-tests': major
+'@sap-cloud-sdk/integration-tests': major
+'@sap-cloud-sdk/test-services-e2e': major
+'@sap-cloud-sdk/test-services-odata-common': major
+'@sap-cloud-sdk/test-services-odata-v2': major
+'@sap-cloud-sdk/test-services-odata-v4': major
+'@sap-cloud-sdk/test-services-openapi': major
+'@sap-cloud-sdk/type-tests': major
+---
+
+Canary release


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

The release with tag next is version [3.24.1-20241205152930.0](https://www.npmjs.com/package/@sap-cloud-sdk/http-client/v/3.24.1-20241205152930.0) which is a bit misleading. 

https://www.npmjs.com/package/@sap-cloud-sdk/http-client?activeTab=versions

This PR adjusts build workflow so we release a version 4.0.0-20241207 with the tag next. This PR should be reverted once v4 is released. In case we forget, there is a check in the step so we dont mistakenly release v5 canary.

- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
~~- [ ] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4~~

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
