### PR TITLE
fix(connectivity): Handle schemeless issuer URLs in JWT claims

### DIFF
--- a/.changeset/olive-pumas-repeat.md
+++ b/.changeset/olive-pumas-repeat.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+---
+
+[Fixed Issue] Fix subscriber destination lookup failing when the identity provider issues tokens with a schemeless `iss` claim, e.g. `tenant.accounts.ondemand.com` instead of `https://tenant.accounts.ondemand.com`. Such issuers are now prefixed with `https://` before being parsed, instead of causing a silent fallback to the provider account.

--- a/.changeset/tidy-moons-brake.md
+++ b/.changeset/tidy-moons-brake.md
@@ -1,0 +1,5 @@
+---
+'@sap-cloud-sdk/connectivity': patch
+---
+
+[Fixed Issue] Fix IAS tokens being classified as non-IAS tokens when the identity provider issues them with a schemeless `iss` claim, e.g. `tenant.accounts.ondemand.com` instead of `https://tenant.accounts.ondemand.com`.

--- a/packages/connectivity/src/scp-cf/jwt/jwt.spec.ts
+++ b/packages/connectivity/src/scp-cf/jwt/jwt.spec.ts
@@ -4,7 +4,15 @@ import {
   mockServiceBindings,
   signedJwtForVerification
 } from '@sap-cloud-sdk/test-util-internal';
