### PR TITLE
chore: Remove devEngines constraint again

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'The auth token for the npm registry'
   pnpm-version:
     description: 'PNPM version'
-    default: '11'
+    default: '10'
   pnpm-install-args:
     description: 'Arguments to pass to pnpm install'
     default: '--frozen-lockfile'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: 'The registry URL to use for npm packages. Defaults to the SAP Artifactory mirror when npm-token is provided, otherwise npmjs.'
   registry-token:
     description: 'The auth token for the npm registry'
+  pnpm-version:
+    description: 'PNPM version'
+    default: '11'
   pnpm-install-args:
     description: 'Arguments to pass to pnpm install'
     default: '--frozen-lockfile'
@@ -46,6 +49,8 @@ runs:
         allow-unsafe-pr-checkout: ${{ inputs.allow-unsafe-pr-checkout }}
     - name: Setup pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      with:
+        version: ${{ inputs.pnpm-version }}
     - name: Resolve registry URL
       id: resolve-registry-url
       env:

--- a/package.json
+++ b/package.json
@@ -15,13 +15,6 @@
   "tsd": {
     "directory": "test-packages/type-tests/test-new"
   },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "version": "^10",
-      "onFail": "warn"
-    }
-  },
   "scripts": {
     "postinstall": "pnpm run compile",
     "compile": "turbo run compile",


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Corepack, which dependabot uses, has issues with semver constraints in package.json for package managers.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
