### PR TITLE
fix: `Proxy-Authorization` token expired issue for cached destination

### DIFF
--- a/.changeset/salty-teams-follow.md
+++ b/.changeset/salty-teams-follow.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+---
+
+[Fixed Issue] Add `proxyConfiguration` on the fly to avoid expired proxy authorization token in cached destination if it lives shorter than the token for destination service.

--- a/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
@@ -54,32 +54,6 @@ describe('connectivity-service', () => {
     expect(serviceTokenSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('does not retrieve a new token if "Proxy-Authorization" header exists and its token is not expired', async () => {
-    jest.useFakeTimers().setSystemTime(0); // Set current time to Thu Jan 01 1970 00:00:00 GMT+0000
-    mockServiceBindings();
-    const serviceTokenSpy = mockServiceToken();
-
-    const token = signedJwtForVerification({
-      ...decodeJwt(providerServiceToken),
-      exp: 1 // Not expired yet
-    });
-
-    const input: Destination = {
-      url: 'https://example.com',
-      proxyType: 'OnPremise',
-      type: 'HTTP',
-      proxyConfiguration: {
-        ...connectivityProxyConfigMock,
-        headers: {
-          'Proxy-Authorization': `Bearer ${token}`
-        }
-      }
-    };
-
-    await addProxyConfigurationOnPrem(input);
-    expect(serviceTokenSpy).toHaveBeenCalledTimes(0);
-  });
-
   it('also contains the "SAP-Connectivity-Authentication" header if a JWT is present', async () => {
     mockServiceBindings();
     mockServiceToken();

--- a/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
@@ -12,13 +12,12 @@ import {
 } from '../../../../test-resources/test/test-util/mocked-access-tokens';
 import { mockServiceToken } from '../../../../test-resources/test/test-util/token-accessor-mocks';
 import { mockClientCredentialsGrantCall } from '../../../../test-resources/test/test-util/xsuaa-service-mocks';
-import { signedJwtForVerification } from '../../../../test-resources/test/test-util';
 import {
   addProxyConfigurationOnPrem,
   httpProxyHostAndPort
 } from './connectivity-service';
 import { getRequiredSubscriberToken } from './destination';
-import { decodeJwt, getJwtPair } from './jwt';
+import { getJwtPair } from './jwt';
 import type { Destination } from './destination';
 
 describe('connectivity-service', () => {

--- a/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../../test-resources/test/test-util/mocked-access-tokens';
 import { mockServiceToken } from '../../../../test-resources/test/test-util/token-accessor-mocks';
 import { mockClientCredentialsGrantCall } from '../../../../test-resources/test/test-util/xsuaa-service-mocks';
+import { signedJwtForVerification } from '../../../../test-resources/test/test-util';
 import {
   addProxyConfigurationOnPrem,
   httpProxyHostAndPort
@@ -19,7 +20,6 @@ import {
 import { getRequiredSubscriberToken } from './destination';
 import { decodeJwt, getJwtPair } from './jwt';
 import type { Destination } from './destination';
-import { signedJwtForVerification } from '../../../../test-resources/test/test-util';
 
 describe('connectivity-service', () => {
   afterEach(() => {

--- a/packages/connectivity/src/scp-cf/connectivity-service.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.ts
@@ -1,7 +1,6 @@
 import { createLogger, ErrorWithCause } from '@sap-cloud-sdk/util';
 import { getServiceBindings } from './environment-accessor';
 import { serviceToken } from './token-accessor';
-import { decodeJwt } from './jwt';
 import type { JwtPayload } from './jsonwebtoken-type';
 import type { Protocol } from './protocol';
 import type {

--- a/packages/connectivity/src/scp-cf/connectivity-service.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.ts
@@ -1,6 +1,7 @@
 import { createLogger, ErrorWithCause } from '@sap-cloud-sdk/util';
 import { getServiceBindings } from './environment-accessor';
 import { serviceToken } from './token-accessor';
+import { decodeJwt } from './jwt';
 import type { JwtPayload } from './jsonwebtoken-type';
 import type { Protocol } from './protocol';
 import type {
@@ -38,7 +39,28 @@ export async function addProxyConfigurationOnPrem(
     };
   }
 
-  const proxyConfiguration: ProxyConfiguration = {
+  // Get the proxy authorization token if it exists
+  const proxyAuthorizationToken =
+    destination.proxyConfiguration?.headers?.['Proxy-Authorization']?.match(
+      /^Bearer (.+)/
+    )?.[1];
+
+  let proxyConfiguration: ProxyConfiguration;
+  if (proxyAuthorizationToken) {
+    // Expiration time is a `NumericDate` value (seconds since the epoch), see https://tools.ietf.org/html/rfc7519#section-2
+    const exp = decodeJwt(proxyAuthorizationToken).exp;
+    // If the token is not expired, use the existing headers
+    if (exp && exp * 1000 > Date.now()) {
+      proxyConfiguration = {
+        ...httpProxyHostAndPort(),
+        headers: destination.proxyConfiguration?.headers
+      };
+      return { ...destination, proxyConfiguration };
+    }
+  }
+
+  // No token or token expired, get a new header
+  proxyConfiguration = {
     ...httpProxyHostAndPort(),
     headers: {
       ...(await proxyHeaders(destination.authentication, subscriberToken))

--- a/packages/connectivity/src/scp-cf/connectivity-service.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.ts
@@ -39,28 +39,7 @@ export async function addProxyConfigurationOnPrem(
     };
   }
 
-  // Get the proxy authorization token if it exists
-  const proxyAuthorizationToken =
-    destination.proxyConfiguration?.headers?.['Proxy-Authorization']?.match(
-      /^Bearer (.+)/
-    )?.[1];
-
-  let proxyConfiguration: ProxyConfiguration;
-  if (proxyAuthorizationToken) {
-    // Expiration time is a `NumericDate` value (seconds since the epoch), see https://tools.ietf.org/html/rfc7519#section-2
-    const exp = decodeJwt(proxyAuthorizationToken).exp;
-    // If the token is not expired, use the existing headers
-    if (exp && exp * 1000 > Date.now()) {
-      proxyConfiguration = {
-        ...httpProxyHostAndPort(),
-        headers: destination.proxyConfiguration?.headers
-      };
-      return { ...destination, proxyConfiguration };
-    }
-  }
-
-  // No token or token expired, get a new header
-  proxyConfiguration = {
+  const proxyConfiguration = {
     ...httpProxyHostAndPort(),
     headers: {
       ...(await proxyHeaders(destination.authentication, subscriberToken))

--- a/packages/connectivity/src/scp-cf/connectivity-service.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.ts
@@ -38,7 +38,7 @@ export async function addProxyConfigurationOnPrem(
     };
   }
 
-  const proxyConfiguration = {
+  const proxyConfiguration: ProxyConfiguration = {
     ...httpProxyHostAndPort(),
     headers: {
       ...(await proxyHeaders(destination.authentication, subscriberToken))

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -116,7 +116,7 @@ export class DestinationFromServiceRetriever {
     setForwardedAuthTokenIfNeeded(destination, options.jwt);
 
     if (destinationResult.fromCache) {
-      return destination;
+      return da.addProxyConfiguration(destination);
     }
 
     if (!destination.forwardAuthToken) {
@@ -153,13 +153,13 @@ export class DestinationFromServiceRetriever {
       }
     }
 
-    const withProxySetting = await da.addProxyConfiguration(destination);
     const withTrustStore = await da.addTrustStoreConfiguration(
-      withProxySetting,
+      destination,
       destinationResult.origin
     );
     await da.updateDestinationCache(withTrustStore, destinationResult.origin);
-    return withTrustStore;
+
+    return da.addProxyConfiguration(withTrustStore);
   }
 
   private static throwUserTokenMissing(destination) {


### PR DESCRIPTION
We do not cache destination with `proxyConfiguration` any more. The proxy configuration will be added every time after a destination is fetched from or not from cache. 

Client credential token is cached anyway already so no performance issue when keep calling `serviceToken()` to set proxy authorization token.

Closes SAP/cloud-sdk-backlog#1255.
Fix https://github.com/SAP/cloud-sdk-js/issues/5131

- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [x] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
