### PR TITLE
chore: Automate v4 canary release

### DIFF
--- a/.github/workflows/automatic-v4-canary-release.yml
+++ b/.github/workflows/automatic-v4-canary-release.yml
@@ -1,0 +1,20 @@
+name: automatic-v4-canary-release
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  trigger-v4-canary-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger v4 release from main branch
+        run: |
+          curl -L \
+           -X POST \
+           -H "Accept: application/vnd.github+json" \
+           -H "Authorization: Bearer ${{ secrets.GH_CLOUD_SDK_JS_ADMIN_WRITE_TOKEN }}" \
+           -H "X-GitHub-Api-Version: 2022-11-28" \
+           https://api.github.com/repos/SAP/cloud-sdk-js/actions/workflows/build.yml/dispatches \
+           -d '{"ref":"main", "inputs": {"canary-release": "true"}}'


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Creating an workflow, that deploys v4 canary release with next tag nightly.

- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [ ] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
