### PR TITLE
chore: Adapt regex in merge and write changelog action

### DIFF
--- a/.github/actions/merge-and-write-changelogs/index.js
+++ b/.github/actions/merge-and-write-changelogs/index.js
@@ -42664,6 +42664,7 @@ function getSummary(matchedSummary) {
 }
 function parseContent(content, version, packageName) {
     // Explanation: https://regex101.com/r/ikvIaa/2
+    // Adapted ? to the original regex <commit>.*? to make it non-greedy
     const contentRegex = /- ((?<commit>.*?):) (\[(?<type>.*?)\])? ?(?<summary>[^]*?)(?=(\n- |\n### |$))/g;
     (0, core_1.info)(`parsing content for ${packageName} v${version}`);
     return [...content.matchAll(contentRegex)].map(({ groups }) => {

--- a/.github/actions/merge-and-write-changelogs/index.js
+++ b/.github/actions/merge-and-write-changelogs/index.js
@@ -23815,7 +23815,7 @@ module.exports = {
 
 
 const { parseSetCookie } = __nccwpck_require__(8915)
-const { stringify, getHeadersList } = __nccwpck_require__(3834)
+const { stringify } = __nccwpck_require__(3834)
 const { webidl } = __nccwpck_require__(4222)
 const { Headers } = __nccwpck_require__(6349)
 
@@ -23891,14 +23891,13 @@ function getSetCookies (headers) {
 
   webidl.brandCheck(headers, Headers, { strict: false })
 
-  const cookies = getHeadersList(headers).cookies
+  const cookies = headers.getSetCookie()
 
   if (!cookies) {
     return []
   }
 
-  // In older versions of undici, cookies is a list of name:value.
-  return cookies.map((pair) => parseSetCookie(Array.isArray(pair) ? pair[1] : pair))
+  return cookies.map((pair) => parseSetCookie(pair))
 }
 
 /**
@@ -24326,14 +24325,15 @@ module.exports = {
 /***/ }),
 
 /***/ 3834:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+/***/ ((module) => {
 
 "use strict";
 
 
-const assert = __nccwpck_require__(2613)
-const { kHeadersList } = __nccwpck_require__(6443)
-
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
 function isCTLExcludingHtab (value) {
   if (value.length === 0) {
     return false
@@ -24594,31 +24594,13 @@ function stringify (cookie) {
   return out.join('; ')
 }
 
-let kHeadersListNode
-
-function getHeadersList (headers) {
-  if (headers[kHeadersList]) {
-    return headers[kHeadersList]
-  }
-
-  if (!kHeadersListNode) {
-    kHeadersListNode = Object.getOwnPropertySymbols(headers).find(
-      (symbol) => symbol.description === 'headers list'
-    )
-
-    assert(kHeadersListNode, 'Headers cannot be parsed')
-  }
-
-  const headersList = headers[kHeadersListNode]
-  assert(headersList)
-
-  return headersList
-}
-
 module.exports = {
   isCTLExcludingHtab,
-  stringify,
-  getHeadersList
+  validateCookieName,
+  validateCookiePath,
+  validateCookieValue,
+  toIMFDate,
+  stringify
 }
 
 
@@ -28622,6 +28604,7 @@ const {
   isValidHeaderName,
   isValidHeaderValue
 } = __nccwpck_require__(5523)
+const util = __nccwpck_require__(9023)
 const { webidl } = __nccwpck_require__(4222)
 const assert = __nccwpck_require__(2613)
 
@@ -29175,6 +29158,9 @@ Object.defineProperties(Headers.prototype, {
   [Symbol.toStringTag]: {
     value: 'Headers',
     configurable: true
+  },
+  [util.inspect.custom]: {
+    enumerable: false
   }
 })
 
@@ -38351,6 +38337,20 @@ class Pool extends PoolBase {
       ? { ...options.interceptors }
       : undefined
     this[kFactory] = factory
+
+    this.on('connectionError', (origin, targets, error) => {
+      // If a connection error occurs, we remove the client from the pool,
+      // and emit a connectionError event. They will not be re-used.
+      // Fixes https://github.com/nodejs/undici/issues/3895
+      for (const target of targets) {
+        // Do not use kRemoveClient here, as it will close the client,
+        // but the client cannot be closed in this state.
+        const idx = this[kClients].indexOf(target)
+        if (idx !== -1) {
+          this[kClients].splice(idx, 1)
+        }
+      }
+    })
   }
 
   [kGetDispatcher] () {
@@ -42664,7 +42664,7 @@ function getSummary(matchedSummary) {
 }
 function parseContent(content, version, packageName) {
     // Explanation: https://regex101.com/r/ikvIaa/2
-    const contentRegex = /- ((?<commit>.*):) (\[(?<type>.*?)\])? ?(?<summary>[^]*?)(?=(\n- |\n### |$))/g;
+    const contentRegex = /- ((?<commit>.*?):) (\[(?<type>.*?)\])? ?(?<summary>[^]*?)(?=(\n- |\n### |$))/g;
     (0, core_1.info)(`parsing content for ${packageName} v${version}`);
     return [...content.matchAll(contentRegex)].map(({ groups }) => {
         const type = getMessageType(groups?.type);

--- a/build-packages/merge-and-write-changelogs/index.ts
+++ b/build-packages/merge-and-write-changelogs/index.ts
@@ -92,6 +92,7 @@ function parseContent(
   packageName: string
 ): Change[] {
   // Explanation: https://regex101.com/r/ikvIaa/2
+  // Adapted ? to the original regex <commit>.*? to make it non-greedy
   const contentRegex =
     /- ((?<commit>.*?):) (\[(?<type>.*?)\])? ?(?<summary>[^]*?)(?=(\n- |\n### |$))/g;
 

--- a/build-packages/merge-and-write-changelogs/index.ts
+++ b/build-packages/merge-and-write-changelogs/index.ts
@@ -93,7 +93,7 @@ function parseContent(
 ): Change[] {
   // Explanation: https://regex101.com/r/ikvIaa/2
   const contentRegex =
-    /- ((?<commit>.*):) (\[(?<type>.*?)\])? ?(?<summary>[^]*?)(?=(\n- |\n### |$))/g;
+    /- ((?<commit>.*?):) (\[(?<type>.*?)\])? ?(?<summary>[^]*?)(?=(\n- |\n### |$))/g;
 
   info(`parsing content for ${packageName} v${version}`);
 


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

`bump` script failed recently while trying to release the AI SDK because for the below changelog added:

```
- 627a152: [Compatibility Note] Removed deprecated models: 
- `text-embedding-ada-002`, use `text-embedding-3-small` or `text-embedding-3-large` instead. 
- `meta--llama3-70b-instruct`, use `meta--llama3.1-70b-instruct` instead. 
- `gpt-35-turbo`, use `gpt-4o-mini` instead. 
- `gpt-35-turbo-16k`, use `gpt-4o-mini` instead. - `gpt-4-32k`, use `gpt-4o` instead.
```
The action tries to greedily match the `:` and fails to determine the type i,e Compatibility Note.
This PR fixes the issue and matches the type and commit correctly.

I ran the script locally to see if the change is successful and the changelog is generated successfully.



<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
