### PR TITLE
chore: move check:test-service out of parallel block

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,13 +70,13 @@ jobs:
       contents: read
     steps:
       - uses: sap/cloud-sdk-js/.github/actions/setup@main
+      - name: Test Service Version Check
+        run: pnpm run check:test-service
       - parallel:
           - name: REUSE Compliance Check
             uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0
           - name: Static Code Check
             run: pnpm run lint
-          - name: Test Service Version Check
-            run: pnpm run check:test-service
           - name: Undeclared dependency Check
             run: pnpm run check:dependencies
           - name: Check public api


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

IIRC it might lead to the failures as it creates some files for short time.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
