### PR TITLE
chore: Discover git-hashes in multi-line release notes

### DIFF
--- a/scripts/add-changelog.ts
+++ b/scripts/add-changelog.ts
@@ -44,7 +44,7 @@ export async function embedCommitLinks(
     await Promise.all(
       lines.map(async line => {
         const match = line.match(SHORT_SHA_AT_LINE_END_RE);
-        if (!match || !line.trimStart().startsWith('- [')) {
+        if (!match) {
           return line;
         }
 


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Hashes aren't always in the first line.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
