### PR TITLE
chore: Fix mock-fs flakiness

### DIFF
--- a/build-packages/check-pr/validators.spec.ts
+++ b/build-packages/check-pr/validators.spec.ts
@@ -20,7 +20,7 @@ describe('check-pr', () => {
     process.exitCode = 0;
   });
 
-  afterAll(() => mock.restore());
+  afterEach(() => mock.restore());
 
   describe('validateTitle', () => {
     it('should validate title with proper structure', async () => {

--- a/build-packages/check-pr/validators.spec.ts
+++ b/build-packages/check-pr/validators.spec.ts
@@ -6,16 +6,13 @@ const prTemplate = `unchanged PR template
 with multiple lines`;
 
 describe('check-pr', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     mock({
       '.github': {
         'PULL_REQUEST_TEMPLATE.md': prTemplate
       },
       'my-changeset.md': '[Fixed Issue] Something is fixed.'
     });
-  });
-
-  beforeEach(() => {
     jest.spyOn(github, 'getInput').mockReturnValue('my-changeset.md');
     process.exitCode = 0;
   });

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "postinstall": "yarn compile",
     "compile": "turbo run compile",
     "test": "turbo run test",
-    "test:unit": "turbo run test --filter=./packages/* --concurrency=1",
+    "test:unit": "turbo run test --filter=./packages/*",
     "test:build-packages": "turbo run test --filter=./build-packages/*",
     "test:integration": "turbo run test --filter=@sap-cloud-sdk/integration-tests",
     "test:type": "turbo run test --filter=@sap-cloud-sdk/type-tests",

--- a/packages/connectivity/src/http-agent/http-agent.spec.ts
+++ b/packages/connectivity/src/http-agent/http-agent.spec.ts
@@ -250,7 +250,7 @@ describe('getAgentConfig', () => {
 
   describe('mTLS', () => {
     describe('on CloudFoundry', () => {
-      beforeAll(() => {
+      beforeEach(() => {
         mock({
           'cf-crypto': {
             'cf-cert': certAsString,
@@ -259,7 +259,7 @@ describe('getAgentConfig', () => {
         });
       });
 
-      afterAll(() => {
+      afterEach(() => {
         mock.restore();
       });
 

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
@@ -35,7 +35,7 @@ const mailDestination: DestinationWithName = {
 
 describe('register-destination', () => {
   describe('with XSUAA service binding', () => {
-    beforeAll(() => {
+    beforeEach(() => {
       mockServiceBindings();
       mock({
         'cf-crypto': {
@@ -45,8 +45,11 @@ describe('register-destination', () => {
       });
     });
 
-    afterAll(() => {
+    afterEach(() => {
       mock.restore();
+    })
+
+    afterAll(() => {
       delete process.env.VCAP_SERVICES;
     });
 

--- a/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-registration.spec.ts
@@ -47,7 +47,7 @@ describe('register-destination', () => {
 
     afterEach(() => {
       mock.restore();
-    })
+    });
 
     afterAll(() => {
       delete process.env.VCAP_SERVICES;

--- a/packages/generator-common/src/compiler.spec.ts
+++ b/packages/generator-common/src/compiler.spec.ts
@@ -15,6 +15,8 @@ import type { CompilerOptions } from 'typescript';
 
 const { readFile, readdir } = promises;
 
+jest.setTimeout(30000)
+
 describe('compiler options', () => {
   const pathRootNodeModules = resolve(__dirname, '../../../node_modules');
   beforeEach(() => {

--- a/packages/generator-common/src/compiler.spec.ts
+++ b/packages/generator-common/src/compiler.spec.ts
@@ -120,7 +120,7 @@ describe('compilation', () => {
     prettierOptions: defaultPrettierConfig
   };
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     const rootNodeModules = resolve(__dirname, '../../../node_modules');
     const packageNodeModules = resolve(__dirname, '../node_modules');
     mock({
@@ -152,7 +152,7 @@ describe('compilation', () => {
     };
   }
 
-  afterAll(() => {
+  afterEach(() => {
     mock.restore();
   });
 

--- a/packages/generator-common/src/compiler.spec.ts
+++ b/packages/generator-common/src/compiler.spec.ts
@@ -15,7 +15,7 @@ import type { CompilerOptions } from 'typescript';
 
 const { readFile, readdir } = promises;
 
-jest.setTimeout(30000);
+jest.setTimeout(300000);
 
 describe('compiler options', () => {
   const pathRootNodeModules = resolve(__dirname, '../../../node_modules');

--- a/packages/generator-common/src/compiler.spec.ts
+++ b/packages/generator-common/src/compiler.spec.ts
@@ -15,7 +15,7 @@ import type { CompilerOptions } from 'typescript';
 
 const { readFile, readdir } = promises;
 
-jest.setTimeout(30000)
+jest.setTimeout(30000);
 
 describe('compiler options', () => {
   const pathRootNodeModules = resolve(__dirname, '../../../node_modules');

--- a/packages/generator/src/generator.spec.ts
+++ b/packages/generator/src/generator.spec.ts
@@ -42,7 +42,7 @@ describe('generator', () => {
 
   describe('common', () => {
     let project;
-    beforeAll(async () => {
+    beforeEach(async () => {
       mock({
         common: {},
         someDir: {},
@@ -66,7 +66,7 @@ describe('generator', () => {
       await generate(options);
     });
 
-    afterAll(() => mock.restore());
+    afterEach(() => mock.restore());
 
     it('fails if skip validation is not enabled', async () => {
       const options = createOptions({

--- a/test-packages/e2e-tests/test/odata-generator-cli.spec.ts
+++ b/test-packages/e2e-tests/test/odata-generator-cli.spec.ts
@@ -26,7 +26,7 @@ describe('OData generator CLI', () => {
   );
   const outputDirGenerateAll = resolve(__dirname, '../generation-e2e-test');
 
-  beforeAll(() => {
+  beforeEach(() => {
     mock({
       [inputDir]: mock.load(inputDir),
       [generatorCommon]: mock.load(generatorCommon),
@@ -37,7 +37,7 @@ describe('OData generator CLI', () => {
     });
   });
 
-  afterAll(() => {
+  afterEach(() => {
     mock.restore();
   });
 

--- a/test-packages/integration-tests/test/mtls.spec.ts
+++ b/test-packages/integration-tests/test/mtls.spec.ts
@@ -11,7 +11,7 @@ import type {
 import type { HttpDestination } from '@sap-cloud-sdk/connectivity';
 
 describe('mTLS on CloudFoundry', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     mock({
       'cf-crypto': {
         'cf-cert': 'my-cert',
@@ -23,7 +23,7 @@ describe('mTLS on CloudFoundry', () => {
     process.env.CF_INSTANCE_KEY = 'cf-crypto/cf-key';
   });
 
-  afterAll(() => {
+  afterEach(() => {
     mock.restore();
 
     delete process.env.CF_INSTANCE_CERT;


### PR DESCRIPTION
Our pipeline got flaky because some of the mock-fs logic is bleeding into other tests, to isolate tests as much as possible, all mocking is now beforeEach / afterEach, so that we prevent bleeding.

Also increased the client generation timeout, because the github runners seem to run into the timeout frequently.

Closes https://github.com/SAP/ai-sdk-js-backlog/issues/247
