### PR TITLE
chore: Remove SANDBOX_TOKEN from unit test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,6 @@ jobs:
           cache: 'yarn'
       - run: yarn install --frozen-lockfile --ignore-engines
       - run: yarn test:unit
-        env:
-          SANDBOX_TOKEN: ${{ secrets.API_HUB_SANDBOX_TOKEN }}
       - run: yarn test:integration
       - run: yarn test:self
       - run: yarn test:build-packages


### PR DESCRIPTION
Removed SANDBOX_TOKEN environment variable from unit tests.

Just noticed this accidentally. I believe this is no longer used.