### PR TITLE
chore: checkout release tag instead of main in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
           permission-pull-requests: write
       - uses: sap/cloud-sdk-js/.github/actions/setup@main
         with:
-          ref: 'main'
           persist-credentials: true
           package-manager-cache: false
       - name: Legacy Release


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes [SAP/ai-sdk-backlog#666](https://github.com/SAP/ai-sdk-js-backlog/issues/666#issuecomment-5509805773).

Regarding the issue https://github.com/SAP/cloud-sdk-js/issues/6941

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `pnpm changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `pnpm doc` still works.
-->
