### PR TITLE
fix(http-client): Set higher default timeout of 120s for http(s) agents

### DIFF
--- a/.changeset/happy-rings-cry.md
+++ b/.changeset/happy-rings-cry.md
@@ -1,0 +1,6 @@
+---
+"@sap-cloud-sdk/http-client": patch
+---
+
+[fix] Use dedicated HTTP/HTTPS agents with `keepAlive: true` instead of `http.globalAgent`/`https.globalAgent` to avoid the 5-second socket timeout applied by the global agents.
+  

--- a/.changeset/happy-rings-cry.md
+++ b/.changeset/happy-rings-cry.md
@@ -1,6 +1,7 @@
 ---
+"@sap-cloud-sdk/connectivity": patch
 "@sap-cloud-sdk/http-client": patch
 ---
 
-[fix] Use dedicated HTTP/HTTPS agents with `keepAlive: true` instead of `http.globalAgent`/`https.globalAgent` to avoid the 5-second socket timeout applied by the global agents.
+[fix] Set explicit timeout of 120s by default for http(s) agents.
   

--- a/packages/connectivity/src/http-agent/http-agent.ts
+++ b/packages/connectivity/src/http-agent/http-agent.ts
@@ -298,6 +298,15 @@ export const agentCache = new Cache<HttpAgentConfig | HttpsAgentConfig>(
 );
 
 /**
+ * Default options for the http(s) agents.
+ * @internal
+ */
+export const defaultAgentOptions: https.AgentOptions | http.AgentOptions = {
+  keepAlive: true,
+  timeout: 120000
+};
+
+/**
  * @internal
  * Agents are cached for up to one hour, but can be evicted earlier if more than 100 agents are created.
  * See https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener for details on the possible options
@@ -313,7 +322,7 @@ function createAgent(
     logger.debug(
       `Creating new ${protocol.toUpperCase()} agent for destination ${destination.name || '<unknown>'}`
     );
-    const optionsWithDefaults = { keepAlive: true, ...options };
+    const optionsWithDefaults = { ...defaultAgentOptions, ...options };
     const entry =
       protocol === 'https'
         ? { httpsAgent: new https.Agent(optionsWithDefaults) }

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -40,7 +40,8 @@ import {
   executeHttpRequest,
   oDataTypedClientParameterEncoder,
   executeHttpRequestWithOrigin,
-  buildHttpRequestConfigWithOrigin
+  buildHttpRequestConfigWithOrigin,
+  getAxiosConfigWithDefaultsWithoutMethod
 } from './http-client';
 import type {
   DestinationHttpRequestConfig,
@@ -1440,6 +1441,19 @@ If the parameters from multiple origins use the same key, the priority is 1. Cus
       expect(buildHttpRequestConfigWithOrigin(requestConfig)).toStrictEqual(
         expected
       );
+    });
+  });
+
+  describe('getAxiosConfigWithDefaultsWithoutMethod', () => {
+    it('uses http agents with keepAlive enabled', () => {
+      const config = getAxiosConfigWithDefaultsWithoutMethod();
+      expect(config.httpAgent.options.keepAlive).toBe(true);
+      expect(config.httpsAgent.options.keepAlive).toBe(true);
+      expect(config.httpAgent.options.timeout).toBeUndefined();
+      expect(config.httpsAgent.options.timeout).toBeUndefined();
+      // Remove workaround if this test ever fails
+      expect((http.globalAgent as any).options.timeout).toBeTruthy();
+      expect((https.globalAgent as any).options.timeout).toBeTruthy();
     });
   });
 });

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -12,7 +12,10 @@ import {
   circuitBreaker
 } from '@sap-cloud-sdk/resilience/internal';
 import { registerDestination } from '@sap-cloud-sdk/connectivity';
-import { registerDestinationCache } from '@sap-cloud-sdk/connectivity/internal';
+import {
+  defaultAgentOptions,
+  registerDestinationCache
+} from '@sap-cloud-sdk/connectivity/internal';
 import {
   basicMultipleResponse,
   connectivityProxyConfigMock,
@@ -1449,8 +1452,10 @@ If the parameters from multiple origins use the same key, the priority is 1. Cus
       const config = getAxiosConfigWithDefaultsWithoutMethod();
       expect(config.httpAgent.options.keepAlive).toBe(true);
       expect(config.httpsAgent.options.keepAlive).toBe(true);
-      expect(config.httpAgent.options.timeout).toBeUndefined();
-      expect(config.httpsAgent.options.timeout).toBeUndefined();
+      expect(config.httpAgent.options.timeout).toBe(defaultAgentOptions.timeout);
+      expect(config.httpsAgent.options.timeout).toBe(
+        defaultAgentOptions.timeout
+      );
       // Remove workaround if this test ever fails
       expect((http.globalAgent as any).options.timeout).toBeTruthy();
       expect((https.globalAgent as any).options.timeout).toBeTruthy();

--- a/packages/http-client/src/http-client.spec.ts
+++ b/packages/http-client/src/http-client.spec.ts
@@ -1452,7 +1452,9 @@ If the parameters from multiple origins use the same key, the priority is 1. Cus
       const config = getAxiosConfigWithDefaultsWithoutMethod();
       expect(config.httpAgent.options.keepAlive).toBe(true);
       expect(config.httpsAgent.options.keepAlive).toBe(true);
-      expect(config.httpAgent.options.timeout).toBe(defaultAgentOptions.timeout);
+      expect(config.httpAgent.options.timeout).toBe(
+        defaultAgentOptions.timeout
+      );
       expect(config.httpsAgent.options.timeout).toBe(
         defaultAgentOptions.timeout
       );

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -10,7 +10,8 @@ import {
   getAdditionalHeaders,
   getAdditionalQueryParameters,
   getProxyConfig,
-  resolveDestination
+  resolveDestination,
+  defaultAgentOptions
 } from '@sap-cloud-sdk/connectivity/internal';
 import { executeWithMiddleware } from '@sap-cloud-sdk/resilience/internal';
 import {
@@ -448,8 +449,8 @@ export function getAxiosConfigWithDefaults(): HttpRequestConfig {
 }
 
 // This does not use the global http.globalAgent and https.globalAgent, because these enable 5s timeouts by default.
-const defaultHttpAgent: http.Agent = new http.Agent({ keepAlive: true });
-const defaultHttpsAgent: https.Agent = new https.Agent({ keepAlive: true });
+const defaultHttpAgent: http.Agent = new http.Agent(defaultAgentOptions);
+const defaultHttpsAgent: https.Agent = new https.Agent(defaultAgentOptions);
 
 /**
  * @internal

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -448,8 +448,8 @@ export function getAxiosConfigWithDefaults(): HttpRequestConfig {
 }
 
 // This does not use the global http.globalAgent and https.globalAgent, because these enable 5s timeouts by default.
-let defaultHttpAgent: http.Agent = new http.Agent({ keepAlive: true });
-let defaultHttpsAgent: https.Agent = new https.Agent({ keepAlive: true });
+const defaultHttpAgent: http.Agent = new http.Agent({ keepAlive: true });
+const defaultHttpsAgent: https.Agent = new https.Agent({ keepAlive: true });
 
 /**
  * @internal

--- a/packages/http-client/src/http-client.ts
+++ b/packages/http-client/src/http-client.ts
@@ -447,6 +447,10 @@ export function getAxiosConfigWithDefaults(): HttpRequestConfig {
   };
 }
 
+// This does not use the global http.globalAgent and https.globalAgent, because these enable 5s timeouts by default.
+let defaultHttpAgent: http.Agent = new http.Agent({ keepAlive: true });
+let defaultHttpsAgent: https.Agent = new https.Agent({ keepAlive: true });
+
 /**
  * @internal
  */
