### PR TITLE
chore: Support changeset type shorthands via shared source of truth

### DIFF
--- a/.github/actions/check-pr/index.js
+++ b/.github/actions/check-pr/index.js
@@ -36259,8 +36259,44 @@ function getOctokit(token, options, ...additionalPlugins) {
 const promises_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:fs/promises");
 ;// CONCATENATED MODULE: external "node:path"
 const external_node_path_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("node:path");
-;// CONCATENATED MODULE: ./lib/validators.js
+;// CONCATENATED MODULE: ./lib/changeset-types.js
 /* eslint-disable jsdoc/require-jsdoc */
+const messageTypes = [
+    {
+        name: 'compat',
+        title: 'Compatibility Notes',
+        alternatives: ['compatibility', 'compatibility note', 'compat']
+    },
+    {
+        name: 'feat',
+        title: 'New Features',
+        alternatives: ['new', 'new functionality', 'feat']
+    },
+    {
+        name: 'fix',
+        title: 'Fixed Issues',
+        alternatives: ['bug', 'bug fix', 'fixed issue', 'fix', 'fix issue']
+    },
+    {
+        name: 'known-issue',
+        title: 'Known Issues',
+        alternatives: ['known issue']
+    },
+    {
+        name: 'impr',
+        title: 'Improvements',
+        alternatives: ['improvement', 'improv']
+    },
+    {
+        name: 'dep',
+        title: 'Updated Dependencies',
+        alternatives: ['dependency', 'dependency update']
+    }
+];
+
+;// CONCATENATED MODULE: ./lib/check-pr/validators.js
+/* eslint-disable jsdoc/require-jsdoc */
+
 
 
 
@@ -36327,13 +36363,10 @@ async function extractChangesetFileContents() {
 }
 function validateChangesets(preamble, commitType, isBreaking, fileContents) {
     const allowedBumps = getAllowedBumps(commitType, isBreaking);
-    const allowedChangeTypes = [
-        'Known Issue',
-        'Compatibility Note',
-        'New Functionality',
-        'Improvement',
-        'Fixed Issue'
-    ];
+    const allAllowedTypes = messageTypes.flatMap(({ name, alternatives }) => [
+        name,
+        ...alternatives
+    ]);
     if (!hasMatchingChangeset(allowedBumps, fileContents)) {
         return setFailed(`Preamble '${preamble}' requires a changeset file with bump ${allowedBumps
             .map(bump => `'${bump}'`)
@@ -36346,11 +36379,9 @@ function validateChangesets(preamble, commitType, isBreaking, fileContents) {
     if (!preamble.startsWith('chore') && !changeTypes.length) {
         return setFailed('Missing change type in changeset.');
     }
-    const allChangeTypesMatch = changeTypes.every(type => allowedChangeTypes.includes(type));
+    const allChangeTypesMatch = changeTypes.every(type => allAllowedTypes.includes(type.toLowerCase()));
     if (!allChangeTypesMatch) {
-        return setFailed(`All change types must match one of the allowed change types ${allowedChangeTypes
-            .map(type => `'[${type}]'`)
-            .join(' or ')}.`);
+        return setFailed(`All change types must be one of: ${messageTypes.map(({ name }) => `'${name}'`).join(', ')} (or their aliases).`);
     }
     info('✓ Changesets: OK');
 }
@@ -36365,7 +36396,7 @@ async function validateBody(body) {
     info('✓ Body: OK');
 }
 
-;// CONCATENATED MODULE: ./lib/index.js
+;// CONCATENATED MODULE: ./lib/check-pr/index.js
 
 
 

--- a/.github/actions/check-pr/index.js
+++ b/.github/actions/check-pr/index.js
@@ -36301,6 +36301,7 @@ const messageTypes = [
 
 
 const validCommitTypes = ['feat', 'fix', 'chore'];
+const allAllowedChangeTypes = new Set(messageTypes.flatMap(({ name, alternatives }) => [name, ...alternatives]));
 // Expected format: preamble(topic)!: Title text
 async function validateTitle(title) {
     if (!title || !title.includes(':')) {
@@ -36363,10 +36364,6 @@ async function extractChangesetFileContents() {
 }
 function validateChangesets(preamble, commitType, isBreaking, fileContents) {
     const allowedBumps = getAllowedBumps(commitType, isBreaking);
-    const allAllowedTypes = messageTypes.flatMap(({ name, alternatives }) => [
-        name,
-        ...alternatives
-    ]);
     if (!hasMatchingChangeset(allowedBumps, fileContents)) {
         return setFailed(`Preamble '${preamble}' requires a changeset file with bump ${allowedBumps
             .map(bump => `'${bump}'`)
@@ -36379,7 +36376,7 @@ function validateChangesets(preamble, commitType, isBreaking, fileContents) {
     if (!preamble.startsWith('chore') && !changeTypes.length) {
         return setFailed('Missing change type in changeset.');
     }
-    const allChangeTypesMatch = changeTypes.every(type => allAllowedTypes.includes(type.toLowerCase()));
+    const allChangeTypesMatch = changeTypes.every(type => allAllowedChangeTypes.has(type.toLowerCase()));
     if (!allChangeTypesMatch) {
         return setFailed(`All change types must be one of: ${messageTypes.map(({ name }) => `'${name}'`).join(', ')} (or their aliases).`);
     }

--- a/.github/actions/merge-and-write-changelogs/index.js
+++ b/.github/actions/merge-and-write-changelogs/index.js
@@ -46242,12 +46242,8 @@ function getIDToken(aud) {
 //# sourceMappingURL=core.js.map
 // EXTERNAL MODULE: ../../node_modules/.pnpm/@manypkg+get-packages@2.2.2/node_modules/@manypkg/get-packages/dist/manypkg-get-packages.cjs.js
 var manypkg_get_packages_cjs = __nccwpck_require__(4344);
-;// CONCATENATED MODULE: ./lib/build-packages/merge-and-write-changelogs/index.js
+;// CONCATENATED MODULE: ./lib/build-packages/changeset-types.js
 /* eslint-disable jsdoc/require-jsdoc */
-
-
-
-
 const messageTypes = [
     {
         name: 'compat',
@@ -46265,6 +46261,11 @@ const messageTypes = [
         alternatives: ['bug', 'bug fix', 'fixed issue', 'fix', 'fix issue']
     },
     {
+        name: 'known-issue',
+        title: 'Known Issues',
+        alternatives: ['known issue']
+    },
+    {
         name: 'impr',
         title: 'Improvements',
         alternatives: ['improvement', 'improv']
@@ -46275,6 +46276,14 @@ const messageTypes = [
         alternatives: ['dependency', 'dependency update']
     }
 ];
+
+;// CONCATENATED MODULE: ./lib/build-packages/merge-and-write-changelogs/index.js
+/* eslint-disable jsdoc/require-jsdoc */
+
+
+
+
+
 function getPackageName(changelog) {
     return changelog.split('\n')[0].split('/')[1];
 }

--- a/build-packages/changeset-types.ts
+++ b/build-packages/changeset-types.ts
@@ -1,0 +1,35 @@
+/* eslint-disable jsdoc/require-jsdoc */
+export const messageTypes = [
+  {
+    name: 'compat',
+    title: 'Compatibility Notes',
+    alternatives: ['compatibility', 'compatibility note', 'compat']
+  },
+  {
+    name: 'feat',
+    title: 'New Features',
+    alternatives: ['new', 'new functionality', 'feat']
+  },
+  {
+    name: 'fix',
+    title: 'Fixed Issues',
+    alternatives: ['bug', 'bug fix', 'fixed issue', 'fix', 'fix issue']
+  },
+  {
+    name: 'known-issue',
+    title: 'Known Issues',
+    alternatives: ['known issue']
+  },
+  {
+    name: 'impr',
+    title: 'Improvements',
+    alternatives: ['improvement', 'improv']
+  },
+  {
+    name: 'dep',
+    title: 'Updated Dependencies',
+    alternatives: ['dependency', 'dependency update']
+  }
+];
+
+export type MessageType = (typeof messageTypes)[number];

--- a/build-packages/check-pr/package.json
+++ b/build-packages/check-pr/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "compile": "tsc -p tsconfig.json",
-    "postcompile": "ncc build lib/index.js --out ../../.github/actions/check-pr/",
+    "postcompile": "ncc build lib/check-pr/index.js --out ../../.github/actions/check-pr/",
     "test": "pnpm run test:unit",
     "test:unit": "NODE_OPTIONS=--experimental-vm-modules pnpm exec jest",
     "lint": "eslint --ignore-pattern '!index.ts' && prettier --check **/*.ts",

--- a/build-packages/check-pr/tsconfig.json
+++ b/build-packages/check-pr/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
+    "rootDir": "..",
     "outDir": "./lib",
     "tsBuildInfoFile": "./lib/.tsbuildinfo"
   },

--- a/build-packages/check-pr/validators.spec.ts
+++ b/build-packages/check-pr/validators.spec.ts
@@ -124,12 +124,30 @@ describe('check-pr', () => {
     it('should fail if change type is wrong', async () => {
       const fileContents = [
         "'@sap-cloud-sdk/generator': major",
-        '[Fix] Something is fixed.'
+        '[Something] Something is fixed.'
       ];
       validateChangesets('chore!', '', true, fileContents);
       expect(setFailed).toHaveBeenCalledWith(
-        "All change types must match one of the allowed change types '[Known Issue]' or '[Compatibility Note]' or '[New Functionality]' or '[Improvement]' or '[Fixed Issue]'."
+        "All change types must be one of: 'compat', 'feat', 'fix', 'known-issue', 'impr', 'dep' (or their aliases)."
       );
+    });
+
+    it('should pass if shorthand change type is provided', async () => {
+      const fileContents = [
+        "'@sap-cloud-sdk/generator': major",
+        '[fix] Something is fixed.'
+      ];
+      validateChangesets('chore!', '', true, fileContents);
+      expect(setFailed).not.toHaveBeenCalled();
+    });
+
+    it('should pass if compat shorthand change type is provided', async () => {
+      const fileContents = [
+        "'@sap-cloud-sdk/generator': major",
+        '[compat] Something changed.'
+      ];
+      validateChangesets('chore!', '', true, fileContents);
+      expect(setFailed).not.toHaveBeenCalled();
     });
 
     it('should pass if correct change type is provided', async () => {

--- a/build-packages/check-pr/validators.ts
+++ b/build-packages/check-pr/validators.ts
@@ -5,6 +5,9 @@ import { getInput, setFailed, info } from '@actions/core';
 import { messageTypes } from '../changeset-types.js';
 
 const validCommitTypes = ['feat', 'fix', 'chore'];
+const allAllowedChangeTypes = new Set(
+  messageTypes.flatMap(({ name, alternatives }) => [name, ...alternatives])
+);
 
 // Expected format: preamble(topic)!: Title text
 export async function validateTitle(title: string | undefined): Promise<void> {
@@ -116,10 +119,6 @@ export function validateChangesets(
   fileContents: string[]
 ): void {
   const allowedBumps = getAllowedBumps(commitType, isBreaking);
-  const allAllowedTypes = messageTypes.flatMap(({ name, alternatives }) => [
-    name,
-    ...alternatives
-  ]);
 
   if (!hasMatchingChangeset(allowedBumps, fileContents)) {
     return setFailed(
@@ -139,7 +138,7 @@ export function validateChangesets(
   }
 
   const allChangeTypesMatch = changeTypes.every(type =>
-    allAllowedTypes.includes(type.toLowerCase())
+    allAllowedChangeTypes.has(type.toLowerCase())
   );
 
   if (!allChangeTypesMatch) {

--- a/build-packages/check-pr/validators.ts
+++ b/build-packages/check-pr/validators.ts
@@ -2,6 +2,7 @@
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { getInput, setFailed, info } from '@actions/core';
+import { messageTypes } from '../changeset-types.js';
 
 const validCommitTypes = ['feat', 'fix', 'chore'];
 
@@ -115,13 +116,10 @@ export function validateChangesets(
   fileContents: string[]
 ): void {
   const allowedBumps = getAllowedBumps(commitType, isBreaking);
-  const allowedChangeTypes = [
-    'Known Issue',
-    'Compatibility Note',
-    'New Functionality',
-    'Improvement',
-    'Fixed Issue'
-  ];
+  const allAllowedTypes = messageTypes.flatMap(({ name, alternatives }) => [
+    name,
+    ...alternatives
+  ]);
 
   if (!hasMatchingChangeset(allowedBumps, fileContents)) {
     return setFailed(
@@ -141,14 +139,12 @@ export function validateChangesets(
   }
 
   const allChangeTypesMatch = changeTypes.every(type =>
-    allowedChangeTypes.includes(type)
+    allAllowedTypes.includes(type.toLowerCase())
   );
 
   if (!allChangeTypesMatch) {
     return setFailed(
-      `All change types must match one of the allowed change types ${allowedChangeTypes
-        .map(type => `'[${type}]'`)
-        .join(' or ')}.`
+      `All change types must be one of: ${messageTypes.map(({ name }) => `'${name}'`).join(', ')} (or their aliases).`
     );
   }
 

--- a/build-packages/merge-and-write-changelogs/index.ts
+++ b/build-packages/merge-and-write-changelogs/index.ts
@@ -3,36 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { setFailed, info } from '@actions/core';
 import { getPackages } from '@manypkg/get-packages';
-
-const messageTypes = [
-  {
-    name: 'compat',
-    title: 'Compatibility Notes',
-    alternatives: ['compatibility', 'compatibility note', 'compat']
-  },
-  {
-    name: 'feat',
-    title: 'New Features',
-    alternatives: ['new', 'new functionality', 'feat']
-  },
-  {
-    name: 'fix',
-    title: 'Fixed Issues',
-    alternatives: ['bug', 'bug fix', 'fixed issue', 'fix', 'fix issue']
-  },
-  {
-    name: 'impr',
-    title: 'Improvements',
-    alternatives: ['improvement', 'improv']
-  },
-  {
-    name: 'dep',
-    title: 'Updated Dependencies',
-    alternatives: ['dependency', 'dependency update']
-  }
-];
-
-type MessageType = (typeof messageTypes)[number];
+import { messageTypes, type MessageType } from '../changeset-types.js';
 
 interface Change {
   packageNames: string[];

--- a/build-packages/package.json
+++ b/build-packages/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/ai-sdk-js-backlog/issues/556.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
