### PR TITLE
chore: Add workflow dispatch for v4 canary release job

### DIFF
--- a/.github/workflows/next-build-nightly.yml
+++ b/.github/workflows/next-build-nightly.yml
@@ -3,7 +3,8 @@ name: next-build-nightly
 on:
   schedule:
     - cron: '0 2 * * *'
-
+  workflow_dispatch:
+    
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->



- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [ ] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
