### PR TITLE
fix: Tests in v4

### DIFF
--- a/.github/actions/check-public-api/index.js
+++ b/.github/actions/check-public-api/index.js
@@ -28851,7 +28851,7 @@ function maybeCallback(callback, ctx, thisArg, func) {
       err = e;
     }
     return new Promise(function (resolve, reject) {
-      setImmediate(function () {
+      process.nextTick(function () {
         if (err) {
           reject(err);
         } else {
@@ -28865,7 +28865,7 @@ function maybeCallback(callback, ctx, thisArg, func) {
     } catch (e) {
       err = e;
     }
-    setImmediate(function () {
+    process.nextTick(function () {
       if (val === undefined) {
         callback(err);
       } else {
@@ -30284,14 +30284,7 @@ Binding.prototype.exists = function (filepath, callback, ctx) {
 
   return maybeCallback(normalizeCallback(callback), ctx, this, function () {
     filepath = deBuffer(filepath);
-    let item;
-    try {
-      item = this._system.getItem(filepath);
-    } catch {
-      // ignore errors
-      // see https://github.com/nodejs/node/blob/v22.11.0/lib/fs.js#L255-L257
-      return false;
-    }
+    const item = this._system.getItem(filepath);
 
     if (item) {
       if (item instanceof SymbolicLink) {

--- a/build-packages/check-pr/package.json
+++ b/build-packages/check-pr/package.json
@@ -22,7 +22,7 @@
     "@vercel/ncc": "^0.38.3",
     "depcheck": "^1.4.7",
     "eslint": "^8.57.1",
-    "mock-fs": "^5.3.0",
+    "mock-fs": "5.3.0",
     "prettier": "^3.4.2",
     "typescript": "~5.7.2"
   }

--- a/build-packages/check-public-api/package.json
+++ b/build-packages/check-public-api/package.json
@@ -1,33 +1,33 @@
 {
-    "name": "check-public-api",
-    "version": "1.0.0",
-    "description": "Checks if the APIs in a package are correctly marked public or internal.",
-    "license": "Apache-2.0",
-    "private": true,
-    "scripts": {
-      "compile": "tsc -p tsconfig.json",
-      "postcompile": "ncc build lib/index.js --external prettier --external typescript  --out ../../.github/actions/check-public-api/",
-      "test": "yarn test:unit",
-      "test:unit": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js",
-      "lint": "eslint && prettier --check **/*.ts",
-      "lint:fix": "eslint --fix --quiet && prettier --write **/*.ts",
-      "check:dependencies": "depcheck --skip-missing=true .",
-      "all": "yarn && yarn run lint && yarn run compile"
-    },
-    "dependencies": {
-      "@actions/core": "^1.10.1",
-      "@manypkg/get-packages": "^2.2.2",
-      "@sap-cloud-sdk/util": "^3.22.2",
-      "@sap-cloud-sdk/generator-common": "^3.22.2",
-      "@types/mock-fs": "^4.13.4",
-      "glob": "^10.4.3",
-      "mock-fs": "^5.3.0"
-    },
-    "devDependencies": {
-      "@vercel/ncc": "^0.38.3",
-      "depcheck": "^1.4.7",
-      "eslint": "^8.57.0",
-      "prettier": "^3.4.2",
-      "typescript": "~5.7.2"
-    }
+  "name": "check-public-api",
+  "version": "1.0.0",
+  "description": "Checks if the APIs in a package are correctly marked public or internal.",
+  "license": "Apache-2.0",
+  "private": true,
+  "scripts": {
+    "compile": "tsc -p tsconfig.json",
+    "postcompile": "ncc build lib/index.js --external prettier --external typescript  --out ../../.github/actions/check-public-api/",
+    "test": "yarn test:unit",
+    "test:unit": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js",
+    "lint": "eslint && prettier --check **/*.ts",
+    "lint:fix": "eslint --fix --quiet && prettier --write **/*.ts",
+    "check:dependencies": "depcheck --skip-missing=true .",
+    "all": "yarn && yarn run lint && yarn run compile"
+  },
+  "dependencies": {
+    "@actions/core": "^1.10.1",
+    "@manypkg/get-packages": "^2.2.2",
+    "@sap-cloud-sdk/util": "^3.22.2",
+    "@sap-cloud-sdk/generator-common": "^3.22.2",
+    "@types/mock-fs": "^4.13.4",
+    "glob": "^10.4.3",
+    "mock-fs": "5.3.0"
+  },
+  "devDependencies": {
+    "@vercel/ncc": "^0.38.3",
+    "depcheck": "^1.4.7",
+    "eslint": "^8.57.0",
+    "prettier": "^3.4.2",
+    "typescript": "~5.7.2"
   }
+}

--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -45,7 +45,7 @@
     "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
-    "mock-fs": "^5.3.0",
+    "mock-fs": "5.3.0",
     "nock": "^14.0.0-beta.19",
     "typescript": "~5.7.2"
   }

--- a/packages/generator-common/package.json
+++ b/packages/generator-common/package.json
@@ -47,6 +47,6 @@
   },
   "devDependencies": {
     "@types/yargs": "^17.0.33",
-    "mock-fs": "^5.3.0"
+    "mock-fs": "5.3.0"
   }
 }

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "execa": "^5.0.0",
-    "mock-fs": "^5.3.0",
+    "mock-fs": "5.3.0",
     "prettier": "^3.4.2"
   }
 }

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
-    "mock-fs": "^5.3.0",
+    "mock-fs": "5.3.0",
     "prettier": "^3.4.2",
     "typescript": "~5.7.2"
   }

--- a/packages/test-util/package.json
+++ b/packages/test-util/package.json
@@ -38,7 +38,7 @@
     "@sap-cloud-sdk/util": "^3.24.0"
   },
   "devDependencies": {
-    "mock-fs": "^5.3.0",
+    "mock-fs": "5.3.0",
     "typescript": "~5.7.2"
   }
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -44,6 +44,6 @@
   "devDependencies": {
     "nock": "^14.0.0-beta.19",
     "typescript": "~5.7.2",
-    "mock-fs": "^5.3.0"
+    "mock-fs": "5.3.0"
   }
 }

--- a/test-packages/e2e-tests/package.json
+++ b/test-packages/e2e-tests/package.json
@@ -42,7 +42,7 @@
     "fs-extra": "^11.2.0",
     "http-proxy-middleware": "^3.0.3",
     "json-schema-faker": "^0.5.8",
-    "mock-fs": "^5.3.0",
+    "mock-fs": "5.3.0",
     "moment": "^2.30.1",
     "openapi-backend": "^5.11.1",
     "pm2": "^5.4.3",

--- a/test-packages/integration-tests/package.json
+++ b/test-packages/integration-tests/package.json
@@ -34,7 +34,7 @@
     "moment": "^2.30.1",
     "execa": "^5.0.0",
     "jsonwebtoken": "^9.0.2",
-    "mock-fs": "^5.3.0",
+    "mock-fs": "5.3.0",
     "nock": "^14.0.0-beta.19",
     "winston": "^3.17.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6840,10 +6840,10 @@ mkdirp@^3.0.1:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz#e44e4c5607fb279c168241713cc6e0fea9adcb50"
   integrity sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==
 
-mock-fs@^5.3.0:
-  version "5.4.1"
-  resolved "https://registry.npmjs.org/mock-fs/-/mock-fs-5.4.1.tgz#b00abc658cb19dbbf282fde2f05bb751cd1e12a5"
-  integrity sha512-sz/Q8K1gXXXHR+qr0GZg2ysxCRr323kuN10O7CtQjraJsFDJ4SJ+0I5MzALz7aRp9lHk8Cc/YdsT95h9Ka1aFw==
+mock-fs@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/mock-fs/-/mock-fs-5.3.0.tgz#7dfc95ce5528aff8e10fa117161b91d8129e0e9e"
+  integrity sha512-IMvz1X+RF7vf+ur7qUenXMR7/FSKSIqS3HqFHXcyNI7G0FbpFO8L5lfsUJhl+bhK1AiulVHWKUSxebWauPA+xQ==
 
 mock-json-schema@^1.0.7:
   version "1.1.1"


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Fixing the `mock-fs` version to `5.3.0` as the latest version `5.4.1` causes some tests to fail.
(Ref: [Dependency updates that fail in v3](https://github.com/SAP/cloud-sdk-js/pull/5242))


- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- ~[ ] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4~

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
