### PR TITLE
chore: fix nightly canary release workflow

### DIFF
--- a/.github/workflows/next-build-nightly.yml
+++ b/.github/workflows/next-build-nightly.yml
@@ -113,7 +113,7 @@ jobs:
       - id: date-check
         name: Check if latest commit is within 24 hrs
         run: |
-          lastCommitDate=$(git --no-pager log -n 1 "${{ github.ref_name }}" --pretty=format:"%at")
+          lastCommitDate=$(git --no-pager log -n 1 ${{ github.ref_name }} --pretty=format:"%at")
           curDate=$(date +%s)
           dateDiff=$(expr $curDate - $lastCommitDate)
           echo $lastCommitDate, $curDate, $dateDiff

--- a/.github/workflows/next-build-nightly.yml
+++ b/.github/workflows/next-build-nightly.yml
@@ -113,14 +113,14 @@ jobs:
       - id: date-check
         name: Check if latest commit is within 24 hrs
         run: |
-          lastCommitDate=$(git --no-pager log -n 1 ${{ github.ref_name }} --pretty=format:"%at")
+          lastCommitDate=$(git --no-pager log -n 1 main --pretty=format:"%at")
           curDate=$(date +%s)
           dateDiff=$(expr $curDate - $lastCommitDate)
           echo $lastCommitDate, $curDate, $dateDiff
 
           if [[ $dateDiff -gt 86400 ]]
           then
-              echo 'No new commit found on ${{ github.ref }} within the last 24 hrs.'
+              echo 'No new commit found on main within the last 24 hrs.'
               echo "skip-release=true" >> $GITHUB_OUTPUT
           else
               echo "skip-release=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/next-build-nightly.yml
+++ b/.github/workflows/next-build-nightly.yml
@@ -3,7 +3,6 @@ name: next-build-nightly
 on:
   schedule:
     - cron: '0 2 * * *'
-  workflow_dispatch:
     
 jobs:
   tests:


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Successful run: https://github.com/SAP/cloud-sdk-js/actions/runs/13412094350

- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [ ] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
