### PR TITLE
fix: Remove log warning for undefined OData V2 response body

### DIFF
--- a/packages/odata-v2/src/request-builder/response-data-accessor.spec.ts
+++ b/packages/odata-v2/src/request-builder/response-data-accessor.spec.ts
@@ -67,6 +67,11 @@ describe('response data accessor', () => {
       );
     });
 
+    it('does not log any warning for undefined response body', () => {
+      getSingleResult(undefined);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
     it('returns single result for collection result format', () => {
       const d = { a: 'b' };
       expect(getSingleResult({ d: { results: d } })).toEqual(d);

--- a/packages/odata-v2/src/request-builder/response-data-accessor.ts
+++ b/packages/odata-v2/src/request-builder/response-data-accessor.ts
@@ -76,7 +76,7 @@ function validateSingleResult(data: any): void {
       'The given response data has the format for collections instead of the standard OData v2 format for single results.'
     );
   }
-  if (!data?.d) {
+  if (data && !data.d) {
     logger.warn(
       'The given response data does not have the standard OData v2 format for single results.'
     );


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#1267.

https://github.com/SAP/cloud-sdk-js/issues/5516

- [X] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [ ] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
