### PR TITLE
fix: Json stringify Axios error response data

### DIFF
--- a/packages/util/src/error-with-cause.spec.ts
+++ b/packages/util/src/error-with-cause.spec.ts
@@ -1,4 +1,5 @@
 import { ErrorWithCause } from './error-with-cause';
+import type { AxiosError } from 'axios';
 
 describe('ErrorWithCause', () => {
   it('creates an error', () => {
@@ -31,5 +32,31 @@ describe('ErrorWithCause', () => {
         "name": "ErrorWithCause"
       }"
     `);
+  });
+
+  it('adds Axios error to stack', () => {
+    const axiosError: AxiosError = {
+      message: "Request failed with status code 400",
+      name: "AxiosError",
+      stack: "AxiosError: Request failed with status code 400",
+      code: "ERR_BAD_REQUEST",
+      status: 400,
+      response: {
+        data: {
+          my_error: {
+            my_code: 'Four Hundred',
+            my_message: 'This is a bad request',
+          }
+        }
+      } as any,
+      isAxiosError: true,
+      toJSON: () => ({}),
+    };
+    const err = new ErrorWithCause('message', axiosError);
+    expect(err.stack).toContain('ErrorWithCause: message');
+    expect(err.stack).toContain('at ');
+    expect(err.stack).toContain('Caused by:');
+    expect(err.stack).toContain('HTTP Response: Request failed with status code 400');
+    expect(err.stack).toContain('Four Hundred');
   });
 });


### PR DESCRIPTION
This issue was found when working on SAP/ai-sdk-js-backlog#235.

If `error.response.data` is an object, it leads to the following error stack, which is not helpful at all

```txt
...
Caused by:
HTTP Response: Request failed with status code 400 - [object Object]
```

Relates to SAP/ai-sdk-js-backlog#235.

- [x] I know which base branch I chose for this PR, as the default branch is `v3-main` now, which is not for v4 development.
- [ ] If my change will be merged into the `main` branch (for v4), I've updated (V4-Upgrade-Guide.md)[./V4-Upgrade-Guide.md] in case my change has any implications for users updating to SDK v4

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
