### PR TITLE
fix: Refactor HTTP agent cache for better runtime compatibility.

### DIFF
--- a/.changeset/free-pans-bow.md
+++ b/.changeset/free-pans-bow.md
@@ -1,0 +1,6 @@
+---
+"@sap-cloud-sdk/connectivity": patch
+---
+
+[fix] Add fallbacks for HTTP agent cache if the main hash algorithm is not available.
+  

--- a/.changeset/free-pans-bow.md
+++ b/.changeset/free-pans-bow.md
@@ -2,5 +2,5 @@
 "@sap-cloud-sdk/connectivity": patch
 ---
 
-[fix] Add fallbacks for HTTP agent cache if the main hash algorithm is not available.
+[fix] Refactor HTTP agent cache for better runtime compatibility.
   

--- a/packages/connectivity/src/http-agent/http-agent.ts
+++ b/packages/connectivity/src/http-agent/http-agent.ts
@@ -302,12 +302,12 @@ export const agentCache = new Cache<HttpAgentConfig | HttpsAgentConfig>(
  * Agents are cached for up to one hour, but can be evicted earlier if more than 100 agents are created.
  * See https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener for details on the possible options
  */
-function createAgent(
+async function createAgent(
   destination: HttpDestination,
   options: https.AgentOptions
-): HttpAgentConfig | HttpsAgentConfig {
+): Promise<HttpAgentConfig | HttpsAgentConfig> {
   const protocol = getProtocolOrDefault(destination);
-  const cacheKey = hashCacheKey({ protocol, options });
+  const cacheKey = await hashCacheKey({ protocol, options });
 
   return agentCache.getOrInsertComputed(cacheKey, () => {
     logger.debug(

--- a/packages/connectivity/src/scp-cf/cache.spec.ts
+++ b/packages/connectivity/src/scp-cf/cache.spec.ts
@@ -153,17 +153,19 @@ describe('Cache', () => {
   });
 
   describe('hashCacheKey', () => {
-    it('produces the same hash for plain objects with different key insertion order', () => {
-      expect(hashCacheKey({ a: 1, b: 2 })).toEqual(
-        hashCacheKey({ b: 2, a: 1 })
+    it('produces the same hash for plain objects with different key insertion order', async () => {
+      await expect(hashCacheKey({ a: 1, b: 2 })).resolves.toEqual(
+        await hashCacheKey({ b: 2, a: 1 })
       );
     });
 
-    it('produces different hashes for plain objects with different values', () => {
-      expect(hashCacheKey({ a: 1 })).not.toEqual(hashCacheKey({ a: 2 }));
+    it('produces different hashes for plain objects with different values', async () => {
+      await expect(hashCacheKey({ a: 1 })).resolves.not.toEqual(
+        await hashCacheKey({ a: 2 })
+      );
     });
 
-    it('produces the same hash for Maps with different insertion order', () => {
+    it('produces the same hash for Maps with different insertion order', async () => {
       const m1 = new Map([
         ['x', 1],
         ['y', 2]
@@ -172,16 +174,20 @@ describe('Cache', () => {
         ['y', 2],
         ['x', 1]
       ]);
-      expect(hashCacheKey({ m: m1 })).toEqual(hashCacheKey({ m: m2 }));
+      await expect(hashCacheKey({ m: m1 })).resolves.toEqual(
+        await hashCacheKey({ m: m2 })
+      );
     });
 
-    it('produces the same hash for Sets with different insertion order', () => {
+    it('produces the same hash for Sets with different insertion order', async () => {
       const s1 = new Set([1, 2, 3]);
       const s2 = new Set([3, 1, 2]);
-      expect(hashCacheKey({ s: s1 })).toEqual(hashCacheKey({ s: s2 }));
+      await expect(hashCacheKey({ s: s1 })).resolves.toEqual(
+        await hashCacheKey({ s: s2 })
+      );
     });
 
-    it('produces the same hash for class instances regardless of property insertion order', () => {
+    it('produces the same hash for class instances regardless of property insertion order', async () => {
       class Point {
         [key: string]: number;
       }
@@ -191,11 +197,14 @@ describe('Cache', () => {
       const p2 = new Point();
       p2.x = 1;
       p2.y = 2;
-      expect(hashCacheKey({ p: p1 })).toEqual(hashCacheKey({ p: p2 }));
+      await expect(hashCacheKey({ p: p1 })).resolves.toEqual(
+        await hashCacheKey({ p: p2 })
+      );
     });
-    it('preserves arrays as arrays (does not coerce to object)', () => {
-      expect(hashCacheKey({ arr: [1, 2, 3] })).not.toEqual(
-        hashCacheKey({ arr: { 0: 1, 1: 2, 2: 3 } })
+
+    it('preserves arrays as arrays (does not coerce to object)', async () => {
+      await expect(hashCacheKey({ arr: [1, 2, 3] })).resolves.not.toEqual(
+        await hashCacheKey({ arr: { 0: 1, 1: 2, 2: 3 } })
       );
     });
   });

--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -147,37 +147,27 @@ export class Cache<T> implements CacheInterface<T> {
   }
 }
 
-const hashAlgorithm = getCacheKeyHashAlgorithm();
-
 /**
  * Hashes the given value to create a cache key.
  * @internal
  * @param value - The value to hash.
  * @returns A hash of the given value using a cryptographic hash function.
  */
-export function hashCacheKey(value: Record<string, unknown>): string {
-  const serialized = stringify(value);
-  const algorithm = hashAlgorithm;
+export async function hashCacheKey(
+  value: Record<string, unknown>
+): Promise<string> {
+  const stringifiedValue = stringify(value);
+  const encodedValue = new TextEncoder().encode(stringifiedValue);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encodedValue);
 
-  return crypto.hash(algorithm, serialized, 'base64url');
-}
-
-function getCacheKeyHashAlgorithm(): string {
-  const availableHashes = crypto.getHashes();
-
-  if (availableHashes.includes('blake2s256')) {
-    return 'blake2s256';
-  }
-  if (availableHashes.includes('sha3-256')) {
-    return 'sha3-256';
-  }
-  if (availableHashes.includes('sha256')) {
-    return 'sha256';
+  // TODO: Supported in Node.js 25 and later + browsers
+  if (typeof (hashBuffer as any).hex === 'function') {
+    return (hashBuffer as any).hex();
   }
 
-  throw new Error(
-    'No supported hash algorithm available for cache key generation. Expected blake2s256, sha3-256, or sha256.'
-  );
+  return Array.from(new Uint8Array(hashBuffer))
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('');
 }
 
 function isExpired<T>(item: CacheEntry<T>): boolean {

--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -161,13 +161,14 @@ export async function hashCacheKey(
   const hashBuffer = await crypto.subtle.digest('SHA-256', encodedValue);
 
   // TODO: Supported in Node.js 25 and later + browsers
-  if (typeof (hashBuffer as any).hex === 'function') {
-    return (hashBuffer as any).hex();
+  if ((Uint8Array.prototype as any).toHex) {
+    // Use toHex if supported.
+    return (new Uint8Array(hashBuffer) as any).toHex(); // Convert ArrayBuffer to hex string.
   }
-
-  return Array.from(new Uint8Array(hashBuffer))
-    .map(byte => byte.toString(16).padStart(2, '0'))
-    .join('');
+  // If toHex() is not supported, fall back to an alternative implementation.
+  const hashArray = Array.from(new Uint8Array(hashBuffer)); // convert buffer to byte array
+  const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join(''); // convert bytes to hex string
+  return hashHex;
 }
 
 function isExpired<T>(item: CacheEntry<T>): boolean {

--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -147,6 +147,8 @@ export class Cache<T> implements CacheInterface<T> {
   }
 }
 
+const hashAlgorithm = getCacheKeyHashAlgorithm();
+
 /**
  * Hashes the given value to create a cache key.
  * @internal
@@ -155,14 +157,27 @@ export class Cache<T> implements CacheInterface<T> {
  */
 export function hashCacheKey(value: Record<string, unknown>): string {
   const serialized = stringify(value);
+  const algorithm = hashAlgorithm;
 
-  // TODO: crypto.hash is available in Node.js v20.12.0 and later.
-  // Remove the fallback to crypto.createHash once Node.js 22 is the minimum supported version.
-  if (typeof crypto.hash === 'function') {
-    return crypto.hash('blake2s256', serialized, 'base64url');
+  return crypto.hash(algorithm, serialized, 'base64url');
+}
+
+function getCacheKeyHashAlgorithm(): string {
+  const availableHashes = crypto.getHashes();
+
+  if (availableHashes.includes('blake2s256')) {
+    return 'blake2s256';
+  }
+  if (availableHashes.includes('sha3-256')) {
+    return 'sha3-256';
+  }
+  if (availableHashes.includes('sha256')) {
+    return 'sha256';
   }
 
-  return crypto.createHash('blake2s256').update(serialized).digest('base64url');
+  throw new Error(
+    'No supported hash algorithm available for cache key generation. Expected blake2s256, sha3-256, or sha256.'
+  );
 }
 
 function isExpired<T>(item: CacheEntry<T>): boolean {

--- a/packages/connectivity/src/scp-cf/cache.ts
+++ b/packages/connectivity/src/scp-cf/cache.ts
@@ -161,10 +161,10 @@ export async function hashCacheKey(
   const hashBuffer = await crypto.subtle.digest('SHA-256', encodedValue);
 
   // TODO: Supported in Node.js 25 and later + browsers
-  if ((Uint8Array.prototype as any).toHex) {
-    // Use toHex if supported.
-    return (new Uint8Array(hashBuffer) as any).toHex(); // Convert ArrayBuffer to hex string.
-  }
+  // if ((Uint8Array.prototype as any).toHex) {
+  //   // Use toHex if supported.
+  //   return (new Uint8Array(hashBuffer) as any).toHex(); // Convert ArrayBuffer to hex string.
+  // }
   // If toHex() is not supported, fall back to an alternative implementation.
   const hashArray = Array.from(new Uint8Array(hashBuffer)); // convert buffer to byte array
   const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join(''); // convert bytes to hex string


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Certain environments with older runtimes (openssl versions) like VSCode may not have `blake2s256`. I added some fallbacks.

Also get rid of node 20 compatibility handling.

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
