### PR TITLE
chore: Add warning logs for cross-host CSRF and iss-based destination fetch

### DIFF
--- a/.changeset/warn-cross-host-csrf.md
+++ b/.changeset/warn-cross-host-csrf.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/http-client': patch
+---
+
+[Fixed Issue] Warn when the CSRF token fetch URL has a different host than the request URL, as sensitive headers would be forwarded to the cross-host endpoint.

--- a/.github/actions/check-public-api/index.js
+++ b/.github/actions/check-public-api/index.js
@@ -68446,8 +68446,24 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.isValidUrl = isValidUrl;
 exports.checkUrlExists = checkUrlExists;
 const axios_1 = __importDefault(__nccwpck_require__(1373));
+/**
+ * Checks whether a string is a valid URL.
+ * @param url - String to check.
+ * @returns True if the string is a valid URL, false otherwise.
+ * @internal
+ */
+function isValidUrl(url) {
+    try {
+        new URL(url);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
 /**
  * Checks whether a URL is existing via a head request.
  * @param url - URL to be checked.

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-provider-subscriber-lookup.spec.ts
@@ -287,7 +287,7 @@ describe('JWT type and selection strategies', () => {
         package: 'connectivity',
         messageContext: 'destination-accessor-service'
       });
-      const debugSpy = jest.spyOn(logger, 'debug');
+      const warnSpy = jest.spyOn(logger, 'warn');
 
       expect(
         await getDestinationFromDestinationService({
@@ -297,8 +297,9 @@ describe('JWT type and selection strategies', () => {
         })
       ).toMatchObject(parseDestination(certificateSingleResponse));
 
-      expect(debugSpy).toHaveBeenCalledWith(
-        'Using `iss` option instead of a full JWT to fetch a destination. No validation is performed.'
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Using `iss` option instead of a full JWT to fetch a destination. No validation is performed.' +
+          'Passing a user-supplied value without verifying it may lead to unintended cross-tenant destination access.'
       );
     });
 

--- a/packages/connectivity/src/scp-cf/destination/destination-accessor-types.ts
+++ b/packages/connectivity/src/scp-cf/destination/destination-accessor-types.ts
@@ -74,7 +74,10 @@ export interface DestinationAccessorOptions {
    * The value for `iss` is the issuer field of a JWT e.g. https://<your-subdomain>.localhost:8080/uaa/oauth/token.
    *
    * ATTENTION: If this property is used, no validation of the provided subdomain value is done.
-   * This is differs from how the `jwt` is handled.
+   * This differs from how the `jwt` is handled.
+   * Never pass a user-supplied or request-derived value directly to this field without verification.
+   * An unvalidated `iss` value controls which BTP tenant's destinations (including embedded credentials and
+   * OAuth tokens) are returned, enabling cross-tenant data access if an attacker can influence this value.
    * So be careful that the used value is not manipulated and breaks the tenant isolation of your application.
    */
   iss?: string;

--- a/packages/connectivity/src/scp-cf/destination/get-subscriber-token.ts
+++ b/packages/connectivity/src/scp-cf/destination/get-subscriber-token.ts
@@ -76,8 +76,9 @@ async function retrieveServiceToken(
 
 function getJwtForServiceToken(iss?: string, decodedUserJwt?: JwtPayload) {
   if (iss) {
-    logger.debug(
-      'Using `iss` option instead of a full JWT to fetch a destination. No validation is performed.'
+    logger.warn(
+      'Using `iss` option instead of a full JWT to fetch a destination. No validation is performed.' +
+       'Passing a user-supplied value without verifying it may lead to unintended cross-tenant destination access.'
     );
 
     return { ext_attr: { zdn: getIssuerSubdomain({ iss }) } };

--- a/packages/connectivity/src/scp-cf/destination/get-subscriber-token.ts
+++ b/packages/connectivity/src/scp-cf/destination/get-subscriber-token.ts
@@ -78,7 +78,7 @@ function getJwtForServiceToken(iss?: string, decodedUserJwt?: JwtPayload) {
   if (iss) {
     logger.warn(
       'Using `iss` option instead of a full JWT to fetch a destination. No validation is performed.' +
-       'Passing a user-supplied value without verifying it may lead to unintended cross-tenant destination access.'
+        'Passing a user-supplied value without verifying it may lead to unintended cross-tenant destination access.'
     );
 
     return { ext_attr: { zdn: getIssuerSubdomain({ iss }) } };

--- a/packages/connectivity/src/scp-cf/subdomain-replacer.ts
+++ b/packages/connectivity/src/scp-cf/subdomain-replacer.ts
@@ -1,5 +1,5 @@
 import { URL } from 'url';
-import { removeTrailingSlashes } from '@sap-cloud-sdk/util';
+import { isValidUrl, removeTrailingSlashes } from '@sap-cloud-sdk/util';
 import type { JwtPayload } from './jsonwebtoken-type';
 
 /**
@@ -27,15 +27,6 @@ function getHost(url: URL): string {
     throw new Error(`Failed to determine hostname: invalid host in "${url}".`);
   }
   return host;
-}
-
-function isValidUrl(url: string): boolean {
-  try {
-    new URL(url);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/packages/http-client/src/csrf-token-middleware.spec.ts
+++ b/packages/http-client/src/csrf-token-middleware.spec.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import axios from 'axios';
+import { createLogger } from '@sap-cloud-sdk/util';
 import { circuitBreaker, timeout } from '@sap-cloud-sdk/resilience';
 import { circuitBreakers } from '@sap-cloud-sdk/resilience/internal';
 import { csrf } from './csrf-token-middleware';
@@ -250,19 +251,42 @@ describe('CSRF middleware', () => {
     ).resolves.not.toThrow();
   });
 
-  it('fetches the token with custom method', async () => {
-    nock(host).get('/some/path/').reply(200, {}, csrfResponseHeaders);
+  it('logs a warning when the CSRF token URL has a different host than the request URL', async () => {
+    const csrfHost = 'http://other.example.com';
+    nock(csrfHost).head('/csrf').reply(200, {}, csrfResponseHeaders);
     nock(host).post('/some/path').reply(200, {});
-    await expect(
-      executeHttpRequest(
-        { url: host },
-        {
-          method: 'POST',
-          url: 'some/path',
-          middleware: [csrf({ method: 'GET' })]
-        },
-        { fetchCsrfToken: false }
-      )
-    ).resolves.not.toThrow();
+    const logger = createLogger('csrf-middleware');
+    const warnSpy = jest.spyOn(logger, 'warn');
+    await executeHttpRequest(
+      { url: host },
+      {
+        method: 'POST',
+        url: 'some/path',
+        middleware: [csrf({ url: `${csrfHost}/csrf` })]
+      },
+      { fetchCsrfToken: false }
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('different host')
+    );
+  });
+
+  it('does not log a warning when the CSRF token URL has the same host as the request URL', async () => {
+    nock(host).head('/alternative/path').reply(200, {}, csrfResponseHeaders);
+    nock(host).post('/some/path').reply(200, {});
+    const logger = createLogger('csrf-middleware');
+    const warnSpy = jest.spyOn(logger, 'warn');
+    await executeHttpRequest(
+      { url: host },
+      {
+        method: 'POST',
+        url: 'some/path',
+        middleware: [csrf({ url: `${host}/alternative/path` })]
+      },
+      { fetchCsrfToken: false }
+    );
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('different host')
+    );
   });
 });

--- a/packages/http-client/src/csrf-token-middleware.ts
+++ b/packages/http-client/src/csrf-token-middleware.ts
@@ -3,10 +3,12 @@ import {
   ErrorWithCause,
   first,
   flatten,
+  isValidUrl,
   pickIgnoreCase,
   pickValueIgnoreCase,
   removeTrailingSlashes
 } from '@sap-cloud-sdk/util';
+import { URL } from 'url';
 import axios from 'axios';
 import { executeWithMiddleware } from '@sap-cloud-sdk/resilience/internal';
 import type {
@@ -166,6 +168,19 @@ function findCsrfHeader(
   return { 'x-csrf-token': csrfHeader, ...cookieHeader };
 }
 
+function isCrossHost(
+  csrfUrl: string | undefined,
+  requestUrl: string | undefined
+): boolean {
+  if (!csrfUrl || !requestUrl) {
+    return false;
+  }
+  if (!isValidUrl(csrfUrl) || !isValidUrl(requestUrl)) {
+    return false;
+  }
+  return new URL(csrfUrl).hostname !== new URL(requestUrl).hostname;
+}
+
 async function makeCsrfRequests(
   requestConfig: HttpRequestConfig,
   options: CsrfMiddlewareOptions & { context: HttpMiddlewareContext }
@@ -173,6 +188,14 @@ async function makeCsrfRequests(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { data, params, parameterEncoder, ...requestConfigWithoutData } =
     requestConfig;
+
+  // TODO: In v5, make cross-host CSRF token fetching opt-in instead of just warning.
+  if (isCrossHost(options.url, requestConfig.baseURL)) {
+    logger.warn(
+      `The CSRF token fetch URL (${options.url}) has a different host than the request URL (${requestConfig.baseURL}). Sensitive headers will be forwarded to the CSRF token endpoint.`
+    );
+  }
+
   const axiosConfig: HttpRequestConfigWithOrigin = {
     ...requestConfigWithoutData,
     method: options.method || 'head',

--- a/packages/http-client/src/csrf-token-middleware.ts
+++ b/packages/http-client/src/csrf-token-middleware.ts
@@ -1,3 +1,4 @@
+import { URL } from 'url';
 import {
   createLogger,
   ErrorWithCause,
@@ -8,7 +9,6 @@ import {
   pickValueIgnoreCase,
   removeTrailingSlashes
 } from '@sap-cloud-sdk/util';
-import { URL } from 'url';
 import axios from 'axios';
 import { executeWithMiddleware } from '@sap-cloud-sdk/resilience/internal';
 import type {

--- a/packages/util/src/url.ts
+++ b/packages/util/src/url.ts
@@ -1,6 +1,21 @@
 import axios from 'axios';
 
 /**
+ * Checks whether a string is a valid URL.
+ * @param url - String to check.
+ * @returns True if the string is a valid URL, false otherwise.
+ * @internal
+ */
+export function isValidUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Checks whether a URL is existing via a head request.
  * @param url - URL to be checked.
  * @returns Promise - resolves if the URL exists.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -936,7 +936,7 @@ importers:
         version: 2.1.1
       openapi-backend:
         specifier: ^5.16.1
-        version: 5.16.1
+        version: 5.17.0
       pm2:
         specifier: ^7.0.1
         version: 7.0.1
@@ -2583,6 +2583,9 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   amp-message@0.1.2:
     resolution: {integrity: sha512-JqutcFwoU1+jhv7ArgW38bqrE+LQdcRv4NxNw0mp0JHQyB6tXesWRjtYKlDgHRY2o3JE5UTaBGUK8kSWUdxWUg==}
@@ -5010,8 +5013,8 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  openapi-backend@5.16.1:
-    resolution: {integrity: sha512-1tfLpC+7CajKv08vuFOLm4t8rJvJyqKuyau5IIIrGg3YuQYhmP7JqDL6p6WnbDCusmh3krCrKXoHB6hLF/iHcQ==}
+  openapi-backend@5.17.0:
+    resolution: {integrity: sha512-wyimPBoz/Gx+pqh4QwvMQRIJiZQHZkLdiyFXwfjiLwS5Jhbm7gCI+T0WTXmx7HXAYXL5Cr+016dR3CV3T/dPmQ==}
     engines: {node: '>=20.0.0'}
 
   openapi-schema-validator@12.1.3:
@@ -5312,12 +5315,12 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
-    engines: {node: '>=0.6'}
-
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -7966,9 +7969,9 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv-formats@2.1.1(ajv@8.18.0):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv@6.14.0:
     dependencies:
@@ -7985,6 +7988,13 @@ snapshots:
       uri-js: 4.4.1
 
   ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.2
@@ -10869,10 +10879,10 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openapi-backend@5.16.1:
+  openapi-backend@5.17.0:
     dependencies:
       '@apidevtools/json-schema-ref-parser': 11.9.3
-      ajv: 8.18.0
+      ajv: 8.20.0
       bath-es5: 3.0.3
       cookie: 1.1.1
       dereference-json-schema: 0.2.2
@@ -10880,12 +10890,12 @@ snapshots:
       mock-json-schema: 1.1.2
       openapi-schema-validator: 12.1.3
       openapi-types: 12.1.3
-      qs: 6.15.0
+      qs: 6.15.2
 
   openapi-schema-validator@12.1.3:
     dependencies:
-      ajv: 8.18.0
-      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
       lodash.merge: 4.6.2
       openapi-types: 12.1.3
 
@@ -11261,11 +11271,11 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  qs@6.15.0:
+  qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#1300.

  Adds warning logs for two security-relevant edge cases:

  - Cross-host CSRF: When csrf({ url }) points to a different host than the request URL, log a warning — sensitive headers are forwarded to the CSRF endpoint. 
  - Unvalidated iss: Upgrade the log from debug to warn and extend the message to call out the cross-tenant risk. Also tightens the JSDoc on `DestinationAccessorOptions.iss`.

Refactor: `isValidUrl` moved from `subdomain-replacer.ts` to `@sap-cloud-sdk/util` for reuse.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
