### PR TITLE
chore: Fix openapi request builder test

### DIFF
--- a/packages/openapi/src/openapi-request-builder.spec.ts
+++ b/packages/openapi/src/openapi-request-builder.spec.ts
@@ -149,7 +149,7 @@ describe('openapi-request-builder', () => {
   });
 
   it('executes a request using the timeout', async () => {
-    const delayInResponse = 10;
+    const delayInResponse = 2000;
     const slowDestination = { url: 'https://example.com' };
     nock(slowDestination.url, {})
       .get('/with-delay')
@@ -163,18 +163,18 @@ describe('openapi-request-builder', () => {
         .execute(slowDestination);
 
     await expect(timeoutBelowDelay()).rejects.toThrow(
-      'Request to URL: https://example.com ran into a timeout after 5ms.'
+      'Request to URL: https://example.com ran into a timeout after 1000ms.'
     );
 
     const timeoutAboveDelay = () =>
       new OpenApiRequestBuilder('get', '/with-delay')
-        .middleware(timeout(delayInResponse * 10))
+        .middleware(timeout(delayInResponse * 2))
         .execute(slowDestination);
     await expect(timeoutAboveDelay()).resolves.not.toThrow();
   });
 
   it('executes a request using retry and timeout (using spread middleware overload)', async () => {
-    const delayInResponse = 10;
+    const delayInResponse = 2000;
     const slowDestination = { url: 'https://example.com' };
     nock(slowDestination.url, {})
       .get('/with-delay')
@@ -186,13 +186,13 @@ describe('openapi-request-builder', () => {
 
     const timeoutAboveDelay = () =>
       new OpenApiRequestBuilder('get', '/with-delay')
-        .middleware(retry(2), timeout(100))
+        .middleware(retry(2), timeout(3000))
         .execute(slowDestination);
     await expect(timeoutAboveDelay()).resolves.not.toThrow();
   }, 10000);
 
   it('executes a request using retry and timeout (using array middleware overload)', async () => {
-    const delayInResponse = 10;
+    const delayInResponse = 2000;
     const slowDestination = { url: 'https://example.com' };
     nock(slowDestination.url, {})
       .get('/with-delay')
@@ -204,10 +204,10 @@ describe('openapi-request-builder', () => {
 
     const timeoutAboveDelay = () =>
       new OpenApiRequestBuilder('get', '/with-delay')
-        .middleware([retry(2), timeout(100)])
+        .middleware([retry(2), timeout(3000)])
         .execute(slowDestination);
     await expect(timeoutAboveDelay()).resolves.not.toThrow();
-  });
+  }, 10000);
 
   it('executes a request using the (iss) to build a token instead of a user JWT', async () => {
     mockServiceBindings();


### PR DESCRIPTION
Cherry-pick #5648.

Closes SAP/ai-sdk-js-backlog#263.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
