### PR TITLE
chore: widen dependency versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 4
+    versioning-strategy: widen
     ignore:
       # We only want to do major node updates on purpose, so don't create dependabot PRs for major versions
       - dependency-name: '@types/node'


### PR DESCRIPTION
I noticed that this is not configured correctly for a lib. I am pretty sure we already had configured this versioning strategy. If it was removed on purpose, please let me know why.