### PR TITLE
chore: Use `pull_request_target` in auto-dependabot-fix.yml

### DIFF
--- a/.github/workflows/auto-dependabot-fix.yml
+++ b/.github/workflows/auto-dependabot-fix.yml
@@ -1,7 +1,7 @@
 name: auto-dependabot-fix
 
 on:
-  pull_request: ~
+  pull_request_target: ~
 
 jobs:
   building:


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

- [X] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [x] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->

Use `pull_request_target` instead of `pull_request` for dependabot PR to get write access.
