### PR TITLE
feat: rename generateESM to generateEsm

### DIFF
--- a/.changeset/ninety-apples-taste.md
+++ b/.changeset/ninety-apples-taste.md
@@ -1,0 +1,7 @@
+---
+'@sap-cloud-sdk/generator': minor
+'@sap-cloud-sdk/generator-common': minor
+'@sap-cloud-sdk/openapi-generator': minor
+---
+
+[improvement] Rename `generateESM` to `generateEsm`.

--- a/packages/generator-common/src/file-writer/create-file.ts
+++ b/packages/generator-common/src/file-writer/create-file.ts
@@ -28,7 +28,7 @@ export interface CreateFileOptions {
   /**
    * Flag to indicate if the file is generated as ESM.
    */
-  generateESM?: boolean;
+  generateEsm?: boolean;
 }
 
 /**

--- a/packages/generator-common/src/options.ts
+++ b/packages/generator-common/src/options.ts
@@ -118,11 +118,12 @@ export function getCommonCliOptions(serviceType: ServiceType) {
       default: false,
       hidden: true
     },
-    generateESM: {
+    generateEsm: {
       describe:
         'When enabled, all generated files follow the ECMAScript module syntax.',
       type: 'boolean',
-      default: false
+      default: false,
+      alias: 'generateESM'
     }
   } as const;
 }
@@ -202,5 +203,5 @@ export interface CommonGeneratorOptions {
   /**
    * Generate ECMAScript modules instead of CommonJS modules.
    */
-  generateESM?: boolean;
+  generateEsm?: boolean;
 }

--- a/packages/generator-common/src/ts-config.spec.ts
+++ b/packages/generator-common/src/ts-config.spec.ts
@@ -16,7 +16,7 @@ describe('tsconfigJson', () => {
     expect(JSON.parse(tsConfig!)).toEqual(defaultTsConfig(false));
   });
 
