### PR TITLE
chore: Fix bump workflow and run `pnpm generate`

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -45,8 +45,8 @@ jobs:
           FULL_VERSION: ${{ inputs.version }}
         run: |
           gh auth setup-git
-          git config user.email "$BOT_EMAIL"
-          git config user.name "$BOT_NAME"
+          git config --global user.email "$BOT_EMAIL"
+          git config --global user.name "$BOT_NAME"
 
           # Extract major version from input (e.g., v4.5.0 -> v4)
           # shellcheck disable=SC2001

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -36,7 +36,9 @@ jobs:
 
       - env:
           NEXT_PACKAGE_VERSION: ${{ steps.bump.outputs.version }}
-        run: yarn ts-node ${{ github.workspace }}/scripts/update-documentation-md.ts
+        run: |
+          pnpm ts-node ${{ github.workspace }}/scripts/update-documentation-md.ts
+          pnpm generate
 
       - name: merge Changelogs
         id: merge-changelogs

--- a/test-packages/test-services-openapi/no-schema-service/package.json
+++ b/test-packages/test-services-openapi/no-schema-service/package.json
@@ -18,7 +18,7 @@
     "compile": "npx tsc"
   },
   "dependencies": {
-    "@sap-cloud-sdk/openapi": "^4.6.0"
+    "@sap-cloud-sdk/openapi": "^4.7.0"
   },
   "devDependencies": {
     "typescript": "~4.1.2"

--- a/test-packages/test-services-openapi/swagger-yaml-service/package.json
+++ b/test-packages/test-services-openapi/swagger-yaml-service/package.json
@@ -18,7 +18,7 @@
     "compile": "npx tsc"
   },
   "dependencies": {
-    "@sap-cloud-sdk/openapi": "^4.6.0"
+    "@sap-cloud-sdk/openapi": "^4.7.0"
   },
   "devDependencies": {
     "typescript": "~4.1.2"

--- a/test-packages/test-services-openapi/test-service/package.json
+++ b/test-packages/test-services-openapi/test-service/package.json
@@ -18,7 +18,7 @@
     "compile": "npx tsc"
   },
   "dependencies": {
-    "@sap-cloud-sdk/openapi": "^4.6.0"
+    "@sap-cloud-sdk/openapi": "^4.7.0"
   },
   "devDependencies": {
     "typescript": "~4.1.2"


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

`pnpm generate` was missing after the doc update changes.

Also run `pnpm generate` to update generated files. 

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
