### PR TITLE
chore: add dev dependency config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,21 @@ updates:
       # yargs v18 needs ESM, see https://github.com/yargs/yargs/releases/tag/v18.0.0, we'll stay on v17 until we can use ESM
       - dependency-name: 'yargs'
         update-types: ['version-update:semver-major']
+  - package-ecosystem: npm
+    target-branch: main
+    registries:
+      - sap-artifactory
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '01:00'
+      timezone: 'Europe/Berlin'
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 4
+    versioning-strategy: increase
+    allow:
+      - dependency-type: development
   - package-ecosystem: 'github-actions'
     directories:
       - '/'


### PR DESCRIPTION
I found, that dev dependencies use the same dependabot rules as prod dependencies. I think we should update them to the highest possible version to reduce possible friction in development. We could even consider pinning them. 