### PR TITLE
chore: run `pnpm generate` once before parallel tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: sap/cloud-sdk-js/.github/actions/setup@main
         with:
           node-version: ${{ matrix.node-version }}
+      - run: pnpm run generate
       - parallel:
           - run: pnpm run test:unit
           - run: pnpm run test:integration


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

Some of the tests depend on `pnpm generate`, this (tells turbo) that we did that.

Alternative would be something like this:
```sh
pnpm exec turbo run test --continue \
      --filter='!@sap-cloud-sdk/e2e-tests' \
      --filter='!./test-packages/memory-tests/**'
```

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `yarn changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `yarn run doc` still works.
-->
