### PR TITLE
chore: Create dependabot PR automation

### DIFF
--- a/.github/workflows/auto-dependabot-fix.yml
+++ b/.github/workflows/auto-dependabot-fix.yml
@@ -18,10 +18,8 @@ jobs:
         with:
           node-version: 22
           cache: 'yarn'
-      - name: Install Dependencies
+      - name: Install Dependencies & Compile
         run: yarn install --frozen-lockfile --ignore-engines
-      - name: Run Lint
-        run: yarn lint:fix
       - name: Commit Changes if needed
         run: |
           diff=`git diff`

--- a/.github/workflows/auto-dependabot-fix.yml
+++ b/.github/workflows/auto-dependabot-fix.yml
@@ -28,6 +28,6 @@ jobs:
           if [ ! -z "$diff" ]; then
             git config --global user.email "cloud-sdk-js@github.com"
             git config --global user.name "cloud-sdk-js"
-            git commit -m "Changes from lint:fix" -a
+            git commit -m "Regenerate check-public-api action" -a
             git push
           fi

--- a/.github/workflows/auto-dependabot-fix.yml
+++ b/.github/workflows/auto-dependabot-fix.yml
@@ -1,0 +1,33 @@
+name: auto-dependabot-fix
+
+on:
+  pull_request: ~
+
+jobs:
+  building:
+    if: github.actor == 'dependabot[bot]' && !github.event.pull_request.head.repo.fork
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}
+      - run: git fetch --depth=1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'yarn'
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile --ignore-engines
+      - name: Run Lint
+        run: yarn lint:fix
+      - name: Commit Changes if needed
+        run: |
+          diff=`git diff`
+          if [ ! -z "$diff" ]; then
+            git config --global user.email "cloud-sdk-js@github.com"
+            git config --global user.name "cloud-sdk-js"
+            git commit -m "Changes from lint:fix" -a
+            git push
+          fi


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Automatically fixes dependency issues of dependabot PRs by re-compiling and committing any potential diff.

Part of SAP/cloud-sdk-backlog#1260.

- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [x] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
