### PR TITLE
chore: Fix auto dependabot workflow using `pull_request_target`

### DIFF
--- a/.github/workflows/auto-dependabot-fix.yml
+++ b/.github/workflows/auto-dependabot-fix.yml
@@ -1,15 +1,12 @@
 name: auto-dependabot-fix
 
 on:
-  pull_request: ~
+  pull_request_target: ~
 
 jobs:
   building:
     if: github.actor == 'dependabot[bot]' && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

~Closes SAP/cloud-sdk-backlog#ISSUENUMBER.~

- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [ ] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

I have to use `pull_request_target` as I saw in https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/, dependabot created PRs are treated as **from a fork** if using `pull_request`