### PR TITLE
fix: Downgrade `@stylistic/eslint-plugin` to `v3.1.0`

### DIFF
--- a/.changeset/tame-spoons-kiss.md
+++ b/.changeset/tame-spoons-kiss.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/eslint-config': patch
+---
+
+[Fixed Issue] Downgrade `@stylistic/eslint-plugin` to v3 as v4 is EMS-only.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
       # execa v6 needs ESM, see https://github.com/sindresorhus/execa/releases/tag/v6.0.0, we'll stay on v5 until we can use ESM
       - dependency-name: 'execa'
         update-types: ['version-update:semver-major']
+      # @stylistic/eslint-plugin v4 needs ESM, see https://github.com/eslint-stylistic/eslint-stylistic/releases/tag/v4.0.0, we'll stay on v3 until we can use ESM
+      - dependency-name: '@stylistic/eslint-plugin'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@eslint/js": "^9.21.0",
-    "@stylistic/eslint-plugin": "^4.2.0",
+    "@stylistic/eslint-plugin": "^3.1.0",
     "@typescript-eslint/parser": "^8.25.0",
     "eslint-config-prettier": "^10.0.2",
     "eslint-import-resolver-typescript": "^3.8.3",


### PR DESCRIPTION
`@stylistic/eslint-plugin` v4 (not Cloud SDK v4 😄 ) supports ESM only. [Release Note v4.0.0](https://github.com/eslint-stylistic/eslint-stylistic/releases/tag/v4.0.0) However, we are still on CJS. 

Also, starting from v4, they do not support legacy config but only flat config. But we currently support both config files. So if user uses legacy config and we upgrade to `@stylistic/eslint-plugin` v4, it will break.

Further discussion required for long-term support, but as for now, I will downgrade to v3.

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->

---
I will create a PR for SDK v3 as it also breaks their..
