### PR TITLE
chore: Fix user on bump

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -53,6 +53,8 @@ jobs:
         uses: ./.github/actions/commit-and-tag
         with:
           version: ${{ steps.bump.outputs.version }}
+          user-email: ${{ secrets.SAP_CLOUD_SDK_BOT_EMAIL }}
+          user-name: ${{ secrets.SAP_CLOUD_SDK_BOT_NAME }}
 
   generate-api-docs:
     name: Generate and Push API Documentation

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -53,8 +53,8 @@ jobs:
         uses: ./.github/actions/commit-and-tag
         with:
           version: ${{ steps.bump.outputs.version }}
-          user-email: ${{ secrets.SAP_CLOUD_SDK_BOT_EMAIL }}
-          user-name: ${{ secrets.SAP_CLOUD_SDK_BOT_NAME }}
+          user-email: ${{ vars.SAP_CLOUD_SDK_BOT_EMAIL }}
+          user-name: ${{ vars.SAP_CLOUD_SDK_BOT_NAME }}
 
   generate-api-docs:
     name: Generate and Push API Documentation


### PR DESCRIPTION
The bump on release didn't work, because the GH user was incorrect and declined by the branch protection rules.