### PR TITLE
fix: Remove destination cache when getting destinations from service binding

### DIFF
--- a/.changeset/twenty-ideas-sleep.md
+++ b/.changeset/twenty-ideas-sleep.md
@@ -2,4 +2,4 @@
 '@sap-cloud-sdk/connectivity': patch
 ---
 
-[Fixed Issue] Remove destination cache in `getDestinationFromServiceBinding()` function to let cached destinations retrieved in `getDestinationFromDestinationService()` function be added with `proxyConfiguration` property.
+[Fixed Issue] Remove destination cache in `getDestinationFromServiceBinding()` function to let cached destinations retrieved in `getDestinationFromDestinationService()` function be added with the `proxyConfiguration` property.

--- a/.changeset/twenty-ideas-sleep.md
+++ b/.changeset/twenty-ideas-sleep.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+---
+
+[Fixed Issue] Remove destination cache in `getDestinationFromServiceBinding()` function to let cached destinations retrieved in `getDestinationFromDestinationService()` function be added with `proxyConfiguration` property.

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
@@ -15,10 +15,10 @@ describe('vcap-service-destination', () => {
     mockServiceBindings();
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     delete process.env.VCAP_SERVICES;
-    jest.clearAllMocks();
     clientCredentialsTokenCache.clear();
+    jest.restoreAllMocks();
   });
 
   function getActualClientId(spyInstance: SpyInstance): string {

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.spec.ts
@@ -1,16 +1,12 @@
 import {
   mockServiceToken,
-  providerUserPayload,
   providerUserToken,
-  signedJwt,
-  signedJwtForVerification,
-  testTenants
+  signedJwt
 } from '../../../../../test-resources/test/test-util';
 import * as xsuaaService from '../xsuaa-service';
-import { decodeJwt } from '../jwt';
+import { clientCredentialsTokenCache } from '../client-credentials-token-cache';
 import { getDestination } from './destination-accessor';
 import { getDestinationFromServiceBinding } from './destination-from-vcap';
-import { clientCredentialsTokenCache } from '../client-credentials-token-cache';
 import SpyInstance = jest.SpyInstance;
 import type { Service } from '../environment-accessor';
 

--- a/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-vcap.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@sap-cloud-sdk/util';
-import { decodeJwt, decodeOrMakeJwt } from '../jwt';
+import { decodeJwt } from '../jwt';
 import { getServiceBindingByInstanceName } from '../environment-accessor';
 import {
   addProxyConfigurationInternet,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,12 +1677,12 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stylistic/eslint-plugin@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-4.1.0.tgz#8882a6fe307cc94022e4495720373e8a5652d60c"
-  integrity sha512-bytbL7qiici7yPyEiId0fGPK9kjQbzcPMj2aftPfzTCyJ/CRSKdtI+iVjM0LSGzGxfunflI+MDDU9vyIIeIpoQ==
+"@stylistic/eslint-plugin@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-3.1.0.tgz#a9f655c518f76bfc5feb46b467d0f06e511b289d"
+  integrity sha512-pA6VOrOqk0+S8toJYhQGv2MWpQQR0QpeUo9AhNkC49Y26nxBQ/nH1rta9bUU1rPw2fJ1zZEMV5oCX5AazT7J2g==
   dependencies:
-    "@typescript-eslint/utils" "^8.23.0"
+    "@typescript-eslint/utils" "^8.13.0"
     eslint-visitor-keys "^4.2.0"
     espree "^10.3.0"
     estraverse "^5.3.0"
@@ -2128,7 +2128,7 @@
     semver "^7.6.0"
     ts-api-utils "^2.0.1"
 
-"@typescript-eslint/utils@8.26.0", "@typescript-eslint/utils@^8.13.0", "@typescript-eslint/utils@^8.23.0":
+"@typescript-eslint/utils@8.26.0", "@typescript-eslint/utils@^8.13.0":
   version "8.26.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.0.tgz#845d20ed8378a5594e6445f54e53b972aee7b3e6"
   integrity sha512-2L2tU3FVwhvU14LndnQCA2frYC8JnPDVKyQtWFPf8IYFMt/ykEN1bPolNhNbCVgOmdzTlWdusCTKA/9nKrf8Ig==


### PR DESCRIPTION
Closes SAP/ai-sdk-js-backlog#256.

Fix user issue #5631.

In #5563, we cache only partial destination without `proxyConfiguration` to allow it being added on the fly after cache retrieval. This works well when calling `getDestinationFromDestinationService()` directly. 

However, since `searchServiceBindingForDestination()` and `getDestinationFromDestinationService()` are sharing one destination cache, and vcap search comes first, it intercepts the cache retrieval and causing `proxyConfiguration` being not added in `getDestinationFromDestinationService()`. 

My first thought was to separate the caches for both functions. But it is not possible because we export `setDestinationCache()` from `destination-cache.ts` to allow user using their own cache object. And we cannot clone such object. 

Therefore, I checked again and found out that, actually, destination cache is not needed for retrieval from service binding, because no request is sent to destination service. And the only request that potentially needs to be sent is inside the `serviceToken()` function to get a token from XSUAA service. And caching this token has already been covered with `clientCredentialsTokenCache`. 

Therefore, I don't see any performance downside when removing destination cache for getting destination from service binding. And this should solve the user issue.
