### PR TITLE
chore: Ignore major update for `yargs` due to ESM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,9 @@ updates:
       # @manypkg/get-packages v3 needs ESM, see https://github.com/Thinkmill/manypkg/releases/tag/%40manypkg%2Fget-packages%403.0.0, we'll stay on v2 until we can use ESM
       - dependency-name: '@manypkg/get-packages'
         update-types: ['version-update:semver-major']
+      # yargs v18 needs ESM, see https://github.com/yargs/yargs/releases/tag/v18.0.0, we'll stay on v17 until we can use ESM
+      - dependency-name: 'yargs'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
See https://github.com/SAP/cloud-sdk-js/pull/5815.

`yargs` v18 requires ESM.