### PR TITLE
chore: Fix handle content media type correctly in OAS 3.1 OpenAPI generator

### DIFF
--- a/packages/openapi-generator/src/parser/schema.spec.ts
+++ b/packages/openapi-generator/src/parser/schema.spec.ts
@@ -801,6 +801,46 @@ describe('schema parser', () => {
         ).toEqual({ type: 'Blob' });
       });
 
+      it('maps a binary contentMediaType string to Blob', async () => {
+        const schema = {
+          type: 'string',
+          contentMediaType: 'application/vnd.apache.parquet'
+        } as any;
+        expect(
+          parseSchema(schema, await createTestRefs(), defaultOptions)
+        ).toEqual({ type: 'Blob' });
+      });
+
+      it('keeps a text contentMediaType string as string', async () => {
+        const schema = {
+          type: 'string',
+          contentMediaType: 'application/json'
+        } as any;
+        expect(
+          parseSchema(schema, await createTestRefs(), defaultOptions)
+        ).toEqual({ type: 'string' });
+      });
+
+      it('keeps a text/plain contentMediaType string as string', async () => {
+        const schema = {
+          type: 'string',
+          contentMediaType: 'text/plain'
+        } as any;
+        expect(
+          parseSchema(schema, await createTestRefs(), defaultOptions)
+        ).toEqual({ type: 'string' });
+      });
+
+      it('keeps an application/*+json contentMediaType string as string', async () => {
+        const schema = {
+          type: 'string',
+          contentMediaType: 'application/problem+json'
+        } as any;
+        expect(
+          parseSchema(schema, await createTestRefs(), defaultOptions)
+        ).toEqual({ type: 'string' });
+      });
+
       it('collects the examples array in schema properties', () => {
         expect(
           parseSchemaProperties({

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -198,15 +198,12 @@ function isBinaryMediaType(mediaType: string | undefined): boolean {
   if (lower.startsWith('text/')) {
     return false;
   }
-  if (
+  return !(
     lower === 'application/json' ||
     lower === 'application/xml' ||
     lower.endsWith('+json') ||
     lower.endsWith('+xml')
-  ) {
-    return false;
-  }
-  return true;
+  );
 }
 
 /**

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -168,9 +168,12 @@ export function parseSchema(
   // 'contentEncoding'/'contentMediaType' instead of the 3.0 'format: binary'
   // idiom. Map such content-encoded strings to 'Blob', consistent with the
   // binary handling elsewhere.
+  // Note: contentMediaType alone only maps to Blob for binary media types.
+  // Text-based types (text/*, application/json, application/*+json, etc.) are
+  // plain strings whose content happens to follow a text format.
   if (
     hasType(schema, 'string') &&
-    (schema.contentEncoding || schema.contentMediaType)
+    (schema.contentEncoding || isBinaryMediaType(schema.contentMediaType))
   ) {
     return { type: 'Blob' };
   }
@@ -178,6 +181,31 @@ export function parseSchema(
   return {
     type: getType(schema.type, schema.format)
   };
+}
+
+/**
+ * Returns true for media types whose content is binary (not human-readable
+ * text). Text-based types — text/*, application/json, application/xml, and
+ * structured-syntax suffixes like +json or +xml — are excluded because their
+ * string values remain plain text and should stay typed as `string`.
+ */
+function isBinaryMediaType(mediaType: string | undefined): boolean {
+  if (!mediaType) {
+    return false;
+  }
+  const lower = mediaType.toLowerCase().split(';')[0].trim();
+  if (lower.startsWith('text/')) {
+    return false;
+  }
+  if (
+    lower === 'application/json' ||
+    lower === 'application/xml' ||
+    lower.endsWith('+json') ||
+    lower.endsWith('+xml')
+  ) {
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -188,6 +188,7 @@ export function parseSchema(
  * text). Text-based types — text/*, application/json, application/xml, and
  * structured-syntax suffixes like +json or +xml — are excluded because their
  * string values remain plain text and should stay typed as `string`.
+ * @internal
  */
 function isBinaryMediaType(mediaType: string | undefined): boolean {
   if (!mediaType) {

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@sap-cloud-sdk/util';
+import { parse as parseContentType } from 'content-type';
 import { isReferenceObject } from '../schema-util';
 import { getType } from './type-mapping';
 import type { OpenAPIV3 } from 'openapi-types';
@@ -194,15 +195,20 @@ function isBinaryMediaType(mediaType: string | undefined): boolean {
   if (!mediaType) {
     return false;
   }
-  const lower = mediaType.toLowerCase().split(';')[0].trim();
-  if (lower.startsWith('text/')) {
+  let type: string;
+  try {
+    type = parseContentType(mediaType).type.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (type.startsWith('text/')) {
     return false;
   }
   return !(
-    lower === 'application/json' ||
-    lower === 'application/xml' ||
-    lower.endsWith('+json') ||
-    lower.endsWith('+xml')
+    type === 'application/json' ||
+    type === 'application/xml' ||
+    type.endsWith('+json') ||
+    type.endsWith('+xml')
   );
 }
 


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Relates to SAP/ai-sdk-js-backlog#633.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->

Previously, the logic for checking where the property is a blob was wrong. When `contentMediaType` is not a binary type, then it should not be blob.
