### PR TITLE
chore: Exclude dependabot from registry URL assignment in action setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -43,11 +43,12 @@ runs:
         REGISTRY_URL: ${{ inputs.registry-url }}
         REGISTRY_TOKEN: ${{ inputs.registry-token }}
         REPO: ${{ github.repository }}
+        ACTOR: ${{ github.actor }}
       shell: bash
       run: |
         if [[ -n "$REGISTRY_URL" ]]; then
           echo "url=$REGISTRY_URL" >> $GITHUB_OUTPUT
-        elif [[ "$REPO" == "SAP/ai-sdk-js" || "$REPO" == "SAP/cloud-sdk-js" ]]; then
+        elif [[ "$REPO" == "SAP/ai-sdk-js" || "$REPO" == "SAP/cloud-sdk-js" ]] && [[ "$ACTOR" != "dependabot[bot]" ]]; then
           if [[ -n "$REGISTRY_TOKEN" ]]; then
             echo "url=https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

From what I can tell, dependabot-triggered workflows don't have access to secrets.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
