### PR TITLE
feat!: Disable `iasToXsuaaTokenExchange` by default

### DIFF
--- a/.changeset/seven-crabs-act.md
+++ b/.changeset/seven-crabs-act.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': major
+---
+
+[Compatibility Note] Disable `iasToXsuaaTokenExchange` by default if not defined.

--- a/V4-Upgrade-Guide.md
+++ b/V4-Upgrade-Guide.md
@@ -19,7 +19,8 @@ The To-Do list is:
 
 - [Update Your Project Dependencies](#update-your-project-dependencies)
 - [Update to Node 22 or Newer](#update-to-node-22-or-newer)
-- [Set `useCache` explicitly to false to turn off destination caching](#set-useCache-explicitly-to-false-to-turn-off-destination-caching)
+- [Set `useCache` explicitly to `false` to turn off destination caching](#set-usecache-explicitly-to-false-to-turn-off-destination-caching)
+- [Set `iasToXsuaaTokenExchange` to `true` to enable IAS to XSUAA token exchange](#set-iastoxsuaatokenexchange-to-true-to-enable-ias-to-xsuaa-token-exchange)
 
 ## Update Your Project Dependencies
 
@@ -36,7 +37,7 @@ All SAP Cloud SDK for JavaScript libraries now support node 22 (LTS) as the **mi
 If you are using a node version older than 22, update your runtime environment to a newer version.
 On Cloud Foundry you can do this by [setting the node engine in your `package.json`](https://docs.cloudfoundry.org/buildpacks/node/index.html#runtime).
 
-## Set `useCache` explicitly to false to turn off destination caching
+## Set `useCache` explicitly to `false` to turn off destination caching
 
 **Destination caching while retrieving destinations via the destination service is now enabled by default.**
 
@@ -48,3 +49,25 @@ To disable caching set `useCache: false` in the options, for example in `execute
 .execute({ destinationName: 'DESTINATION', jwt: 'JWT', useCache: false })
 ```
 
+## Set `iasToXsuaaTokenExchange` to `true` to enable IAS to XSUAA token exchange
+
+**Token exchange from IAS to XSUAA is now disabled by default. Set `iasToXsuaaTokenExchange` to `true` explicitly if token exchange is expected.** 
+
+This change affects the default behaviour of following functions
+
+- `getDestination()`
+- `getAllDestinationsFromDestinationService()`
+- `registerDestination()`
+- `getDestinationFromDestinationService()`
+- `useOrFetchDestination()`
+- `toDestinationNameUrl()`
+- `buildHttpRequest()`
+- `executeHttpRequest()`
+- `executeHttpRequestWithOrigin()`
+
+and following methods of request builder
+
+- `execute()`
+- `executeRaw()`
+- `url()`
+- `build()`

--- a/V4-Upgrade-Guide.md
+++ b/V4-Upgrade-Guide.md
@@ -51,7 +51,8 @@ To disable caching set `useCache: false` in the options, for example in `execute
 
 ## Set `iasToXsuaaTokenExchange` to `true` to enable IAS to XSUAA token exchange
 
-**Token exchange from IAS to XSUAA is now disabled by default. Set `iasToXsuaaTokenExchange` to `true` explicitly if token exchange is expected.** 
+**Token exchange from IAS to XSUAA is now disabled by default.
+Set `iasToXsuaaTokenExchange` to `true` explicitly if token exchange is expected.** 
 
 This change affects the default behaviour of following functions
 

--- a/V4-Upgrade-Guide.md
+++ b/V4-Upgrade-Guide.md
@@ -58,7 +58,6 @@ This change affects the default behaviour of following functions
 
 - `getDestination()`
 - `getAllDestinationsFromDestinationService()`
-- `registerDestination()`
 - `getDestinationFromDestinationService()`
 - `useOrFetchDestination()`
 - `toDestinationNameUrl()`

--- a/V4-Upgrade-Guide.md
+++ b/V4-Upgrade-Guide.md
@@ -70,4 +70,3 @@ and following methods of request builder
 - `execute()`
 - `executeRaw()`
 - `url()`
-- `build()`

--- a/packages/connectivity/src/scp-cf/identity-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/identity-service.spec.ts
@@ -11,7 +11,9 @@ describe('shouldExchangeToken', () => {
   });
 
   it('should exchange non-XSUAA token', async () => {
-    expect(shouldExchangeToken({ iasToXsuaaTokenExchange: true, jwt: signedJwt({}) })).toBe(true);
+    expect(
+      shouldExchangeToken({ iasToXsuaaTokenExchange: true, jwt: signedJwt({}) })
+    ).toBe(true);
   });
 
   it('should not exchange token, if there is no JWT given', async () => {

--- a/packages/connectivity/src/scp-cf/identity-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/identity-service.spec.ts
@@ -11,11 +11,11 @@ describe('shouldExchangeToken', () => {
   });
 
   it('should exchange non-XSUAA token', async () => {
-    expect(shouldExchangeToken({ jwt: signedJwt({}) })).toBe(true);
+    expect(shouldExchangeToken({ iasToXsuaaTokenExchange: true, jwt: signedJwt({}) })).toBe(true);
   });
 
   it('should not exchange token, if there is no JWT given', async () => {
-    expect(shouldExchangeToken({})).toBe(false);
+    expect(shouldExchangeToken({ iasToXsuaaTokenExchange: true })).toBe(false);
   });
 
   it('should not exchange token, if `iasToXsuaaTokenExchange` is disabled', async () => {

--- a/packages/connectivity/src/scp-cf/identity-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/identity-service.spec.ts
@@ -26,4 +26,12 @@ describe('shouldExchangeToken', () => {
       })
     ).toBe(false);
   });
+
+  it('should not exchange token, if `iasToXsuaaTokenExchange` is undefined', async () => {
+    expect(
+      shouldExchangeToken({
+        jwt: signedJwt({})
+      })
+    ).toBe(false);
+  });
 });

--- a/packages/connectivity/src/scp-cf/identity-service.ts
+++ b/packages/connectivity/src/scp-cf/identity-service.ts
@@ -19,9 +19,9 @@ export async function exchangeToken(jwt: string): Promise<string> {
  * @returns A boolean value, that indicates whether the token exchange should be applied.
  */
 export function shouldExchangeToken(options: DestinationOptions): boolean {
-  // iasToXsuaaTokenExchange is optional, token exchange is enabled by default
+  // iasToXsuaaTokenExchange is optional, token exchange is disabled by default
   return (
-    options.iasToXsuaaTokenExchange !== false &&
+    options.iasToXsuaaTokenExchange === true &&
     !!options.jwt &&
     !isXsuaaToken(decodeJwt(options.jwt))
   );


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Relates to SAP/ai-sdk-js-backlog#192.

- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [x] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