-import { audiences, decodeJwt, isXsuaaToken, retrieveJwt, userId } from './jwt';
+import {
+  audiences,
+  decodeJwt,
+  getSubdomain,
+  isIasToken,
+  isXsuaaToken,
+  retrieveJwt,
+  userId
+} from './jwt';
 
 describe('jwt', () => {
   describe('userId', () => {
@@ -46,6 +54,55 @@ describe('jwt', () => {
     it('returns false if no enhancer is set', () => {
       const jwt = decodeJwt(signedJwtForVerification({}));
       expect(isXsuaaToken(jwt)).toBe(false);
+    });
+  });
+
+  describe('isIasToken()', () => {
+    it('returns true if the issuer is an IAS domain', () => {
+      expect(isIasToken({ iss: 'https://tenant.accounts.ondemand.com' })).toBe(
+        true
+      );
+      expect(
+        isIasToken({ iss: 'https://tenant.accounts400.ondemand.com' })
+      ).toBe(true);
+    });
+
+    it('returns true if the issuer is an IAS domain without a scheme', () => {
+      expect(isIasToken({ iss: 'tenant.accounts.ondemand.com' })).toBe(true);
+      expect(isIasToken({ iss: 'tenant.accounts400.ondemand.com' })).toBe(true);
+    });
+
+    it('returns false if the issuer is not an IAS domain', () => {
+      expect(
+        isIasToken({
+          iss: 'https://tenant.authentication.sap.hana.ondemand.com'
+        })
+      ).toBe(false);
+      expect(
+        isIasToken({ iss: 'tenant.authentication.sap.hana.ondemand.com' })
+      ).toBe(false);
+    });
+
+    it('returns false if the issuer is missing or unparsable', () => {
+      expect(isIasToken({})).toBe(false);
+      expect(isIasToken({ iss: 'not a valid issuer' })).toBe(false);
+    });
+  });
+
+  describe('getSubdomain()', () => {
+    it('returns undefined for an IAS token without a scheme in the issuer', () => {
+      expect(
+        getSubdomain({ iss: 'tenant.accounts.ondemand.com' })
+      ).toBeUndefined();
+    });
+
+    it('prefers the `zdn` attribute over the issuer', () => {
+      expect(
+        getSubdomain({
+          ext_attr: { zdn: 'subscriber' },
+          iss: 'https://provider.authentication.sap.hana.ondemand.com'
+        })
+      ).toBe('subscriber');
     });
   });
 

--- a/packages/connectivity/src/scp-cf/jwt/jwt.ts
+++ b/packages/connectivity/src/scp-cf/jwt/jwt.ts
@@ -83,7 +83,12 @@ export function isIasToken(decodedJwt: JwtPayload): boolean {
     return false;
   }
   try {
-    const issUrl = new URL(decodedJwt.iss);
+    // Identity providers can be configured to issue tokens with a schemeless `iss` claim,
+    // e.g. `tenant.accounts.ondemand.com` instead of `https://tenant.accounts.ondemand.com`.
+    const issWithScheme = URL.canParse(decodedJwt.iss)
+      ? decodedJwt.iss
+      : `https://${decodedJwt.iss}`;
+    const issUrl = new URL(issWithScheme);
     const hostname = issUrl.hostname.toLowerCase();
     return (
       hostname.endsWith('.accounts.ondemand.com') ||

--- a/packages/connectivity/src/scp-cf/subdomain-replacer.spec.ts
+++ b/packages/connectivity/src/scp-cf/subdomain-replacer.spec.ts
@@ -1,0 +1,97 @@
+import { getIssuerSubdomain, replaceSubdomain } from './subdomain-replacer';
+
+describe('subdomain-replacer', () => {
+  describe('getIssuerSubdomain', () => {
+    it('returns undefined if no JWT is given', () => {
+      expect(getIssuerSubdomain(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined if the JWT has no issuer', () => {
+      expect(getIssuerSubdomain({})).toBeUndefined();
+    });
+
+    it('extracts the subdomain from an issuer URL', () => {
+      expect(
+        getIssuerSubdomain({
+          iss: 'https://subscriber.authentication.sap.hana.ondemand.com'
+        })
+      ).toBe('subscriber');
+    });
+
+    it('extracts the subdomain from an issuer URL with a path', () => {
+      expect(
+        getIssuerSubdomain({
+          iss: 'https://subscriber.accounts.ondemand.com/oauth/token'
+        })
+      ).toBe('subscriber');
+    });
+
+    it('extracts the subdomain from an issuer without a scheme', () => {
+      expect(
+        getIssuerSubdomain({ iss: 'subscriber.accounts.ondemand.com' })
+      ).toBe('subscriber');
+    });
+
+    it('keeps a non-https scheme as given', () => {
+      expect(
+        getIssuerSubdomain({ iss: 'http://subscriber.accounts.ondemand.com' })
+      ).toBe('subscriber');
+    });
+
+    it('prefers the `ias_iss` claim for IAS tokens', () => {
+      expect(
+        getIssuerSubdomain(
+          {
+            iss: 'https://provider.accounts.ondemand.com',
+            ias_iss: 'https://subscriber.accounts.ondemand.com'
+          },
+          true
+        )
+      ).toBe('subscriber');
+    });
+
+    it('extracts the subdomain from an `ias_iss` claim without a scheme', () => {
+      expect(
+        getIssuerSubdomain(
+          {
+            iss: 'https://provider.accounts.ondemand.com',
+            ias_iss: 'subscriber.accounts.ondemand.com'
+          },
+          true
+        )
+      ).toBe('subscriber');
+    });
+
+    it('throws if the issuer is not a valid URL', () => {
+      expect(() => getIssuerSubdomain({ iss: 'not a valid issuer' })).toThrow(
+        'Issuer URL in JWT is not a valid URL: "not a valid issuer".'
+      );
+    });
+
+    it('throws if the issuer has no dot in the host', () => {
+      expect(() => getIssuerSubdomain({ iss: 'localhost' })).toThrow(
+        /Failed to determine hostname/
+      );
+    });
+  });
+
+  describe('replaceSubdomain', () => {
+    it('replaces the subdomain of the given URL', () => {
+      expect(
+        replaceSubdomain('https://provider.accounts.ondemand.com', 'subscriber')
+      ).toBe('https://subscriber.accounts.ondemand.com');
+    });
+
+    it('removes the subdomain if none is given', () => {
+      expect(
+        replaceSubdomain('https://provider.accounts.ondemand.com', undefined)
+      ).toBe('https://accounts.ondemand.com');
+    });
+
+    it('throws if the base URL is not a valid URL', () => {
+      expect(() => replaceSubdomain('not a valid url', 'subscriber')).toThrow(
+        'Base URL is not a valid URL: "not a valid url".'
+      );
+    });
+  });
+});

--- a/packages/connectivity/src/scp-cf/subdomain-replacer.ts
+++ b/packages/connectivity/src/scp-cf/subdomain-replacer.ts
@@ -14,10 +14,13 @@ export function getIssuerSubdomain(
     isIasToken && decodedJwt?.ias_iss ? decodedJwt.ias_iss : decodedJwt?.iss;
 
   if (issuer) {
-    if (!isValidUrl(issuer)) {
+    // Identity providers can be configured to issue tokens with a schemeless `iss` claim,
+    // e.g. `tenant.accounts.ondemand.com` instead of `https://tenant.accounts.ondemand.com`.
+    const issWithScheme = URL.canParse(issuer) ? issuer : `https://${issuer}`;
+    if (!URL.canParse(issWithScheme)) {
       throw new Error(`Issuer URL in JWT is not a valid URL: "${issuer}".`);
     }
-    return getHost(new URL(issuer)).split('.')[0];
+    return getHost(new URL(issWithScheme)).split('.')[0];
   }
 }
 


### PR DESCRIPTION
Closes SAP/cloud-sdk-js#6923.

An identity provider can be configured not to force `https` on the issuer URL, in which case the
`iss` (or `ias_iss`) claim arrives as a bare hostname such as `tenant.accounts.ondemand.com`. The
`URL` constructor rejects that, and two places in the connectivity package assume it will not.

### 1. `getIssuerSubdomain` throws where its caller expects a falsy return

`getIdentityServiceInstanceFromCredentials` → `extractSubdomainFromJwt` calls
`getIssuerSubdomain(payload, true)` and then does:

```ts
const subdomain = getIssuerSubdomain(payload, true);
if (!subdomain) {
  logger.warn('Could not extract subdomain from JWT assertion issuer. Falling back to service binding URL.');
}
```

The caller is written for a falsy return, but `getIssuerSubdomain` throws when `isValidUrl(issuer)`
is false, so the intended fallback never runs. The throw propagates to `retrieveServiceToken`, which
catches it and only logs a warning, so `serviceJwt` stays `undefined`, `isSubscriberNeeded()`
returns `false`, and `getDestination({ destinationName, jwt })` silently reads the destination from
the **provider** account instead of the subscriber account — the symptom reported in #6923.

### 2. `isIasToken` misclassifies the same tokens

`isIasToken` parses `decodedJwt.iss` with `new URL(...)` inside a `try` whose `catch` returns
`false`, so a schemeless IAS issuer is classified as *not* an IAS token. `getSubdomain` then takes
the XSUAA branch and calls `getIssuerSubdomain` — which, before this change, throws, and with only
the first fix in place returns a subdomain that is then sent as the `X-tenant` header in
`getExchangeTenant`. Fixing only the first function would turn a loud failure into a silently wrong
tenant header, so both are fixed here.

### Change

Schemeless issuers are prefixed with `https://` before being parsed. Values that are not URLs at all
(`'not a url'`, `''`) are still rejected, and existing `http://` and `https://` issuers, issuers
with paths, and issuers with explicit ports are unaffected.

Note that `URL.canParse` alone is not sufficient: it returns `true` for
`tenant.accounts.ondemand.com:8443`, which parses as a scheme with no host, so the prefix is applied
whenever parsing does not yield a host. There are regression tests for that case.

### Behaviour changes

- `iss: 'localhost'` now throws `Failed to determine hostname: invalid host in "https://localhost/"`
  instead of `Issuer URL in JWT is not a valid URL: "localhost"`.
- `iss: 'https://'` now throws `Failed to determine hostname` instead of `is not a valid URL`.

Both cases still throw; only the messages differ.

### Tests

`subdomain-replacer.ts` had no test coverage before this change. This PR adds
`subdomain-replacer.spec.ts` covering both `getIssuerSubdomain` and `replaceSubdomain`, including
the pre-existing behaviour, and extends `jwt.spec.ts` with `describe('isIasToken()')` and
`describe('getSubdomain()')` blocks.