### PR TITLE
fix: check proxy and sap connectivity auth tokens for caching

### DIFF
--- a/.changeset/thick-glasses-lick.md
+++ b/.changeset/thick-glasses-lick.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/connectivity': minor
 ---
 
-[Fix Issue] Check `Proxy-Authorization` and `SAP-Connectivity-Authentication` tokens to determine cache expiration time.
+[Fixed Issue] Check `Proxy-Authorization` and `SAP-Connectivity-Authentication` tokens to determine cache expiration time.

--- a/.changeset/thick-glasses-lick.md
+++ b/.changeset/thick-glasses-lick.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': minor
+---
+
+[Fix Issue] Check `Proxy-Authorization` and `SAP-Connectivity-Authentication` tokens to determine cache expiration time.

--- a/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-cache.spec.ts
@@ -31,6 +31,7 @@ import {
   mockJwtBearerToken,
   mockServiceToken
 } from '../../../../../test-resources/test/test-util/token-accessor-mocks';
+import { signedJwtForVerification } from '../../../../../test-resources/test/test-util';
 import { destinationServiceCache } from './destination-service-cache';
 import {
   alwaysProvider,
@@ -51,9 +52,6 @@ import type {
   Destination,
   DestinationAuthToken
 } from './destination-service-types';
-import exp from 'constants';
-import { JwtPayload } from 'jsonwebtoken';
-import { signedJwtForVerification } from '../../../../../test-resources/test/test-util';
 
 const destinationOne: Destination = {
   url: 'https://destination1.example',


### PR DESCRIPTION
Closes SAP/cloud-sdk-backlog#1255.
Fix SAP/cloud-sdk-js#5131

- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [ ] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

Use the minimum of authentication token, `Proxy-Authorization` token, and `SAP-Connectivity-Authentication` token to determine the expiration time.