### PR TITLE
fix: `Proxy-Authorization` token expired issue for cached destination

### DIFF
--- a/.changeset/salty-teams-follow.md
+++ b/.changeset/salty-teams-follow.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+---
+
+[Fixed Issue] Add `proxyConfiguration` on the fly to avoid expired proxy authorization token in cached destination if it lives shorter than the token for destination service.

--- a/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
+++ b/packages/connectivity/src/scp-cf/connectivity-service.spec.ts
@@ -28,7 +28,7 @@ describe('connectivity-service', () => {
 
   it('adds a proxy configuration containing at least the host, the port, and the "Proxy-Authorization" header to a destination', async () => {
     mockServiceBindings();
-    mockServiceToken();
+    const serviceTokenSpy = mockServiceToken();
 
     const input: Destination = {
       url: 'https://example.com',
@@ -50,6 +50,7 @@ describe('connectivity-service', () => {
 
     const withProxy = await addProxyConfigurationOnPrem(input);
     expect(withProxy).toEqual(expected);
+    expect(serviceTokenSpy).toHaveBeenCalledTimes(1);
   });
 
   it('also contains the "SAP-Connectivity-Authentication" header if a JWT is present', async () => {

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -116,7 +116,7 @@ export class DestinationFromServiceRetriever {
     setForwardedAuthTokenIfNeeded(destination, options.jwt);
 
     if (destinationResult.fromCache) {
-      return destination;
+      return da.addProxyConfiguration(destination);
     }
 
     if (!destination.forwardAuthToken) {
@@ -153,13 +153,13 @@ export class DestinationFromServiceRetriever {
       }
     }
 
-    const withProxySetting = await da.addProxyConfiguration(destination);
     const withTrustStore = await da.addTrustStoreConfiguration(
-      withProxySetting,
+      destination,
       destinationResult.origin
     );
     await da.updateDestinationCache(withTrustStore, destinationResult.origin);
-    return withTrustStore;
+
+    return da.addProxyConfiguration(withTrustStore);
   }
 
   private static throwUserTokenMissing(destination) {


### PR DESCRIPTION
Cherry pick #5563.

Closes SAP/cloud-sdk-backlog#1255.

- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [x] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
