### PR TITLE
feat: Inherit Content-Type from `Blob` bodies

### DIFF
--- a/.changeset/ripe-papers-open.md
+++ b/.changeset/ripe-papers-open.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/openapi': minor
+---
+
+[New Functionality] For `Blob` bodies in HTTP-requests, use the `Blob`'s `Content-Type` as the request's `Content-Type` by default.

--- a/packages/openapi/src/openapi-request-builder.spec.ts
+++ b/packages/openapi/src/openapi-request-builder.spec.ts
@@ -155,7 +155,9 @@ describe('openapi-request-builder', () => {
     expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(
       sanitizeDestination(destination),
       expect.objectContaining({
-        headers: { requestConfig: { 'content-type': 'application/octet-stream' } },
+        headers: {
+          requestConfig: { 'content-type': 'application/octet-stream' }
+        },
         data: blob
       }),
       expect.anything()

--- a/packages/openapi/src/openapi-request-builder.spec.ts
+++ b/packages/openapi/src/openapi-request-builder.spec.ts
@@ -146,6 +146,55 @@ describe('openapi-request-builder', () => {
     );
   });
 
+  it('uses Blob content-type as content-type header when body is a Blob with a type', async () => {
+    const blob = new Blob(['<data>'], { type: 'application/octet-stream' });
+    const requestBuilder = new OpenApiRequestBuilder('post', '/test', {
+      body: blob
+    });
+    await requestBuilder.executeRaw(destination);
+    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(
+      sanitizeDestination(destination),
+      expect.objectContaining({
+        headers: { requestConfig: { 'content-type': 'application/octet-stream' } },
+        data: blob
+      }),
+      expect.anything()
+    );
+  });
+
+  it('does not override explicit content-type header when body is a Blob', async () => {
+    const blob = new Blob(['<data>'], { type: 'application/octet-stream' });
+    const requestBuilder = new OpenApiRequestBuilder('post', '/test', {
+      body: blob,
+      headerParameters: { 'content-type': 'application/xml' }
+    });
+    await requestBuilder.executeRaw(destination);
+    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(
+      sanitizeDestination(destination),
+      expect.objectContaining({
+        headers: { requestConfig: { 'content-type': 'application/xml' } },
+        data: blob
+      }),
+      expect.anything()
+    );
+  });
+
+  it('does not set content-type header when Blob has no type', async () => {
+    const blob = new Blob(['<data>']);
+    const requestBuilder = new OpenApiRequestBuilder('post', '/test', {
+      body: blob
+    });
+    await requestBuilder.executeRaw(destination);
+    expect(httpClient.executeHttpRequest).toHaveBeenCalledWith(
+      sanitizeDestination(destination),
+      expect.objectContaining({
+        headers: { requestConfig: {} },
+        data: blob
+      }),
+      expect.anything()
+    );
+  });
+
   it('executes a request with multipart body using executeRaw', async () => {
     const requestBuilder = new OpenApiRequestBuilder('post', '/test', {
       body: {

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -376,7 +376,16 @@ export class OpenApiRequestBuilder<ResponseT = any> {
   }
 
   private getHeaders(): OriginOptions {
-    const options = { requestConfig: this.parameters?.headerParameters || {} };
+    const headerParameters = { ...(this.parameters?.headerParameters || {}) };
+    const body = this.parameters?.body;
+    if (
+      body instanceof Blob &&
+      body.type &&
+      !pickValueIgnoreCase(headerParameters, 'content-type')
+    ) {
+      headerParameters['content-type'] = body.type;
+    }
+    const options = { requestConfig: headerParameters };
     if (Object.keys(this.customHeaders).length) {
       return { custom: this.customHeaders, ...options };
     }


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Related https://github.com/SAP/ai-sdk/pull/464

Should improve batch API UX.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
