### PR TITLE
chore: Remove default Node.js version from setup action input

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,6 @@ description: Setup repo, node and pnpm.
 inputs:
   node-version:
     description: 'Node.js version'
-    default: '22'
   registry-token:
     description: 'The auth token for the npm registry'
   pnpm-version:


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

This forces users either to set explicit `node-version` or provide `packageManager`/`devEngines`.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
