### PR TITLE
feat: support OpenAPI 3.1 contentschemas

### DIFF
--- a/.changeset/fluffy-trains-jump.md
+++ b/.changeset/fluffy-trains-jump.md
@@ -3,5 +3,3 @@
 ---
 
 [feat] Support `contentSchema` in OpenAPI 3.1 schemas: fields with `contentMediaType: application/json` and a `contentSchema` are now typed as the `contentSchema` type instead of `string`. Serialization to a JSON string is supported for multipart bodies via `FormDataBuilder`; non-multipart bodies are not yet handled.
-
-[compat] Fields with `contentMediaType: application/json` and a `contentSchema` will now be typed as the `contentSchema` type instead of `string`. Re-generate your client to pick up the new types.

--- a/.changeset/purple-wolves-sing.md
+++ b/.changeset/purple-wolves-sing.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/openapi-generator': minor
+---
+
+[compat] Fields with `contentMediaType: application/json` and a `contentSchema` will now be typed as the `contentSchema` type instead of `string`. Re-generate your client to pick up the new types.

--- a/.changeset/support-content-media-type-schema.md
+++ b/.changeset/support-content-media-type-schema.md
@@ -1,5 +1,5 @@
 ---
-'@sap-cloud-sdk/openapi-generator': patch
+'@sap-cloud-sdk/openapi-generator': minor
 ---
 
 [feat] Support `contentSchema` in OpenAPI 3.1 schemas: fields with `contentMediaType: application/json` and a `contentSchema` are now typed as the `contentSchema` type instead of `string`. Serialization to a JSON string is supported for multipart bodies via `FormDataBuilder`; non-multipart bodies are not yet handled.

--- a/.changeset/support-content-media-type-schema.md
+++ b/.changeset/support-content-media-type-schema.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/openapi-generator': patch
+---
+
+[feat] Support `contentSchema` in OpenAPI 3.1 schemas: fields with `contentMediaType: application/json` and a `contentSchema` are now typed as the `contentSchema` type instead of `string`. Serialization to a JSON string is supported for multipart bodies via `FormDataBuilder`; non-multipart bodies are not yet handled.

--- a/.changeset/support-content-media-type-schema.md
+++ b/.changeset/support-content-media-type-schema.md
@@ -3,3 +3,5 @@
 ---
 
 [feat] Support `contentSchema` in OpenAPI 3.1 schemas: fields with `contentMediaType: application/json` and a `contentSchema` are now typed as the `contentSchema` type instead of `string`. Serialization to a JSON string is supported for multipart bodies via `FormDataBuilder`; non-multipart bodies are not yet handled.
+
+[compat] Fields with `contentMediaType: application/json` and a `contentSchema` will now be typed as the `contentSchema` type instead of `string`. Re-generate your client to pick up the new types.

--- a/packages/openapi-generator/src/openapi-types.ts
+++ b/packages/openapi-generator/src/openapi-types.ts
@@ -666,4 +666,10 @@ export interface OpenApiSchemaProperties {
    * 2020-12, 3.1).
    */
   contentMediaType?: string;
+
+  /**
+   * Validates the structure of a string's decoded content when
+   * `contentMediaType` is present (JSON Schema 2020-12, 3.1).
+   */
+  contentSchema?: any;
 }

--- a/packages/openapi-generator/src/openapi-types.ts
+++ b/packages/openapi-generator/src/openapi-types.ts
@@ -671,5 +671,5 @@ export interface OpenApiSchemaProperties {
    * Validates the structure of a string's decoded content when
    * `contentMediaType` is present (JSON Schema 2020-12, 3.1).
    */
-  contentSchema?: any;
+  contentSchema?: OpenApiV3xSchema | OpenAPIV3.ReferenceObject;
 }

--- a/packages/openapi-generator/src/parser/media-type.spec.ts
+++ b/packages/openapi-generator/src/parser/media-type.spec.ts
@@ -257,6 +257,32 @@ describe('parseTopLevelMediaType', () => {
     });
   });
 
