### PR TITLE
chore: Re-enable sap-artifactory registry in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ registries:
   sap-artifactory:
     type: npm-registry
     url: https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/
-    token: ${{secrets.NPM_TOKEN_ARTIFACTORY}}
+    token: ${{secrets.DBOT_NPM_TOKEN_ARTIFACTORY}}
     replaces-base: true
 updates:
   - package-ecosystem: npm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,15 @@
 version: 2
 registries:
-  # sap-artifactory:
-  #   type: npm-registry
-  #   url: https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/
-  #   token: ${{secrets.NPM_TOKEN_ARTIFACTORY}}
-  #   replaces-base: true
+  sap-artifactory:
+    type: npm-registry
+    url: https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/
+    token: ${{secrets.NPM_TOKEN_ARTIFACTORY}}
+    replaces-base: true
 updates:
   - package-ecosystem: npm
     target-branch: main
-    # registries:
-    #   - sap-artifactory
+    registries:
+      - sap-artifactory
     directory: '/'
     schedule:
       interval: daily


### PR DESCRIPTION
This reverts commit 081c446ae3da57370265dfac881f3048cfdfed0d.

<!-- Please provide a description of what your change does and why it is needed. -->

I've now added a non-action dependabot secret, which dependabot should be able to access.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