-  it('returns the default tsconfig with ESM config when generateESM is true', async () => {
+  it('returns the default tsconfig with ESM config when generateEsm is true', async () => {
     const tsConfig = await tsconfigJson(true, undefined, true);
     expect(JSON.parse(tsConfig!)).toEqual(defaultTsConfig(true));
   });

--- a/packages/generator-common/src/ts-config.ts
+++ b/packages/generator-common/src/ts-config.ts
@@ -6,17 +6,17 @@ const { readFile, lstat } = promises;
  * @internal
  */
 export const defaultTsConfig = (
-  generateESM?: boolean
+  generateEsm?: boolean
 ): Record<string, any> => ({
   compilerOptions: {
     target: 'es2021',
-    module: generateESM ? 'nodenext' : 'node16',
+    module: generateEsm ? 'nodenext' : 'node16',
     lib: ['esnext'],
     declaration: true,
     declarationMap: false,
     sourceMap: true,
     diagnostics: true,
-    moduleResolution: generateESM ? 'nodenext' : 'node16',
+    moduleResolution: generateEsm ? 'nodenext' : 'node16',
     esModuleInterop: true,
     inlineSources: false,
     strict: true
@@ -27,8 +27,8 @@ export const defaultTsConfig = (
 /**
  * @internal
  */
-export function formatTsConfig(generateESM?: boolean): string {
-  return JSON.stringify(defaultTsConfig(generateESM), null, 2) + '\n';
+export function formatTsConfig(generateEsm?: boolean): string {
+  return JSON.stringify(defaultTsConfig(generateEsm), null, 2) + '\n';
 }
 
 /**
@@ -53,18 +53,18 @@ export async function readCustomTsConfig(configPath: string): Promise<string> {
  * If transpile is true or tsconfig is provided, return the appropriate config.
  * @param transpile - Whether to transpile.
  * @param tsconfig - Path to custom tsconfig file.
- * @param generateESM - Whether to generate ES modules instead of CommonJS.
+ * @param generateEsm - Whether to generate ES modules instead of CommonJS.
  * @returns The serialized tsconfig.json contents.
  * @internal
  */
 export async function tsconfigJson(
   transpile?: boolean,
   tsconfig?: string,
-  generateESM?: boolean
+  generateEsm?: boolean
 ): Promise<string | undefined> {
   if (transpile || tsconfig) {
     return tsconfig
       ? readCustomTsConfig(tsconfig)
-      : formatTsConfig(generateESM);
+      : formatTsConfig(generateEsm);
   }
 }

--- a/packages/generator/src/batch/imports.ts
+++ b/packages/generator/src/batch/imports.ts
@@ -34,7 +34,7 @@ export function importBatchDeclarations(
     },
     {
       kind: StructureKind.ImportDeclaration,
-      moduleSpecifier: options?.generateESM ? './index.js' : './index',
+      moduleSpecifier: options?.generateEsm ? './index.js' : './index',
       namedImports: getNamedImports(service)
     }
   ];

--- a/packages/generator/src/complex-type/imports.spec.ts
+++ b/packages/generator/src/complex-type/imports.spec.ts
@@ -97,7 +97,7 @@ describe('complex type imports', () => {
   });
 
   const esmOptions = {
-    generateESM: true
+    generateEsm: true
   } as CreateFileOptions;
   it('adds .js in import declarations when ESM flag is true', () => {
     const actual = importDeclarations(complexMealWithDesert, 'v2', esmOptions);

--- a/packages/generator/src/entity/imports.spec.ts
+++ b/packages/generator/src/entity/imports.spec.ts
@@ -3,7 +3,7 @@ import { entityImportDeclarations, otherEntityImports } from './imports';
 import type { CreateFileOptions } from '@sap-cloud-sdk/generator-common/internal';
 
 const esmOptions = {
-  generateESM: true
+  generateEsm: true
 } as CreateFileOptions;
 
 describe('imports', () => {

--- a/packages/generator/src/entity/imports.ts
+++ b/packages/generator/src/entity/imports.ts
@@ -29,7 +29,7 @@ export function entityImportDeclarations(
       ...complexTypeImportDeclarations(entity.properties, options),
       {
         namedImports: [`${entity.className}Api`],
-        moduleSpecifier: options?.generateESM
+        moduleSpecifier: options?.generateEsm
           ? `./${entity.className}Api.js`
           : `./${entity.className}Api`,
         kind: StructureKind.ImportDeclaration,
@@ -48,7 +48,7 @@ export function entityImportDeclarations(
     ...complexTypeImportDeclarations(entity.properties, options),
     {
       namedImports: [`${entity.className}Api`],
-      moduleSpecifier: options?.generateESM
+      moduleSpecifier: options?.generateEsm
         ? `./${entity.className}Api.js`
         : `./${entity.className}Api`,
       kind: StructureKind.ImportDeclaration,
@@ -88,6 +88,6 @@ function otherEntityImport(
   return {
     kind: StructureKind.ImportDeclaration,
     namedImports: [name, `${name}Type`],
-    moduleSpecifier: options?.generateESM ? `./${name}.js` : `./${name}`
+    moduleSpecifier: options?.generateEsm ? `./${name}.js` : `./${name}`
   };
 }

--- a/packages/generator/src/generator-without-ts-morph/entity-api/file.ts
+++ b/packages/generator/src/generator-without-ts-morph/entity-api/file.ts
@@ -43,14 +43,14 @@ function getImports(
   return [
     {
       names: [`${entity.className}`],
-      moduleIdentifier: options?.generateESM
+      moduleIdentifier: options?.generateEsm
         ? `./${entity.className}.js`
         : `./${entity.className}`,
       typeOnly: false
     },
     {
       names: [`${entity.className}RequestBuilder`],
-      moduleIdentifier: options?.generateESM
+      moduleIdentifier: options?.generateEsm
         ? `./${entity.className}RequestBuilder.js`
         : `./${entity.className}RequestBuilder`,
       typeOnly: false
@@ -109,7 +109,7 @@ function otherEntityImports(
   return [
     {
       names: [`${name}Api`],
-      moduleIdentifier: options?.generateESM
+      moduleIdentifier: options?.generateEsm
         ? `./${name}Api.js`
         : `./${name}Api`
     }

--- a/packages/generator/src/generator-without-ts-morph/entity-api/imports.ts
+++ b/packages/generator/src/generator-without-ts-morph/entity-api/imports.ts
@@ -44,7 +44,7 @@ function complexTypeImport(
 ): Import {
   return {
     names: [prop.jsType, ...(prop.isCollection ? [] : [prop.fieldType])],
-    moduleIdentifier: options?.generateESM
+    moduleIdentifier: options?.generateEsm
       ? `./${prop.jsType}.js`
       : `./${prop.jsType}`,
     typeOnly: false
@@ -96,7 +96,7 @@ function enumTypeImport(
   options?: CreateFileOptions
 ): Import {
   return {
-    moduleIdentifier: options?.generateESM
+    moduleIdentifier: options?.generateEsm
       ? `./${prop.jsType}.js`
       : `./${prop.jsType}`,
     names: [prop.jsType],

--- a/packages/generator/src/generator-without-ts-morph/request-builder/imports.spec.ts
+++ b/packages/generator/src/generator-without-ts-morph/request-builder/imports.spec.ts
@@ -31,7 +31,7 @@ describe('imports', () => {
     const actual = requestBuilderImportDeclarations(breakfastEntity, 'v2', {
       overwrite: true,
       prettierOptions: defaultPrettierConfig,
-      generateESM: true
+      generateEsm: true
     });
     expect(actual[1].moduleIdentifier).toBe('./Breakfast.js');
   });

--- a/packages/generator/src/generator-without-ts-morph/request-builder/imports.ts
+++ b/packages/generator/src/generator-without-ts-morph/request-builder/imports.ts
@@ -68,10 +68,10 @@ function entityImportDeclaration(
   entity: VdmEntity,
   options?: CreateFileOptions
 ): Import {
-  const generateESM = options?.generateESM;
+  const generateEsm = options?.generateEsm;
   return {
     names: [entity.className],
-    moduleIdentifier: generateESM
+    moduleIdentifier: generateEsm
       ? `./${entity.className}.js`
       : `./${entity.className}`
   };
@@ -84,13 +84,13 @@ function entityKeyImportDeclaration(
   properties: VdmProperty[],
   options?: CreateFileOptions
 ): Import[] {
-  const generateESM = options?.generateESM;
+  const generateEsm = options?.generateEsm;
   return unique(
     properties
       .filter(property => property.isEnum)
       .map(property => property.jsType)
   ).map(type => ({
     names: [type],
-    moduleIdentifier: generateESM ? `./${type}.js` : `./${type}`
+    moduleIdentifier: generateEsm ? `./${type}.js` : `./${type}`
   }));
 }

--- a/packages/generator/src/generator-without-ts-morph/service/file.ts
+++ b/packages/generator/src/generator-without-ts-morph/service/file.ts
@@ -38,7 +38,7 @@ function getImports(
   return [
     {
       names: [...names, ...parameterNames],
-      moduleIdentifier: options?.generateESM
+      moduleIdentifier: options?.generateEsm
         ? './operations.js'
         : './operations'
     }
@@ -57,7 +57,7 @@ export function imports(
   const serviceImports = [
     ...service.entities.map(entity => ({
       names: [`${entity.className}Api`],
-      moduleIdentifier: options?.generateESM
+      moduleIdentifier: options?.generateEsm
         ? `./${entity.className}Api.js`
         : `./${entity.className}Api`
     })),
@@ -87,7 +87,7 @@ export function imports(
   if (hasEntities(service)) {
     serviceImports.push({
       names: ['batch', 'changeset'],
-      moduleIdentifier: options?.generateESM
+      moduleIdentifier: options?.generateEsm
         ? './BatchRequest.js'
         : './BatchRequest'
     });

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -183,7 +183,7 @@ export async function generateProject(
   }
 
   const project = new Project(
-    projectOptions(options.generateESM ? 'esm' : 'commonjs')
+    projectOptions(options.generateEsm ? 'esm' : 'commonjs')
   );
 
   const promises = services.map(service =>
@@ -245,7 +245,7 @@ async function getFileCreationOptions(
       options.prettierConfig?.toString()
     ),
     overwrite: options.overwrite,
-    generateESM: options.generateESM
+    generateEsm: options.generateEsm
   };
 }
 
@@ -325,7 +325,7 @@ export async function generateSourcesForService(
           sdkVersion: await getSdkVersion(),
           description: packageDescription(service.speakingModuleName),
           oDataVersion: service.oDataVersion,
-          generateESM: options.generateESM
+          generateEsm: options.generateEsm
         }),
         createFileOptions
       )
@@ -336,7 +336,7 @@ export async function generateSourcesForService(
     const tsConfig = await tsconfigJson(
       options.transpile,
       options.tsconfig,
-      options.generateESM
+      options.generateEsm
     );
     if (tsConfig) {
       filePromises.push(

--- a/packages/generator/src/imports.ts
+++ b/packages/generator/src/imports.ts
@@ -195,7 +195,7 @@ function complexTypeImportDeclaration(
 ): ImportDeclarationStructure {
   return {
     kind: StructureKind.ImportDeclaration,
-    moduleSpecifier: options?.generateESM
+    moduleSpecifier: options?.generateEsm
       ? `./${prop.jsType}.js`
       : `./${prop.jsType}`,
     namedImports: [prop.jsType, ...(prop.isCollection ? [] : [prop.fieldType])]
@@ -208,7 +208,7 @@ function enumTypeImportDeclaration(
 ): ImportDeclarationStructure {
   return {
     kind: StructureKind.ImportDeclaration,
-    moduleSpecifier: options?.generateESM
+    moduleSpecifier: options?.generateEsm
       ? `./${prop.jsType}.js`
       : `./${prop.jsType}`,
     namedImports: [prop.jsType]

--- a/packages/generator/src/operations/import.ts
+++ b/packages/generator/src/operations/import.ts
@@ -66,7 +66,7 @@ function returnTypeImport(
   returnType: VdmOperationReturnType,
   options?: CreateFileOptions
 ): ImportDeclarationStructure[] {
-  const extension = options?.generateESM ? '.js' : '';
+  const extension = options?.generateEsm ? '.js' : '';
   const typeImports: ImportDeclarationStructure[] = [
     {
       kind: StructureKind.ImportDeclaration,
@@ -115,7 +115,7 @@ export function operationDeclarations(
       'Bound and unbound operations found in generation - this should not happen.'
     );
   }
-  const extension = options?.generateESM ? '.js' : '';
+  const extension = options?.generateEsm ? '.js' : '';
   const serviceImport: ImportDeclarationStructure[] = includesBound
     ? []
     : [

--- a/packages/generator/src/service/index-file.ts
+++ b/packages/generator/src/service/index-file.ts
@@ -43,7 +43,7 @@ function exportStatement(
 ): ExportDeclarationStructure {
   return {
     kind: StructureKind.ExportDeclaration,
-    moduleSpecifier: options?.generateESM
+    moduleSpecifier: options?.generateEsm
       ? `./${moduleName}.js`
       : `./${moduleName}`
   };

--- a/packages/generator/src/service/package-json.ts
+++ b/packages/generator/src/service/package-json.ts
@@ -18,15 +18,15 @@ export interface PackageJsonOptions extends PackageJsonOptionsBase {
  * @internal
  */
 export async function packageJson(
-  options: PackageJsonOptions & { generateESM?: boolean }
+  options: PackageJsonOptions & { generateEsm?: boolean }
 ): Promise<string> {
   const oDataModule =
     options.oDataVersion === 'v2'
       ? '@sap-cloud-sdk/odata-v2'
       : '@sap-cloud-sdk/odata-v4';
 
-  // Determine module type based on generateESM option
-  const moduleType = options.generateESM ? 'esm' : 'commonjs';
+  // Determine module type based on generateEsm option
+  const moduleType = options.generateEsm ? 'esm' : 'commonjs';
 
   return (
     JSON.stringify(

--- a/packages/openapi-generator/src/file-serializer/api-file.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/api-file.spec.ts
@@ -141,7 +141,7 @@ describe('api-file', () => {
 
   it('creates an api file following the esm pattern', async () => {
     const createFileOptions = {
-      generateESM: true,
+      generateEsm: true,
       overwrite: false,
       prettierOptions: await readPrettierConfig(undefined)
     };

--- a/packages/openapi-generator/src/file-serializer/api-file.ts
+++ b/packages/openapi-generator/src/file-serializer/api-file.ts
@@ -70,7 +70,7 @@ function getImports(api: OpenApiApi, options?: CreateFileOptions): Import[] {
 
   const refImports = {
     names: refs,
-    moduleIdentifier: options?.generateESM ? './schema/index.js' : './schema',
+    moduleIdentifier: options?.generateEsm ? './schema/index.js' : './schema',
     typeOnly: true
   };
   const openApiImports = {

--- a/packages/openapi-generator/src/file-serializer/index-file.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/index-file.spec.ts
@@ -19,7 +19,7 @@ describe('index-file', () => {
         schemas: [{}]
       } as OpenApiDocument;
       const createFileOptions: CreateFileOptions = {
-        generateESM: true,
+        generateEsm: true,
         overwrite: false,
         prettierOptions: await readPrettierConfig(undefined)
       };
@@ -56,7 +56,7 @@ describe('index-file', () => {
         ]
       } as unknown as OpenApiDocument;
       const createFileOptions: CreateFileOptions = {
-        generateESM: true,
+        generateEsm: true,
         overwrite: false,
         prettierOptions: await readPrettierConfig(undefined)
       };

--- a/packages/openapi-generator/src/file-serializer/index-file.ts
+++ b/packages/openapi-generator/src/file-serializer/index-file.ts
@@ -50,7 +50,7 @@ function exportAllFiles(
 }
 
 function exportAll(file: string, options?: CreateFileOptions) {
-  return options?.generateESM
+  return options?.generateEsm
     ? file === 'schema'
       ? "export * from './schema/index.js';"
       : `export * from './${file}.js';`

--- a/packages/openapi-generator/src/file-serializer/package-json.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/package-json.spec.ts
@@ -22,19 +22,19 @@ describe('packageJson', () => {
     expect(parsed.license).toBe('UNLICENSED');
   });
 
-  it('includes type module when generateESM is true', () => {
+  it('includes type module when generateEsm is true', () => {
     const parsed = JSON.parse(
       packageJson({
         npmPackageName: 'workflow-service',
         description: 'description',
         sdkVersion: '1.35.0',
-        generateESM: true
+        generateEsm: true
       })
     );
     expect(parsed.type).toBe('module');
   });
 
-  it('includes type module when generateESM is undefined', () => {
+  it('includes type module when generateEsm is undefined', () => {
     const parsed = JSON.parse(
       packageJson({
         npmPackageName: 'workflow-service',

--- a/packages/openapi-generator/src/file-serializer/package-json.ts
+++ b/packages/openapi-generator/src/file-serializer/package-json.ts
@@ -8,10 +8,10 @@ import type { PackageJsonOptions } from '@sap-cloud-sdk/generator-common/interna
  * @internal
  */
 export function packageJson(
-  options: PackageJsonOptions & { generateESM?: boolean }
+  options: PackageJsonOptions & { generateEsm?: boolean }
 ): string {
-  // Determine module type based on generateESM option
-  const moduleType = options.generateESM ? 'esm' : 'commonjs';
+  // Determine module type based on generateEsm option
+  const moduleType = options.generateEsm ? 'esm' : 'commonjs';
 
   return (
     JSON.stringify(

--- a/packages/openapi-generator/src/file-serializer/schema-file.spec.ts
+++ b/packages/openapi-generator/src/file-serializer/schema-file.spec.ts
@@ -140,7 +140,7 @@ describe('schemaFile', () => {
 
   it('serializes schema file for schema including ESM references', async () => {
     const createFileOptions: CreateFileOptions = {
-      generateESM: true,
+      generateEsm: true,
       overwrite: false,
       prettierOptions: await readPrettierConfig(undefined)
     };

--- a/packages/openapi-generator/src/file-serializer/schema-file.ts
+++ b/packages/openapi-generator/src/file-serializer/schema-file.ts
@@ -38,7 +38,7 @@ function getImports(
     .map(ref => ({
       names: [ref.schemaName],
       typeOnly: true,
-      moduleIdentifier: options?.generateESM
+      moduleIdentifier: options?.generateEsm
         ? `./${ref.fileName}.js`
         : `./${ref.fileName}`
     }));

--- a/packages/openapi-generator/src/generator.ts
+++ b/packages/openapi-generator/src/generator.ts
@@ -89,7 +89,7 @@ export async function generateWithParsedOptions(
   const tsConfig = await tsconfigJson(
     options.transpile,
     options.tsconfig,
-    options.generateESM
+    options.generateEsm
   );
 
   const promises = inputFilePaths.map(inputFilePath =>
@@ -138,7 +138,7 @@ async function getFileCreationOptions(
   return {
     prettierOptions: await readPrettierConfig(options.prettierConfig),
     overwrite: options.overwrite,
-    generateESM: options.generateESM
+    generateEsm: options.generateEsm
   };
 }
 
@@ -345,7 +345,7 @@ async function generatePackageJson(
       npmPackageName: openApiDocument.serviceOptions.packageName,
       description: packageDescription(openApiDocument.serviceName),
       sdkVersion: await getSdkVersion(),
-      generateESM: options.generateESM
+      generateEsm: options.generateEsm
     }),
     createFileOptions
   );

--- a/packages/openapi-generator/src/options/generator-options.spec.ts
+++ b/packages/openapi-generator/src/options/generator-options.spec.ts
@@ -40,7 +40,7 @@ describe('parseGeneratorOptions', () => {
     verbose: false,
     overwrite: false,
     config: undefined,
-    generateESM: false,
+    generateEsm: false,
     schemaPrefix: '',
     resolveExternal: true
   };

--- a/packages/openapi-generator/src/options/options.ts
+++ b/packages/openapi-generator/src/options/options.ts
@@ -17,7 +17,7 @@ export interface OpenAPIGeneratorOptions {
   /**
    * Whether to generate ECMAScript modules instead of CommonJS modules.
    */
-  generateESM?: boolean;
+  generateEsm?: boolean;
   /**
    * Prefix all schema names with a value.
    * @experimental
@@ -40,11 +40,12 @@ export type ParsedGeneratorOptions = ParsedOptions<typeof cliOptions>;
  */
 export const cliOptions = {
   ...getCommonCliOptions('OpenApi'),
-  generateESM: {
+  generateEsm: {
     describe:
       'When enabled, all generated files follow the ECMAScript module syntax.',
     type: 'boolean',
-    default: false
+    default: false,
+    alias: 'generateESM'
   },
   schemaPrefix: {
     describe:


### PR DESCRIPTION
It was disturbing me for a while: this property does not follow the styleguide. I left an alias for compatibility.