### PR TITLE
chore: Change from tj-actions/changed-files to step-security/changed-files

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Collect changed files
-        uses: tj-actions/changed-files@v46
+        uses: step-security/changed-files@v45.0.1
         id: changed-files
         with:
           files: |


### PR DESCRIPTION
As tj-actions owners did not prove to have safeguarded their organization, it is better to not trust the organization anymore.