### PR TITLE
fix: Reintroduce option to pass iss in getClientCredentials function

### DIFF
--- a/.changeset/nice-comics-punch.md
+++ b/.changeset/nice-comics-punch.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+---
+
+[Fixed Issue] Reintroduce option to pass iss object to getClientCredentials function.

--- a/.changeset/nice-comics-punch.md
+++ b/.changeset/nice-comics-punch.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/connectivity': patch
 ---
 
-[Fixed Issue] Reintroduce option to pass iss object to getClientCredentials function.
+[Fixed Issue] Reintroduce option to pass `iss` property to `getClientCredentialsToken` function.

--- a/packages/connectivity/src/scp-cf/jwt/jwt.ts
+++ b/packages/connectivity/src/scp-cf/jwt/jwt.ts
@@ -62,6 +62,13 @@ export function getTenantId(
   return decodedJwt.zid || decodedJwt.app_tid || undefined;
 }
 
+/**
+ * Check if the given JWT is not an IAS token.
+ * Currently, there are only two domains for IAS tokens:
+ * `accounts.ondemand.com` and `accounts400.onemand.com`.
+ * @param decodedJwt - The decoded JWT to check.
+ * @returns Whether the given JWT is not an IAS token.
+ */
 function isNotIasToken(decodedJwt: JwtPayload): boolean {
   return (
     !decodedJwt.iss?.includes('accounts.ondemand.com') &&
@@ -71,8 +78,10 @@ function isNotIasToken(decodedJwt: JwtPayload): boolean {
 
 /**
  * @internal
- * Retrieve the subdomain from the decoded XSUAA JWT. If the JWT is not in XSUAA format, returns `undefined`.
- * @param jwt - JWT to retrieve the subdomain from.
+ * Retrieve the subdomain from the decoded XSUAA JWT or ISS object.
+ * If it is an IAS JWT, or the passed object doesn't contain an ISS propety,
+ * returns `undefined`.
+ * @param jwt - JWT or ISS object to retrieve the subdomain from.
  * @returns The subdomain, if available.
  */
 export function getSubdomain(

--- a/packages/connectivity/src/scp-cf/jwt/jwt.ts
+++ b/packages/connectivity/src/scp-cf/jwt/jwt.ts
@@ -62,6 +62,13 @@ export function getTenantId(
   return decodedJwt.zid || decodedJwt.app_tid || undefined;
 }
 
+function isNotIasToken(decodedJwt: JwtPayload): boolean {
+  return (
+    !decodedJwt.iss?.includes('accounts.ondemand.com') &&
+    !decodedJwt.iss?.includes('accounts400.ondemand.com')
+  );
+}
+
 /**
  * @internal
  * Retrieve the subdomain from the decoded XSUAA JWT. If the JWT is not in XSUAA format, returns `undefined`.
@@ -74,7 +81,7 @@ export function getSubdomain(
   const decodedJwt = jwt ? decodeJwt(jwt) : {};
   return (
     decodedJwt?.ext_attr?.zdn ||
-    (isXsuaaToken(decodedJwt) ? getIssuerSubdomain(decodedJwt) : undefined)
+    (isNotIasToken(decodedJwt) ? getIssuerSubdomain(decodedJwt) : undefined)
   );
 }
 


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Relates to #5476 


- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [x] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
