### PR TITLE
fix: Auto fix dependabot using `pull_request_target`

### DIFF
--- a/.github/workflows/auto-dependabot-fix.yml
+++ b/.github/workflows/auto-dependabot-fix.yml
@@ -1,7 +1,7 @@
 name: auto-dependabot-fix
 
 on:
-  pull_request: ~
+  pull_request_target: ~
 
 jobs:
   building:


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

~Closes SAP/cloud-sdk-backlog#ISSUENUMBER.~

- [X] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [ ] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

Workflows triggered by dependabot from `pull_request` do not have write access to the repository, even when providing a PAT with write access. The fix is to use `pull_request_target` instead, which can have write access. As described in https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/, there is a risk of using `pull_request_target`. But since we only re-run yarn install and commit the changes, the risk that this command would introduce malicious code is from my point of view rather low. @deekshas8 @tomfrenken Correct me if I am wrong. 