@@ -455,8 +459,8 @@ export function getAxiosConfigWithDefaultsWithoutMethod(): Omit<
   'method'
 > {
   return {
-    httpAgent: http.globalAgent,
-    httpsAgent: https.globalAgent,
+    httpAgent: defaultHttpAgent,
+    httpsAgent: defaultHttpsAgent,
     timeout: 0, // zero means no timeout https://github.com/axios/axios/blob/main/README.md#request-config
     paramsSerializer: {
       serialize: (params = {}) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5263,16 +5263,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  prettier@3.8.5:
-    resolution: {integrity: sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==}
-    engines: {node: '>=14'}
-    hasBin: true
-
-  prettier@3.8.5:
-    resolution: {integrity: sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -11229,10 +11219,6 @@ snapshots:
       fast-diff: 1.3.0
 
   prettier@2.8.8: {}
-
-  prettier@3.8.5: {}
-
-  prettier@3.8.5: {}
 
   prettier@3.8.5: {}
 


### PR DESCRIPTION
…eouts

<!-- Please provide a description of what your change does and why it is needed. -->

The global HTTP(S) Agent has a 5s timeout ([source](https://nodejs.org/api/http.html#httpglobalagent)).
This is likely the cause of https://github.com/SAP/ai-sdk-js-backlog/issues/603.

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