+  it('uses contentMediaType from schema as encoding content type in multipart/form-data', async () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        config: {
+          type: 'string',
+          contentMediaType: 'application/json',
+          contentSchema: { type: 'object' }
+        },
+        name: { type: 'string' }
+      }
+    };
+    const result = parseTopLevelMediaType(
+      createMultipartFormContent(schema),
+      await createTestRefs(),
+      defaultOptions
+    );
+
+    expect(result?.encoding?.config).toEqual(
+      createImplicitMultipartFormEncoding('application/json')
+    );
+    expect(result?.encoding?.name).toEqual(
+      createImplicitMultipartFormEncoding('text/plain')
+    );
+  });
+
   it('auto-infers content type for arrays based on item type in multipart/form-data', async () => {
     const schema = {
       type: 'object',

--- a/packages/openapi-generator/src/parser/media-type.ts
+++ b/packages/openapi-generator/src/parser/media-type.ts
@@ -2,7 +2,11 @@ import { createLogger } from '@sap-cloud-sdk/util';
 import { parse as parseContentType, type ContentType } from 'content-type';
 import { parseSchema } from './schema';
 import type { OpenAPIV3 } from 'openapi-types';
-import type { OpenApiMediaTypeObject, OpenApiSchema, OpenApiV3xSchema } from '../openapi-types';
+import type {
+  OpenApiMediaTypeObject,
+  OpenApiSchema,
+  OpenApiV3xSchema
+} from '../openapi-types';
 import type { OpenApiDocumentRefs } from './refs';
 import type { ParserOptions } from './options';
 
@@ -36,9 +40,7 @@ function parseContentTypes(contentType: string): ContentType[] {
  * @param s - The schema object to infer content type from.
  * @returns The inferred content type, or undefined if cannot be determined.
  */
-function inferContentTypeFromSchema(
-  s: OpenApiV3xSchema
-): string | undefined {
+function inferContentTypeFromSchema(s: OpenApiV3xSchema): string | undefined {
   // Explicit contentMediaType takes priority over inferred defaults.
   if (s.contentMediaType) {
     return s.contentMediaType;

--- a/packages/openapi-generator/src/parser/media-type.ts
+++ b/packages/openapi-generator/src/parser/media-type.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@sap-cloud-sdk/util';
 import { parse as parseContentType, type ContentType } from 'content-type';
 import { parseSchema } from './schema';
 import type { OpenAPIV3 } from 'openapi-types';
-import type { OpenApiMediaTypeObject, OpenApiSchema } from '../openapi-types';
+import type { OpenApiMediaTypeObject, OpenApiSchema, OpenApiV3xSchema } from '../openapi-types';
 import type { OpenApiDocumentRefs } from './refs';
 import type { ParserOptions } from './options';
 
@@ -37,8 +37,12 @@ function parseContentTypes(contentType: string): ContentType[] {
  * @returns The inferred content type, or undefined if cannot be determined.
  */
 function inferContentTypeFromSchema(
-  s: OpenAPIV3.SchemaObject
+  s: OpenApiV3xSchema
 ): string | undefined {
+  // Explicit contentMediaType takes priority over inferred defaults.
+  if (s.contentMediaType) {
+    return s.contentMediaType;
+  }
   // Binary format -> application/octet-stream
   if (s.type === 'string' && s.format === 'binary') {
     return 'application/octet-stream';

--- a/packages/openapi-generator/src/parser/schema.spec.ts
+++ b/packages/openapi-generator/src/parser/schema.spec.ts
@@ -845,9 +845,16 @@ describe('schema parser', () => {
         const schema = {
           type: 'string',
           contentMediaType: 'application/json',
-          contentSchema: { type: 'object', properties: { name: { type: 'string' } } }
+          contentSchema: {
+            type: 'object',
+            properties: { name: { type: 'string' } }
+          }
         } as any;
-        const result = parseSchema(schema, await createTestRefs(), defaultOptions) as any;
+        const result = parseSchema(
+          schema,
+          await createTestRefs(),
+          defaultOptions
+        ) as any;
         expect(result.properties).toHaveLength(1);
         expect(result.properties[0].name).toBe('name');
       });
@@ -904,7 +911,10 @@ describe('schema parser', () => {
             contentMediaType: 'application/json',
             contentSchema: { type: 'object' }
           } as any)
-        ).toEqual({ contentMediaType: 'application/json', contentSchema: { type: 'object' } });
+        ).toEqual({
+          contentMediaType: 'application/json',
+          contentSchema: { type: 'object' }
+        });
       });
 
       it('collects the examples array in schema properties', () => {

--- a/packages/openapi-generator/src/parser/schema.spec.ts
+++ b/packages/openapi-generator/src/parser/schema.spec.ts
@@ -841,6 +841,72 @@ describe('schema parser', () => {
         ).toEqual({ type: 'string' });
       });
 
+      it('resolves contentSchema type for application/json contentMediaType', async () => {
+        const schema = {
+          type: 'string',
+          contentMediaType: 'application/json',
+          contentSchema: { type: 'object', properties: { name: { type: 'string' } } }
+        } as any;
+        const result = parseSchema(schema, await createTestRefs(), defaultOptions) as any;
+        expect(result.properties).toHaveLength(1);
+        expect(result.properties[0].name).toBe('name');
+      });
+
+      it('resolves contentSchema $ref for application/json contentMediaType', async () => {
+        const refs = await createTestRefs({
+          schemas: { MyModel: { type: 'object', properties: {} } }
+        });
+        const schema = {
+          type: 'string',
+          contentMediaType: 'application/json',
+          contentSchema: { $ref: '#/components/schemas/MyModel' }
+        } as any;
+        const result = parseSchema(schema, refs, defaultOptions) as any;
+        expect(result.schemaName).toBe('MyModel');
+      });
+
+      it('resolves contentSchema type for application/*+json contentMediaType', async () => {
+        const schema = {
+          type: 'string',
+          contentMediaType: 'application/merge-patch+json',
+          contentSchema: { type: 'integer' }
+        } as any;
+        expect(
+          parseSchema(schema, await createTestRefs(), defaultOptions)
+        ).toEqual({ type: 'number' });
+      });
+
+      it('ignores contentSchema without contentMediaType', async () => {
+        const schema = {
+          type: 'string',
+          contentSchema: { type: 'integer' }
+        } as any;
+        expect(
+          parseSchema(schema, await createTestRefs(), defaultOptions)
+        ).toEqual({ type: 'string' });
+      });
+
+      it('ignores contentSchema for non-JSON contentMediaType', async () => {
+        const schema = {
+          type: 'string',
+          contentMediaType: 'text/plain',
+          contentSchema: { type: 'integer' }
+        } as any;
+        expect(
+          parseSchema(schema, await createTestRefs(), defaultOptions)
+        ).toEqual({ type: 'string' });
+      });
+
+      it('collects contentSchema in schema properties', () => {
+        expect(
+          parseSchemaProperties({
+            type: 'string',
+            contentMediaType: 'application/json',
+            contentSchema: { type: 'object' }
+          } as any)
+        ).toEqual({ contentMediaType: 'application/json', contentSchema: { type: 'object' } });
+      });
+
       it('collects the examples array in schema properties', () => {
         expect(
           parseSchemaProperties({

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -174,7 +174,9 @@ export function parseSchema(
 
     // OAS 3.1: a JSON contentMediaType + contentSchema types the field as the
     // contentSchema type. Only supported for multipart bodies (FormDataBuilder
-    // handles JSON.stringify); non-multipart bodies are not yet handled.
+    // handles JSON.stringify).
+    // TODO: support non-multipart bodies by preserving wire-type metadata so
+    // the serialization layer knows to JSON.stringify the value.
     if (schema.contentSchema && isJsonMediaType(schema.contentMediaType)) {
       return parseSchema(schema.contentSchema, refs, options);
     }

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -223,18 +223,21 @@ export function parseMediaTypeString(
  */
 function isBinaryMediaType(mediaType: string | undefined): boolean {
   const type = parseMediaTypeString(mediaType);
-  return !!type && !(
-    type.startsWith('text/') ||
-    type === 'application/json' ||
-    type === 'application/xml' ||
-    type.endsWith('+json') ||
-    type.endsWith('+xml')
+  return (
+    !!type &&
+    !(
+      type.startsWith('text/') ||
+      type === 'application/json' ||
+      type === 'application/xml' ||
+      type.endsWith('+json') ||
+      type.endsWith('+xml')
+    )
   );
 }
 
 function isJsonMediaType(mediaType: string | undefined): boolean {
   const type = parseMediaTypeString(mediaType);
-  return !!type && (type === 'application/json' || type.endsWith('+json'))
+  return !!type && (type === 'application/json' || type.endsWith('+json'));
 }
 
 /**

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -179,9 +179,39 @@ export function parseSchema(
     return { type: 'Blob' };
   }
 
+  // OpenAPI 3.1 / JSON Schema 2020-12: a string with a JSON contentMediaType
+  // and a contentSchema is typed as the contentSchema type. Serialization to a
+  // JSON string is only supported for multipart bodies (via FormDataBuilder);
+  // non-multipart bodies are not yet supported.
+  if (
+    schema.contentSchema &&
+    hasType(schema, 'string') &&
+    isJsonMediaType(schema.contentMediaType)
+  ) {
+    return parseSchema(schema.contentSchema, refs, options);
+  }
+
   return {
     type: getType(schema.type, schema.format)
   };
+}
+
+/**
+ * Parse and normalize a media type string. Returns the lowercased type token,
+ * or undefined if the input is absent or unparsable.
+ * @internal
+ */
+export function parseMediaTypeString(
+  mediaType: string | undefined
+): string | undefined {
+  if (!mediaType) {
+    return undefined;
+  }
+  try {
+    return parseContentType(mediaType).type.toLowerCase();
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -192,24 +222,19 @@ export function parseSchema(
  * @internal
  */
 function isBinaryMediaType(mediaType: string | undefined): boolean {
-  if (!mediaType) {
-    return false;
-  }
-  let type: string;
-  try {
-    type = parseContentType(mediaType).type.toLowerCase();
-  } catch {
-    return false;
-  }
-  if (type.startsWith('text/')) {
-    return false;
-  }
-  return !(
+  const type = parseMediaTypeString(mediaType);
+  return !!type && !(
+    type.startsWith('text/') ||
     type === 'application/json' ||
     type === 'application/xml' ||
     type.endsWith('+json') ||
     type.endsWith('+xml')
   );
+}
+
+function isJsonMediaType(mediaType: string | undefined): boolean {
+  const type = parseMediaTypeString(mediaType);
+  return !!type && (type === 'application/json' || type.endsWith('+json'))
 }
 
 /**
@@ -638,7 +663,8 @@ export function parseSchemaProperties(
     'maxItems',
     'pattern',
     'contentEncoding',
-    'contentMediaType'
+    'contentMediaType',
+    'contentSchema'
   ];
   const collected = schemaPropertyNames.reduce(
     (properties, propertyName) => {

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -165,30 +165,19 @@ export function parseSchema(
     };
   }
 
-  // OpenAPI 3.1 / JSON Schema 2020-12 expresses binary string content via
-  // 'contentEncoding'/'contentMediaType' instead of the 3.0 'format: binary'
-  // idiom. Map such content-encoded strings to 'Blob', consistent with the
-  // binary handling elsewhere.
-  // Note: contentMediaType alone only maps to Blob for binary media types.
-  // Text-based types (text/*, application/json, application/*+json, etc.) are
-  // plain strings whose content happens to follow a text format.
-  if (
-    hasType(schema, 'string') &&
-    (schema.contentEncoding || isBinaryMediaType(schema.contentMediaType))
-  ) {
-    return { type: 'Blob' };
-  }
+  if (hasType(schema, 'string')) {
+    // OAS 3.1: contentEncoding or a binary contentMediaType maps to Blob.
+    // Text-based types (text/*, application/json, etc.) fall through.
+    if (schema.contentEncoding || isBinaryMediaType(schema.contentMediaType)) {
+      return { type: 'Blob' };
+    }
 
-  // OpenAPI 3.1 / JSON Schema 2020-12: a string with a JSON contentMediaType
-  // and a contentSchema is typed as the contentSchema type. Serialization to a
-  // JSON string is only supported for multipart bodies (via FormDataBuilder);
-  // non-multipart bodies are not yet supported.
-  if (
-    schema.contentSchema &&
-    hasType(schema, 'string') &&
-    isJsonMediaType(schema.contentMediaType)
-  ) {
-    return parseSchema(schema.contentSchema, refs, options);
+    // OAS 3.1: a JSON contentMediaType + contentSchema types the field as the
+    // contentSchema type. Only supported for multipart bodies (FormDataBuilder
+    // handles JSON.stringify); non-multipart bodies are not yet handled.
+    if (schema.contentSchema && isJsonMediaType(schema.contentMediaType)) {
+      return parseSchema(schema.contentSchema, refs, options);
+    }
   }
 
   return {

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -207,11 +207,8 @@ export function parseMediaTypeString(
   if (!mediaType) {
     return undefined;
   }
-  try {
-    return parseContentType(mediaType).type.toLowerCase();
-  } catch {
-    return undefined;
-  }
+  return parseContentType(mediaType)?.type?.toLowerCase();
+
 }
 
 /**
@@ -226,16 +223,18 @@ function isBinaryMediaType(mediaType: string | undefined): boolean {
   return (
     !!type &&
     !(
+      isJsonMediaType(mediaType) ||
       type.startsWith('text/') ||
-      type === 'application/json' ||
       type === 'application/xml' ||
-      type.endsWith('+json') ||
       type.endsWith('+xml')
     )
   );
 }
 
-function isJsonMediaType(mediaType: string | undefined): boolean {
+/**
+ * @internal
+ */
+export function isJsonMediaType(mediaType: string | undefined): boolean {
   const type = parseMediaTypeString(mediaType);
   return !!type && (type === 'application/json' || type.endsWith('+json'));
 }

--- a/packages/openapi-generator/src/parser/schema.ts
+++ b/packages/openapi-generator/src/parser/schema.ts
@@ -208,7 +208,6 @@ export function parseMediaTypeString(
     return undefined;
   }
   return parseContentType(mediaType)?.type?.toLowerCase();
-
 }
 
 /**

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -192,7 +192,9 @@ class FormDataBuilder {
     // Handle string data
     // Only use JSON.stringify for application/json content type - otherwise may unduly escape e.g. stringified XML
     // To avoid stringifying pre-stringified JSON, users should use `Blob` or raw `FormData`
-    const stringValue = allowedTypes.values().some(val => val === 'application/json' || val .endsWith('+json'))
+    const stringValue = allowedTypes
+      .values()
+      .some(val => val === 'application/json' || val.endsWith('+json'))
       ? JSON.stringify(value)
       : String(value);
 

--- a/packages/openapi/src/openapi-request-builder.ts
+++ b/packages/openapi/src/openapi-request-builder.ts
@@ -192,7 +192,7 @@ class FormDataBuilder {
     // Handle string data
     // Only use JSON.stringify for application/json content type - otherwise may unduly escape e.g. stringified XML
     // To avoid stringifying pre-stringified JSON, users should use `Blob` or raw `FormData`
-    const stringValue = allowedTypes.has('application/json')
+    const stringValue = allowedTypes.values().some(val => val === 'application/json' || val .endsWith('+json'))
       ? JSON.stringify(value)
       : String(value);
 


### PR DESCRIPTION
This allows reflecting content schemas of strings in types, while serializing them as strings in formdata bodies. Other contexts outside of formdata bodies are not supported.

Related to https://github.com/SAP/ai-sdk-js-backlog/issues/632