### PR TITLE
chore: Fix public-api-check in case a input file has ts extension

### DIFF
--- a/.github/actions/check-public-api/index.js
+++ b/.github/actions/check-public-api/index.js
@@ -73330,7 +73330,9 @@ async function parseIndexFile(filePath, forceInternalExports) {
     const starFileExports = await Promise.all(starFiles.map(async (relativeFilePath) => {
         const absolutePath = relativeFilePath.endsWith('.js')
             ? (0,node_path__WEBPACK_IMPORTED_MODULE_0__.resolve)(cwd, `${relativeFilePath.slice(0, -3)}.ts`)
-            : (0,node_path__WEBPACK_IMPORTED_MODULE_0__.resolve)(cwd, `${relativeFilePath}.ts`);
+            : relativeFilePath.endsWith('.ts')
+                ? (0,node_path__WEBPACK_IMPORTED_MODULE_0__.resolve)(cwd, relativeFilePath)
+                : (0,node_path__WEBPACK_IMPORTED_MODULE_0__.resolve)(cwd, `${relativeFilePath}.ts`);
         return parseIndexFile(absolutePath, forceInternalExports);
     }));
     return [...localExports, ...starFileExports.flat()];

--- a/build-packages/check-public-api/index.ts
+++ b/build-packages/check-public-api/index.ts
@@ -378,7 +378,9 @@ export async function parseIndexFile(
     starFiles.map(async relativeFilePath => {
       const absolutePath = relativeFilePath.endsWith('.js')
         ? resolve(cwd, `${relativeFilePath.slice(0, -3)}.ts`)
-        : resolve(cwd, `${relativeFilePath}.ts`);
+        : relativeFilePath.endsWith('.ts')
+          ? resolve(cwd, relativeFilePath)
+          : resolve(cwd, `${relativeFilePath}.ts`);
 
       return parseIndexFile(absolutePath, forceInternalExports);
     })


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

Don't add ts if extension is already `ts`

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
