### PR TITLE
fix: Support `TrustStoreLocation` OAuth2ClientCredentials in destination retrieval

### DIFF
--- a/.changeset/famous-snakes-doubt.md
+++ b/.changeset/famous-snakes-doubt.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+---
+
+[Fixed Issue] Support `TrustStoreLocation` for `OAuth2ClientCredentials` destinations.

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-proxy-configuration.spec.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../../../test-resources/test/test-util/mocked-access-tokens';
 import {
   basicMultipleResponse,
+  oauthClientCredentialsSingleResponse,
   onPremisePrincipalPropagationMultipleResponse
 } from '../../../../../test-resources/test/test-util/example-destination-service-responses';
 import { getDestination } from './destination-accessor';
@@ -178,6 +179,33 @@ describe('truststore configuration', () => {
     const actual = await getDestination({
       destinationName: 'TrustStoreDestination',
       jwt: providerUserToken,
+      selectionStrategy: alwaysProvider,
+      cacheVerificationKeys: false
+    });
+    expect(actual?.trustStoreCertificate).toEqual({
+      name: 'my-cert.pem',
+      content: expect.any(String),
+      type: 'CERTIFICATE'
+    });
+  });
+
+  it('returns a destination with truststore for OAuth2ClientCredentials', async () => {
+    const destinationWithTrustStore = {
+      ...oauthClientCredentialsSingleResponse,
+      destinationConfiguration: {
+        ...oauthClientCredentialsSingleResponse.destinationConfiguration,
+        TrustStoreLocation: 'my-cert.pem'
+      }
+    };
+    mockCertificateCall('my-cert.pem', providerServiceToken, 'subaccount');
+    mockServiceBindings();
+    mockServiceToken();
+    mockJwtBearerToken();
+
+    mockFetchDestinationCalls(destinationWithTrustStore);
+
+    const actual = await getDestination({
+      destinationName: 'FINAL-DESTINATION',
       selectionStrategy: alwaysProvider,
       cacheVerificationKeys: false
     });

--- a/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-from-service.ts
@@ -581,13 +581,17 @@ Possible alternatives for such technical user authentication are BasicAuthentica
     destination: Destination,
     origin: DestinationOrigin
   ): Promise<Destination> {
-    if (destination.originalProperties?.TrustStoreLocation) {
+    const originalProperties = destination.originalProperties;
+    const trustStoreLocation =
+      originalProperties?.TrustStoreLocation ||
+      originalProperties?.destinationConfiguration?.TrustStoreLocation;
+    if (trustStoreLocation) {
       const trustStoreCertificate = await fetchCertificate(
         getDestinationServiceCredentials().uri,
         origin === 'provider'
           ? this.providerServiceToken.encoded
           : this.subscriberToken!.serviceJwt!.encoded,
-        destination.originalProperties.TrustStoreLocation
+        trustStoreLocation
       );
       destination.trustStoreCertificate = trustStoreCertificate;
     }


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes #6412

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
