### PR TITLE
fix: Add support for OData Version 4.0x

### DIFF
--- a/.changeset/vast-dots-yawn.md
+++ b/.changeset/vast-dots-yawn.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/generator': patch
+---
+
+Add fix for Version 4.01 and pattern matching 4.0x

--- a/packages/generator/src/edmx-parser/edmx-file-reader.ts
+++ b/packages/generator/src/edmx-parser/edmx-file-reader.ts
@@ -73,7 +73,8 @@ function parseEdmxFile(edmx: string, edmxPath: PathLike): EdmxMetadata {
 }
 
 function getODataVersion(edmx): ODataVersion {
-  return edmx['edmx:Edmx'].Version === '4.0' ? 'v4' : 'v2';
+  const odataV4VersionRegex = new RegExp('^4.0\\d{0,1}$'); // Regex for 4.0, 4.0X
+  return odataV4VersionRegex.test(edmx['edmx:Edmx'].Version) ? 'v4' : 'v2';
 }
 
 function getRoot(edmx) {


### PR DESCRIPTION
- Fixes #5726: Add supports for 4.0x based on regex during generation of client

<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#5762.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
