### PR TITLE
chore: Ignore major @apidevtools/swagger-parser updates

### DIFF
--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -10,7 +10,7 @@
     },
     {
       // These packages require ESM in their next major version, stay on current major until we support ESM
-      "matchPackageNames": ["content-type", "yargs", "@stylistic/eslint-plugin"],
+      "matchPackageNames": ["content-type", "yargs", "@apidevtools/swagger-parser", "@stylistic/eslint-plugin"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },


### PR DESCRIPTION
<!-- Please provide a description of what your change does and why it is needed. -->

Closes SAP/cloud-sdk-backlog#ISSUENUMBER.

It has ESM dependencies, but itself is still CJS.

<!-- Check List:
* Tests created/adjusted for your changes.
* PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org).
* Created a changeset `pnpm changeset`
* If applicable:
  * Documented public API (TypeDoc).
  * Checked that `pnpm doc` still works.
-->
